### PR TITLE
Apply wood theme to wheel and card UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -487,7 +487,7 @@ export default function ThreeWheel_WinsOnly() {
 
     return (
       <div
-        className={`relative rounded-lg border ${active[i] ? "border-slate-700 bg-slate-800/70" : "border-slate-700/70 bg-slate-900/50"} p-0 shadow`}
+        className={`relative rounded-lg border ${active[i] ? "border-slate-700" : "border-slate-700/70"} p-0 shadow bg-transparent`}
         style={{ width: panelW, paddingTop: 0, paddingBottom: 0 }}
       >
         <div className="w-full h-[2px] rounded-t-md mb-0" style={{ background: wheelHUD[i] ?? "#475569" }} />
@@ -500,7 +500,7 @@ export default function ThreeWheel_WinsOnly() {
             onDragLeave={onZoneLeave}
             onDrop={onZoneDrop}
             onClick={(e) => { e.stopPropagation(); if (selectedCardId) { tapAssignIfSelected(); } else if (pc) { clearAssign(i); } }}
-            className={`${dragOverWheel === i ? "border-amber-400 bg-amber-400/10" : "border-slate-600 bg-slate-900/40"} w-[80px] min-h-[92px] rounded-md border px-1 py-0 flex items-center justify-center`}
+            className={`${dragOverWheel === i ? "border-amber-400 bg-amber-400/10" : "border-slate-600 bg-transparent"} w-[80px] min-h-[92px] rounded-md border px-1 py-0 flex items-center justify-center`}
             style={{ transform: 'translateY(-4px)' }}
             aria-label={`Wheel ${i+1} player slot`}
           >
@@ -521,7 +521,7 @@ export default function ThreeWheel_WinsOnly() {
           </div>
 
           {/* Enemy slot */}
-          <div className="w-[80px] min-h-[92px] rounded-md border px-1 py-0 flex items-center justify-center border-slate-600 bg-slate-900/40" aria-label={`Wheel ${i+1} enemy slot`}>
+          <div className="w-[80px] min-h-[92px] rounded-md border px-1 py-0 flex items-center justify-center border-slate-600 bg-transparent" aria-label={`Wheel ${i+1} enemy slot`}>
             {ec && (phase === "showEnemy" || phase === "anim" || phase === "roundEnd" || phase === "ended") ? (
               <StSCard card={ec} size="sm" disabled />
             ) : (
@@ -651,7 +651,7 @@ export default function ThreeWheel_WinsOnly() {
 
   return (
     <div
-      className="h-screen w-screen overflow-x-hidden overflow-y-hidden bg-slate-900 text-slate-100 p-1 grid gap-2"
+      className="h-screen w-screen overflow-x-hidden overflow-y-hidden text-slate-100 p-1 grid gap-2"
       style={{ gridTemplateRows: "auto auto 1fr auto" }}
     >
       {/* Controls */}

--- a/src/index.css
+++ b/src/index.css
@@ -13,7 +13,7 @@ body {
    * slate fallback ensures the UI remains legible if the image fails to
    * load.  Text uses the custom font defined in tailwind.config.js. */
   @apply bg-slate-900 text-slate-200 font-text;
-  background-image: url("../assets/wood-bg.jpg");
+  background-image: url("/assets/wood-bg.jpg");
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center;
@@ -48,7 +48,7 @@ h1, h2, h3, h4, h5, h6 {
  * Wood-themed frames for wheels and card slots.
  */
 div.relative[aria-label^="Wheel"] {
-  background-image: url("../assets/wheel-frame.png");
+  background-image: url("/assets/wheel-frame.png");
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
@@ -58,10 +58,12 @@ div.relative[aria-label^="Wheel"] {
 /* Player and enemy card slots */
 [aria-label$="player slot"],
 [aria-label$="enemy slot"] {
-  background-image: url("../assets/card-frame.png");
+  background-image: url("/assets/card-frame.png");
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
+  background-color: transparent;
+  border: none;
 }
 
 /*
@@ -70,8 +72,8 @@ div.relative[aria-label^="Wheel"] {
  * Apply the wood frame image as the background, hide the gradient overlays,
  * and set the number color to a light parchment tone.
  */
-button[Card^="Card"] {
-  background-image: url("../assets/card-frame.png");
+button[aria-label^="Card"] {
+  background-image: url("/assets/card-frame.png");
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
@@ -86,17 +88,6 @@ button[aria-label^="Card"] > div:nth-child(2) {
 }
 button[aria-label^="Card"] .text-3xl {
   color: #f5e7c4;
-}
-
-
-/* Override card frames using correct attribute selector */
-button[aria-label^="Card"] {
-
-  background-image: url("../assets/card-frame.png");
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
-  border: none;
 }
 
 /* Add margin below the last wheel to prevent overlap with the player's hand */


### PR DESCRIPTION
## Summary
- Fix asset URLs and selectors so wheel, slot, and card backgrounds use wood textures
- Remove dark background classes to let wood textures show through

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found after install attempt; install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e97ff8b88332a60cc9596c1fe423