### PR TITLE
feat: add animated start hub menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "framer-motion": "^10.16.2"
+    "framer-motion": "^10.16.2",
+    "lucide-react": "^0.344.0"
   },
   "devDependencies": {
     "typescript": "^5.2.2",

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import TitleScreen from "../ui/TitleScreen";
+import RogueWheelHub from "../ui/RogueWheelHub";
 import App from "./App"; // your existing game component (default export)
 
 export default function AppShell() {
@@ -7,7 +7,7 @@ export default function AppShell() {
 
   return (
     <div className="min-h-screen w-full bg-gradient-to-b from-indigo-900 via-indigo-800 to-indigo-900 text-slate-100">
-      {showTitle ? <TitleScreen onStart={() => setShowTitle(false)} /> : <App />}
+      {showTitle ? <RogueWheelHub onPlay={() => setShowTitle(false)} /> : <App />}
     </div>
   );
 }

--- a/ui/RogueWheelHub.tsx
+++ b/ui/RogueWheelHub.tsx
@@ -1,0 +1,282 @@
+import React, { useMemo, useState } from "react";
+import { motion } from "framer-motion";
+import {
+  PlayCircle,
+  Swords,
+  Trophy,
+  BookOpen,
+  Sparkles,
+  Settings,
+  User,
+  RefreshCw,
+  Star,
+  Wand2,
+  Info,
+  Power,
+} from "lucide-react";
+
+export type HubProps = {
+  logoSrc?: string;
+  playerName?: string;
+  level?: number;
+  xp?: number;
+  continueAvailable?: boolean;
+  onPlay?: () => void;
+  onContinue?: () => void;
+  onNewRun?: () => void;
+  onChallenge?: () => void;
+  onDraftPractice?: () => void;
+  onSettings?: () => void;
+  onCredits?: () => void;
+  onQuit?: () => void;
+};
+
+export default function RogueWheelHub({
+  logoSrc = "/rogue-wheel-logo.png",
+  playerName = "Adventurer",
+  level = 3,
+  xp = 0.42,
+  continueAvailable = false,
+  onPlay,
+  onContinue,
+  onNewRun,
+  onChallenge,
+  onDraftPractice,
+  onSettings,
+  onCredits,
+  onQuit,
+}: HubProps) {
+  const [logoError, setLogoError] = useState(false);
+
+  const sparkleSeeds = useMemo(
+    () =>
+      Array.from({ length: 16 }, (_, i) => ({
+        key: i,
+        x: Math.random() * 100,
+        y: Math.random() * 100,
+        d: 6 + Math.random() * 10,
+        delay: Math.random() * 4,
+      })),
+    []
+  );
+
+  return (
+    <div className="relative min-h-screen w-full overflow-hidden bg-gradient-to-b from-indigo-700 via-indigo-800 to-indigo-900 text-slate-100">
+      <div aria-hidden className="pointer-events-none absolute inset-0 opacity-25">
+        {sparkleSeeds.map((s) => (
+          <motion.div
+            key={s.key}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: [0, 1, 0], y: [0, -10, 0] }}
+            transition={{ duration: s.d, repeat: Infinity, delay: s.delay }}
+            className="absolute"
+            style={{ left: `${s.x}%`, top: `${s.y}%` }}
+          >
+            <Sparkles className="h-4 w-4" />
+          </motion.div>
+        ))}
+      </div>
+
+      <div className="relative mx-auto flex max-w-6xl flex-col gap-6 px-4 pb-10 pt-10 md:gap-10 md:px-6 md:pt-12">
+        <div className="mx-auto flex max-w-4xl flex-col items-center text-center">
+          <div className="mb-3 flex items-center gap-3">
+            {logoSrc && !logoError ? (
+              <img
+                src={logoSrc}
+                alt="Rogue Wheel logo"
+                className="h-14 w-auto drop-shadow"
+                onError={() => setLogoError(true)}
+                loading="eager"
+              />
+            ) : (
+              <motion.div
+                initial={{ rotate: -6, scale: 0.9, opacity: 0 }}
+                animate={{ rotate: 0, scale: 1, opacity: 1 }}
+                transition={{ type: "spring", stiffness: 80, damping: 12 }}
+                className="grid h-14 w-14 place-items-center rounded-full bg-indigo-500/40 ring-1 ring-white/40"
+              >
+                <Wand2 className="h-7 w-7" />
+              </motion.div>
+            )}
+            <motion.h1
+              initial={{ y: -10, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              transition={{ type: "spring", stiffness: 100, damping: 12 }}
+              className="text-2xl font-extrabold tracking-wide md:text-3xl"
+            >
+              Rogue Wheel
+            </motion.h1>
+          </div>
+          <p className="text-indigo-100/90">
+            Lighthearted fantasy. <span className="font-semibold">Spin</span>, <span className="font-semibold">draft</span>, triumph.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 items-start gap-6 md:grid-cols-3">
+          <motion.section
+            initial={{ x: -12, opacity: 0 }}
+            animate={{ x: 0, opacity: 1 }}
+            transition={{ type: "spring", stiffness: 120, damping: 16, delay: 0.05 }}
+            className="rounded-2xl bg-indigo-950/30 p-4 shadow-xl ring-1 ring-white/10 backdrop-blur-sm"
+          >
+            <header className="mb-3 flex items-center gap-2">
+              <User className="h-5 w-5" />
+              <h2 className="text-lg font-semibold">Profile</h2>
+            </header>
+            <div className="flex items-center gap-3">
+              <div className="grid h-12 w-12 place-items-center rounded-full bg-indigo-600/50 ring-1 ring-white/30">
+                <Star className="h-6 w-6" />
+              </div>
+              <div className="min-w-0">
+                <div className="truncate text-sm/5 opacity-90">{playerName}</div>
+                <div className="text-xs opacity-80">Level {level}</div>
+                <div aria-label="experience" className="mt-1 h-2 w-40 overflow-hidden rounded-full bg-white/10">
+                  <div
+                    className="h-full bg-gradient-to-r from-amber-300 to-amber-500"
+                    style={{ width: `${Math.min(Math.max(xp, 0), 1) * 100}%` }}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-4 grid grid-cols-3 gap-3 text-center text-xs">
+              <StatCard label="Wins" value="12" />
+              <StatCard label="Best Streak" value="4" />
+              <StatCard label="Cards" value="36" />
+            </div>
+          </motion.section>
+
+          <motion.section
+            initial={{ scale: 0.98, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            transition={{ type: "spring", stiffness: 120, damping: 14, delay: 0.1 }}
+            className="rounded-2xl bg-indigo-950/40 p-4 shadow-2xl ring-1 ring-white/10 backdrop-blur-sm md:p-6"
+          >
+            <div className="mx-auto flex max-w-md flex-col gap-3">
+              <HubButton
+                large
+                icon={<PlayCircle className="h-6 w-6" />}
+                label="Play"
+                kbd="Enter"
+                onClick={onPlay}
+              />
+              <HubButton
+                icon={<RefreshCw className="h-5 w-5" />}
+                label="Continue"
+                disabled={!continueAvailable}
+                onClick={onContinue}
+              />
+              <HubButton icon={<Swords className="h-5 w-5" />} label="New Run" onClick={onNewRun} />
+              <HubButton icon={<Trophy className="h-5 w-5" />} label="Daily Challenge" onClick={onChallenge} />
+              <HubButton icon={<BookOpen className="h-5 w-5" />} label="Draft Practice" onClick={onDraftPractice} />
+            </div>
+          </motion.section>
+
+          <motion.section
+            initial={{ x: 12, opacity: 0 }}
+            animate={{ x: 0, opacity: 1 }}
+            transition={{ type: "spring", stiffness: 120, damping: 16, delay: 0.15 }}
+            className="rounded-2xl bg-indigo-950/30 p-4 shadow-xl ring-1 ring-white/10 backdrop-blur-sm"
+          >
+            <header className="mb-3 flex items-center gap-2">
+              <Trophy className="h-5 w-5" />
+              <h2 className="text-lg font-semibold">Meta & Progress</h2>
+            </header>
+            <ul className="space-y-2 text-sm">
+              <li className="flex items-center justify-between rounded-lg bg-white/5 p-2 ring-1 ring-white/10">
+                <span>Achievements</span>
+                <span className="text-amber-300">7/32</span>
+              </li>
+              <li className="flex items-center justify-between rounded-lg bg-white/5 p-2 ring-1 ring-white/10">
+                <span>Lore Codex</span>
+                <span className="opacity-80">12 entries</span>
+              </li>
+              <li className="flex items-center justify-between rounded-lg bg-white/5 p-2 ring-1 ring-white/10">
+                <span>Card Album</span>
+                <span className="opacity-80">36/120</span>
+              </li>
+            </ul>
+          </motion.section>
+        </div>
+
+        <div className="mx-auto flex w-full max-w-4xl flex-wrap items-center justify-center gap-3 pt-2 text-sm opacity-95">
+          <FooterButton icon={<Settings className="h-4 w-4" />} label="Settings" onClick={onSettings} />
+          <FooterButton icon={<Info className="h-4 w-4" />} label="Credits" onClick={onCredits} />
+          <FooterButton icon={<Power className="h-4 w-4" />} label="Quit" onClick={onQuit} />
+          <span className="select-none opacity-60">v0.1.0</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HubButton({
+  label,
+  icon,
+  onClick,
+  disabled,
+  large,
+  kbd,
+}: {
+  label: string;
+  icon?: React.ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+  large?: boolean;
+  kbd?: string;
+}) {
+  return (
+    <motion.button
+      whileHover={!disabled ? { scale: 1.02 } : undefined}
+      whileTap={!disabled ? { scale: 0.98 } : undefined}
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      className={[
+        "group relative flex items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-left shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-300",
+        large ? "py-4 text-lg" : "text-base",
+        disabled
+          ? "cursor-not-allowed border-white/10 bg-white/5 text-white/40"
+          : "border-amber-400/20 bg-gradient-to-b from-amber-300/10 to-amber-400/10 hover:from-amber-300/20 hover:to-amber-400/20",
+      ].join(" ")}
+    >
+      <span className="pointer-events-none absolute -left-2 -top-2 hidden rounded-full bg-amber-400/20 p-1 group-hover:block" />
+      <div className="flex items-center gap-3">
+        {icon}
+        <span className="font-semibold tracking-wide">{label}</span>
+      </div>
+      {kbd && (
+        <span className="rounded bg-white/10 px-2 py-0.5 text-xs tracking-wider opacity-80">{kbd}</span>
+      )}
+    </motion.button>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl bg-white/5 p-2 ring-1 ring-white/10">
+      <div className="text-xs opacity-75">{label}</div>
+      <div className="text-base font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function FooterButton({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3 py-1.5 shadow-sm ring-1 ring-white/10 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}
+


### PR DESCRIPTION
## Summary
- integrate new animated start hub with profile, core, and meta sections
- switch app shell to use start hub
- add lucide-react dependency for icon set

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "lucide-react")*

------
https://chatgpt.com/codex/tasks/task_e_68c6a397c6e88332a58eefba2a4f0178