### PR TITLE
Ensure initiative flag visible on mobile HUD

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -621,7 +621,10 @@ export default function ThreeWheel_WinsOnly() {
       return (
         <div className="flex min-w-0 items-center gap-2 rounded-lg border px-2 py-1 text-[12px] shadow w-full" style={{ maxWidth: '100%', background: THEME.panelBg, borderColor: THEME.panelBorder, color: THEME.textWarm }}>
           <div className="w-1.5 h-6 rounded" style={{ background: color }} />
-          <div className="truncate max-w-[36vw] sm:max-w-none"><span className="font-semibold">{name}</span>{hasInit && <span className="ml-1">⚑</span>}</div>
+          <div className="flex items-center max-w-[36vw] sm:max-w-none min-w-0">
+            <span className="truncate block font-semibold">{name}</span>
+            {hasInit && <span className="ml-1 flex-shrink-0">⚑</span>}
+          </div>
           <div className="flex items-center gap-1 ml-1 flex-shrink-0"><span className="opacity-80">Wins</span><span className="text-base font-extrabold">{win}</span></div>
           <div className={`ml-2 rounded-full border px-2 py-0.5 text-[11px] overflow-hidden text-ellipsis whitespace-nowrap ${isReserveVisible ? 'opacity-100 visible' : 'opacity-0 invisible'}`} style={{ maxWidth: '44vw', minWidth: '90px', background: '#1b1209ee', borderColor: THEME.slotBorder, color: THEME.textWarm }} title={rs !== null ? `Reserve: ${rs}` : undefined}>
             Reserve: <span className="font-bold tabular-nums">{rs ?? 0}</span>


### PR DESCRIPTION
## Summary
- Prevent initiative flag from being truncated on mobile by separating it from the player name text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: sh: 1: vite: not found — `npm install` blocked: 403 Forbidden for lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d416558c8332aec9eeaf7434ff23