### PR TITLE
Fix TitleScreen import for build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import TitleScreen from "./ui/TitleScreen";
+import TitleScreen from "../ui/TitleScreen";
 import App from "./App"; // your existing game component (default export)
 
 export default function AppShell() {


### PR DESCRIPTION
## Summary
- fix AppShell TitleScreen path
- add ignore rules for build output and dependencies

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c5f1f09fe88332afbab4ad2f9f17b2