### PR TITLE
fix: close unclosed block in App

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -693,3 +693,6 @@ if (typeof window !== 'undefined') {
     console.assert(sum === 15, 'sections cover 15 slices');
   } catch {}
 }
+
+}
+


### PR DESCRIPTION
## Summary
- close missing closing brace at end of App.tsx

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden fetching lucide-react)*
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68c72ebe0a2083329b61a3b01a6b4776