### PR TITLE
fix: remove dev self-tests from App

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -676,20 +676,7 @@ export default function ThreeWheel_WinsOnly() {
   );
 }
 
-// ---------------- Dev Self-Tests (lightweight) ----------------
-// These run once in dev consoles to catch regressions.
-if (typeof window !== 'undefined') {
-  try {
-    // inSection should exclude 0 and handle wrap
-    const s: Section = { id: "Strongest", color: "#fff", start: 14, end: 2 } as any;
-    console.assert(!inSection(0, s), 'slice 0 excluded');
-    console.assert(inSection(14, s) && inSection(15, s) && inSection(1, s) && inSection(2, s), 'wrap includes 14,15,1,2');
-  } catch {}
-  try {
-    // sections cover 15 slices total (1..15)
-    const secs = genWheelSections("bandit");
-    const len = (sec: Section) => (sec.start <= sec.end ? (sec.end - sec.start + 1) : (SLICES - sec.start + (sec.end + 1)));
-    const sum = secs.reduce((a, s) => a + len(s), 0);
-    console.assert(sum === 15, 'sections cover 15 slices');
-  } catch {}
 }
+
+
+


### PR DESCRIPTION
## Summary
- remove in-browser self-tests from `App.tsx`

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden fetching lucide-react)*
- `npx tsc --noEmit` *(fails: Cannot find module 'framer-motion' and many implicit any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c72ebe0a2083329b61a3b01a6b4776