### PR TITLE
refactor: remove router for offline build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "framer-motion": "^10.16.2",
-    "react-router-dom": "^6.22.3"
+    "framer-motion": "^10.16.2"
   },
   "devDependencies": {
     "typescript": "^5.2.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -662,26 +662,17 @@ const HUDPanels = () => {
   };
 
   return (
-    <div className="w-full grid grid-cols-2 gap-2 overflow-x-hidden">
-      <div className="min-w-0 w-full max-w-[420px] mx-auto"><Panel side="player" /></div>
-      <div className="min-w-0 w-full max-w-[420px] mx-auto"><Panel side="enemy" /></div>
+    <div className="w-full flex flex-col items-center">
+      <div className="w-full grid grid-cols-2 gap-2 overflow-x-hidden">
+        <div className="min-w-0 w-full max-w-[420px] mx-auto"><Panel side="player" /></div>
+        <div className="min-w-0 w-full max-w-[420px] mx-auto"><Panel side="enemy" /></div>
+      </div>
+      <div className="mt-1 flex justify-center w-full">
+        <span style={{ color: HUD_COLORS[initiative] }}>⚑</span>
+      </div>
     </div>
   );
 };
-
-
-    return (
-      <div className="w-full flex flex-col items-center">
-        <div className="w-full grid grid-cols-2 gap-2 overflow-x-hidden">
-          <div className="min-w-0 w-full max-w-[420px] mx-auto"><Panel side="player" /></div>
-          <div className="min-w-0 w-full max-w-[420px] mx-auto"><Panel side="enemy" /></div>
-        </div>
-        <div className="mt-1 flex justify-center w-full">
-          <span style={{ color: HUD_COLORS[initiative] }}>⚑</span>
-        </div>
-      </div>
-    );
-  };
 
   return (
     <div className="h-screen w-screen overflow-x-hidden overflow-y-hidden text-slate-100 p-1 grid gap-2" style={{ gridTemplateRows: "auto auto 1fr auto" }}>

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -1,15 +1,12 @@
-import React from "react";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import React, { useState } from "react";
 import App from "./App";
 import HubRoute from "./HubRoute";
 
 export default function AppShell() {
-  return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<HubRoute />} />
-        <Route path="/game" element={<App />} />
-      </Routes>
-    </BrowserRouter>
+  const [view, setView] = useState<"hub" | "game">("hub");
+  return view === "hub" ? (
+    <HubRoute onStart={() => setView("game")} />
+  ) : (
+    <App />
   );
 }

--- a/src/HubRoute.tsx
+++ b/src/HubRoute.tsx
@@ -1,14 +1,12 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
 import RogueWheelHub from "../ui/RogueWheelHub";
 
-export default function HubRoute() {
-  const navigate = useNavigate();
+export default function HubRoute({ onStart }: { onStart: () => void }) {
   return (
     <RogueWheelHub
       hasSave={false}
-      onNew={() => navigate("/game")}
-      onContinue={() => navigate("/game?resume=1")}
+      onNew={onStart}
+      onContinue={onStart}
       onQuit={() => console.log("Quit clicked")}
       profileName="Adventurer"
       version="v0.1.0"


### PR DESCRIPTION
## Summary
- drop `react-router-dom` and use internal state for navigation
- simplify hub screen with callback-driven navigation

## Testing
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ddd421b483328020ee1f356e4f94