### PR TITLE
Fix Ably presence subscription for multiplayer

### DIFF
--- a/src/MultiplayerRoute.tsx
+++ b/src/MultiplayerRoute.tsx
@@ -118,9 +118,11 @@ export default function MultiplayerRoute({
       }
 
       // 2) Subscribe to presence first (so we don't miss early events)
-      const onPresence = () => refreshMembers(chan);
+      const onPresence = () => {
+        void refreshMembers(chan);
+      };
       presenceListenerRef.current = onPresence;
-      chan.presence.subscribe(["enter", "leave", "update"] as any, onPresence);
+      chan.presence.subscribe(onPresence);
 
       // 3) Enter presence with the current name
       await chan.presence.enter({ name });
@@ -129,7 +131,9 @@ export default function MultiplayerRoute({
       await refreshMembers(chan);
 
       // 5) Refresh when connection state changes (covers reconnects)
-      const onConn = () => refreshMembers(chan);
+      const onConn = () => {
+        void refreshMembers(chan);
+      };
       connectionListenerRef.current = onConn;
       ably.connection.on(onConn);
 


### PR DESCRIPTION
## Summary
- register the Ably presence listener without passing an unsupported event array so joins and leaves refresh the member list
- wrap presence and connection listeners with void refresh calls to avoid unhandled promise rejections when they trigger asynchronously

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c98083cc248332a38e1cc41b75257a