### PR TITLE
fix: close App component to resolve build error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -723,6 +723,8 @@ const HUDPanels = () => {
     </div>
   );
 
+}
+
 // ---------------- Dev Self-Tests (lightweight) ----------------
 // These run once in dev consoles to catch regressions.
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- add missing closing brace in App component so TypeScript compiles

## Testing
- `npm run build` (fails: vite not found)
- `npm test`
- `tsc --noEmit` (fails: Cannot find type definition file for 'react' and others)


------
https://chatgpt.com/codex/tasks/task_e_68c7edddff408332806bcef09d765d9c