### PR TITLE
Fix tailwind theme color configuration

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,13 +7,11 @@ export default {
   ],
   theme: {
     extend: {
-          colors: {
-                primary: '#b68a4e',
+      colors: {
+        primary: '#b68a4e',
         secondary: '#704921',
         surface: '#3b2610',
         panel: '#2c1c0e',
-    
-      ,
       },
       fontFamily: {
         heading: ['Poppins', 'sans-serif'],


### PR DESCRIPTION
## Summary
- fix Tailwind `theme.extend.colors` object by removing stray comma and cleaning braces

## Testing
- `npm run build` *(fails: Rollup failed to resolve import "react-router-dom" from src/AppShell.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e07dba9083329524424b00fc27d6