### PR TITLE
Enable moving placed cards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -514,6 +514,54 @@ function nextRound() {
   // panel width (border-box) so wheel is visually centered
   const panelW = ws + slotW * 2 + gapX + paddingX + borderX;
 
+  const renderSlotCard = (slot: typeof leftSlot, isSlotSelected: boolean) => {
+    if (!slot.card) return null;
+    const card = slot.card;
+    const interactable = slot.side === localLegacySide && phase === "choose";
+
+    const handlePick = () => {
+      if (!interactable) return;
+      if (selectedCardId) {
+        tapAssignIfSelected();
+      } else {
+        setSelectedCardId(card.id);
+      }
+    };
+
+    const handleDragStart = (e: React.DragEvent<HTMLButtonElement>) => {
+      if (!interactable) return;
+      setSelectedCardId(card.id);
+      setDragCardId(card.id);
+      try { e.dataTransfer.setData("text/plain", card.id); } catch {}
+      e.dataTransfer.effectAllowed = "move";
+    };
+
+    const handleDragEnd = () => {
+      setDragCardId(null);
+      setDragOverWheel(null);
+    };
+
+    const handlePointerDown = (e: React.PointerEvent<HTMLButtonElement>) => {
+      if (!interactable) return;
+      e.stopPropagation();
+      startPointerDrag(card, e);
+    };
+
+    return (
+      <StSCard
+        card={card}
+        size="sm"
+        disabled={!interactable}
+        selected={isSlotSelected}
+        onPick={handlePick}
+        draggable={interactable}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onPointerDown={handlePointerDown}
+      />
+    );
+  };
+
   const onZoneDragOver = (e: React.DragEvent) => { e.preventDefault(); if (dragCardId && active[i]) setDragOverWheel(i); };
   const onZoneLeave = () => { if (dragCardId) setDragOverWheel(null); };
   const handleDropCommon = (id: string | null, assignCard: (card: Card) => void = assignToLeft) => {
@@ -621,7 +669,7 @@ function nextRound() {
           aria-label={`Wheel ${i+1} left slot`}
         >
           {leftSlot.card
-            ? <StSCard card={leftSlot.card} size="sm" />
+            ? renderSlotCard(leftSlot, isLeftSelected)
             : <div className="text-[11px] opacity-80 text-center">
                 {leftSlot.side === localLegacySide ? "Your card" : leftSlot.name}
               </div>}
@@ -673,7 +721,7 @@ function nextRound() {
           }}
         >
           {rightSlot.card && (phase === "showEnemy" || phase === "anim" || phase === "roundEnd" || phase === "ended")
-            ? <StSCard card={rightSlot.card} size="sm" disabled={rightSlot.side !== localLegacySide} />
+            ? renderSlotCard(rightSlot, isRightSelected)
             : <div className="text-[11px] opacity-60 text-center">
                 {rightSlot.side === localLegacySide ? "Your card" : rightSlot.name}
               </div>}

--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -9,12 +9,20 @@ export default memo(function StSCard({
   size = "sm",
   selected,
   onPick,
+  draggable,
+  onDragStart,
+  onDragEnd,
+  onPointerDown,
 }: {
   card: Card;
   disabled?: boolean;
   size?: "sm" | "md" | "lg";
   selected?: boolean;
   onPick?: () => void;
+  draggable?: boolean;
+  onDragStart?: React.DragEventHandler<HTMLButtonElement>;
+  onDragEnd?: React.DragEventHandler<HTMLButtonElement>;
+  onPointerDown?: React.PointerEventHandler<HTMLButtonElement>;
 }) {
   const dims = size === "lg" ? { w: 120, h: 160 } : size === "md" ? { w: 92, h: 128 } : { w: 72, h: 96 };
   return (
@@ -24,6 +32,10 @@ export default memo(function StSCard({
       className={`relative select-none ${disabled ? 'opacity-60' : 'hover:scale-[1.02]'} transition will-change-transform ${selected ? 'ring-2 ring-amber-400' : ''}`}
       style={{ width: dims.w, height: dims.h }}
       aria-label={`Card`}
+      draggable={draggable}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      onPointerDown={onPointerDown}
     >
       <div className="absolute inset-0 rounded-xl border bg-gradient-to-br from-slate-600 to-slate-800 border-slate-400"></div>
       <div className="absolute inset-px rounded-[10px] bg-slate-900/85 backdrop-blur-[1px] border border-slate-700/70" />


### PR DESCRIPTION
## Summary
- allow placed cards to be selected or dragged after placement via a shared slot-card helper
- extend `StSCard` so slot cards can forward drag and pointer handlers

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68c9b4a793a883328da6ca409b8c7955