### PR TITLE
Add Ably intent synchronization in App

### DIFF
--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -56,7 +56,8 @@ export default function AppShell() {
   let localSide: Side;
   let localPlayerId: string;
   let extraProps: {
-    mpChannel?: ReturnType<Realtime["channels"]["get"]>;
+    roomCode?: string;
+    hostId?: string;
   } = {};
 
   if (view.mode === "mp" && (view.mpPayload ?? mpPayload)) {
@@ -67,7 +68,8 @@ export default function AppShell() {
     localSide = mp.localSide;
     localPlayerId = mp.players[localSide].id;
     extraProps = {
-      mpChannel: mp.channel,
+      roomCode: mp.roomCode,
+      hostId: mp.hostId,
     };
   } else {
     // Solo path (fabricate right-side AI)
@@ -90,8 +92,7 @@ export default function AppShell() {
       {...extraProps}
       // Optionally add:
       // onExit={() => setView({ key: "hub" })}
-      // mode={view.mode} roomCode={(view.mpPayload ?? mpPayload)?.roomCode}
-      // hostId={(view.mpPayload ?? mpPayload)?.hostId}
+      // mode={view.mode}
     />
   );
 }

--- a/src/MultiplayerRoute.tsx
+++ b/src/MultiplayerRoute.tsx
@@ -250,8 +250,6 @@ setMembers(mapped);
           connectionListenerRef.current = null;
         }
 
-        handoffRef.current = true;
-
         onStart({
           ...payload,
           localSide,


### PR DESCRIPTION
## Summary
- connect App to Ably when a room code is provided and subscribe to multiplayer intents
- reuse shared assign/clear helpers for multiplayer mirroring and emit intents for local UI actions
- pass room metadata from AppShell and allow MultiplayerRoute to clean up the lobby connection after starting a game

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9daa8705c8332a20624f239267927