### PR TITLE
Add local profile storage and deck management UI

### DIFF
--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -4,6 +4,7 @@ import type { Realtime } from "ably";
 import App from "./App";
 import HubRoute from "./HubRoute";
 import MultiplayerRoute from "./MultiplayerRoute";
+import ProfilePage from "./features/profile/ProfilePage";
 import type { Players, Side } from "./game/types";
 
 // Shape emitted by MultiplayerRoute.onStart
@@ -22,6 +23,7 @@ type MPStartPayload = {
 type View =
   | { key: "hub" }
   | { key: "mp" }
+  | { key: "profile" }
   | { key: "game"; mode: "solo" | "mp"; mpPayload?: MPStartPayload };
 
 export default function AppShell() {
@@ -33,8 +35,13 @@ export default function AppShell() {
       <HubRoute
         onStart={() => setView({ key: "game", mode: "solo" })}
         onMultiplayer={() => setView({ key: "mp" })}
+        onProfile={() => setView({ key: "profile" })}
       />
     );
+  }
+
+  if (view.key === "profile") {
+    return <ProfilePage onBack={() => setView({ key: "hub" })} />;
   }
 
   if (view.key === "mp") {

--- a/src/HubRoute.tsx
+++ b/src/HubRoute.tsx
@@ -1,21 +1,39 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import RogueWheelHub from "../ui/RogueWheelHub";
+import { getProfileBundle } from "./local/decks";
 
 export default function HubRoute({
   onStart,
   onMultiplayer,
+  onProfile,
 }: {
   onStart: () => void;
   onMultiplayer: () => void;
+  onProfile: () => void;
 }) {
+  const [profileName, setProfileName] = useState("Adventurer");
+  const [hasSave, setHasSave] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const bundle = getProfileBundle();
+      setProfileName(bundle.profile.displayName);
+      setHasSave(bundle.decks.some((deck) => deck.cards.length > 0));
+    } catch (err) {
+      console.warn("HubRoute: unable to load profile", err);
+    }
+  }, []);
+
   return (
     <RogueWheelHub
-      hasSave={false}
+      hasSave={hasSave}
       onNew={onStart}
       onContinue={onStart}
-      onMultiplayer={onMultiplayer}   // ← wire it here
+      onMultiplayer={onMultiplayer}
+      onProfile={onProfile}
       onQuit={() => console.log("Quit clicked")}
-      profileName="Adventurer"
+      profileName={profileName}
       version="v0.1.0"
     />
   );

--- a/src/features/profile/ProfilePage.tsx
+++ b/src/features/profile/ProfilePage.tsx
@@ -1,0 +1,196 @@
+import { useEffect, useState } from "react";
+import {
+  getProfileBundle,
+  createDeck,
+  setActiveDeck,
+  renameDeck,
+  deleteDeck,
+  swapDeckCards,
+} from "../../local/decks";
+import type { Deck } from "../../types/profile";
+
+type ProfileBundle = ReturnType<typeof getProfileBundle>;
+
+const FALLBACK_BUNDLE: ProfileBundle = {
+  profile: { id: "", displayName: "Local Player", mmr: 0, createdAt: Date.now() },
+  inventory: [],
+  decks: [],
+  active: undefined,
+};
+
+export default function ProfilePage({ onBack }: { onBack?: () => void }) {
+  const [bundle, setBundle] = useState<ProfileBundle>(() => {
+    if (typeof window === "undefined") return FALLBACK_BUNDLE;
+    return getProfileBundle();
+  });
+
+  const refresh = () => {
+    if (typeof window === "undefined") return;
+    setBundle(getProfileBundle());
+  };
+
+  const run = (fn: () => void) => {
+    try {
+      fn();
+      refresh();
+    } catch (err) {
+      console.error(err);
+      if (typeof window !== "undefined" && "alert" in window) {
+        window.alert((err as Error).message);
+      }
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const { profile, inventory, decks, active } = bundle;
+
+  return (
+    <div className="p-4">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 className="text-2xl font-semibold">{profile.displayName}</h2>
+          <p className="text-sm opacity-75">MMR {profile.mmr}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs opacity-60">ID: {profile.id || "local"}</span>
+          {onBack && (
+            <button className="rounded border border-slate-700 px-3 py-1 text-sm" onClick={onBack}>
+              Back to Hub
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <section className="rounded-xl border border-slate-700 p-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg">Decks</h3>
+            <button
+              className="rounded border px-2 py-1 text-sm"
+              onClick={() =>
+                run(() => {
+                  createDeck();
+                })
+              }
+            >
+              + New
+            </button>
+          </div>
+
+          <ul className="mt-2 space-y-1">
+            {decks.map((d: Deck) => (
+              <li
+                key={d.id}
+                className={`flex items-center justify-between rounded px-2 py-1 ${d.isActive ? "bg-slate-800" : "bg-slate-900"}`}
+              >
+                <div className="flex items-center gap-2">
+                  <button
+                    className="text-xs underline"
+                    onClick={() =>
+                      run(() => {
+                        setActiveDeck(d.id);
+                      })
+                    }
+                  >
+                    {d.isActive ? "Active" : "Set active"}
+                  </button>
+                  <input
+                    className="border-b border-slate-600 bg-transparent text-sm focus:outline-none"
+                    defaultValue={d.name}
+                    onBlur={(e) =>
+                      run(() => {
+                        renameDeck(d.id, e.target.value || "Deck");
+                      })
+                    }
+                  />
+                </div>
+                <button
+                  className="text-xs text-red-400"
+                  onClick={() =>
+                    run(() => {
+                      deleteDeck(d.id);
+                    })
+                  }
+                >
+                  delete
+                </button>
+              </li>
+            ))}
+          </ul>
+
+          <h3 className="mt-4 text-lg">Active Deck</h3>
+          {!active ? (
+            <p className="text-sm opacity-80">No deck.</p>
+          ) : (
+            <ul className="mt-2 space-y-1">
+              {active.cards.map((c) => (
+                <li
+                  key={c.cardId}
+                  className="flex items-center justify-between rounded border border-slate-700 px-2 py-1"
+                >
+                  <span>{c.cardId}</span>
+                  <div className="flex items-center gap-2">
+                    <button
+                      className="rounded border px-2 py-0.5 text-xs"
+                      onClick={() =>
+                        run(() => {
+                          swapDeckCards(active.id, [{ cardId: c.cardId, qty: 1 }], []);
+                        })
+                      }
+                    >
+                      −
+                    </button>
+                    <span>x{c.qty}</span>
+                    <button
+                      className="rounded border px-2 py-0.5 text-xs"
+                      onClick={() =>
+                        run(() => {
+                          swapDeckCards(active.id, [], [{ cardId: c.cardId, qty: 1 }]);
+                        })
+                      }
+                    >
+                      +
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="rounded-xl border border-slate-700 p-3">
+          <h3 className="text-lg">Inventory</h3>
+          <ul className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {inventory.map((i) => (
+              <li
+                key={i.cardId}
+                className="flex items-center justify-between rounded border border-slate-700 px-2 py-1"
+              >
+                <span>{i.cardId}</span>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs opacity-80">x{i.qty}</span>
+                  {active && (
+                    <button
+                      className="rounded border px-2 py-0.5 text-xs"
+                      onClick={() =>
+                        run(() => {
+                          swapDeckCards(active.id, [], [{ cardId: i.cardId, qty: 1 }]);
+                        })
+                      }
+                    >
+                      Add
+                    </button>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/game/decks.ts
+++ b/src/game/decks.ts
@@ -1,10 +1,16 @@
 // src/game/decks.ts
 import { Card, Fighter } from "./types";
 import { shuffle } from "./math";
+import { getProfileBundle } from "../local/decks";
 
 const uid = (() => { let i = 1; return () => `C${i++}`; })();
 
 export function starterDeck(): Card[] {
+  const profileDeck = loadActiveProfileDeck();
+  if (profileDeck) {
+    return shuffle(profileDeck);
+  }
+
   const base: Card[] = Array.from({ length: 10 }, (_, n) => ({
     id: uid(),
     name: `${n}`,
@@ -13,6 +19,65 @@ export function starterDeck(): Card[] {
     tags: [],
   }));
   return shuffle(base);
+}
+
+function loadActiveProfileDeck(): Card[] | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const { active } = getProfileBundle();
+    if (!active) return null;
+    const cards: Card[] = [];
+    for (const entry of active.cards) {
+      for (let i = 0; i < entry.qty; i += 1) {
+        cards.push(cardFromId(entry.cardId));
+      }
+    }
+    return cards.length ? cards : null;
+  } catch (err) {
+    console.warn("starterDeck: failed to load profile deck", err);
+    return null;
+  }
+}
+
+function cardFromId(cardId: string): Card {
+  const nextId = uid();
+  if (cardId.startsWith("split_")) {
+    const [leftRaw, rightRaw] = cardId.replace("split_", "").split("|");
+    const left = parseCardNumber(leftRaw);
+    const right = parseCardNumber(rightRaw);
+    return {
+      id: nextId,
+      name: `Split ${formatSigned(left)} | ${formatSigned(right)}`,
+      type: "split",
+      leftValue: left,
+      rightValue: right,
+      tags: [],
+    };
+  }
+
+  const value = (() => {
+    if (cardId.startsWith("basic_")) return parseCardNumber(cardId.split("_")[1]);
+    if (cardId.startsWith("neg_")) return parseCardNumber(cardId.split("_")[1]);
+    return parseCardNumber(cardId);
+  })();
+
+  return {
+    id: nextId,
+    name: formatSigned(value),
+    type: "normal",
+    number: value,
+    tags: [],
+  };
+}
+
+function parseCardNumber(raw: string | undefined): number {
+  if (!raw) return 0;
+  const num = Number(raw);
+  return Number.isFinite(num) ? num : 0;
+}
+
+function formatSigned(value: number): string {
+  return value > 0 ? `+${value}` : `${value}`;
 }
 
 export function makeFighter(name: string): Fighter {

--- a/src/local/decks.ts
+++ b/src/local/decks.ts
@@ -1,0 +1,93 @@
+import { loadState, saveState } from "./singleStore";
+import type { Deck, DeckCard, InventoryItem, LocalState } from "../types/profile";
+
+const MAX_DECK_SIZE = 10;
+const MAX_COPIES_PER_DECK = 2;
+
+const findActive = (s: LocalState) => s.decks.find((d) => d.isActive) ?? s.decks[0];
+const sum = (cards: DeckCard[]) => cards.reduce((a, c) => a + c.qty, 0);
+const qtyInDeck = (d: Deck, id: string) => d.cards.find((c) => c.cardId === id)?.qty ?? 0;
+const setQty = (d: Deck, id: string, q: number) => {
+  const i = d.cards.findIndex((c) => c.cardId === id);
+  if (q <= 0) {
+    if (i >= 0) d.cards.splice(i, 1);
+    return;
+  }
+  if (i >= 0) d.cards[i].qty = q;
+  else d.cards.push({ cardId: id, qty: q });
+};
+const ownAtLeast = (inv: InventoryItem[], id: string, need: number) => (inv.find((i) => i.cardId === id)?.qty ?? 0) >= need;
+
+export function getProfileBundle() {
+  const s = loadState();
+  return { profile: s.profile, inventory: s.inventory, decks: s.decks, active: findActive(s) };
+}
+
+export function createDeck(name = "New Deck") {
+  const s = loadState();
+  const d: Deck = {
+    id: crypto.randomUUID?.() ?? Math.random().toString(36).slice(2),
+    name,
+    isActive: false,
+    cards: [],
+  };
+  s.decks.push(d);
+  saveState(s);
+  return d;
+}
+export function setActiveDeck(id: string) {
+  const s = loadState();
+  s.decks = s.decks.map((d) => ({ ...d, isActive: d.id === id }));
+  saveState(s);
+}
+export function renameDeck(id: string, name: string) {
+  const s = loadState();
+  const d = s.decks.find((x) => x.id === id);
+  if (d) d.name = name || "Deck";
+  saveState(s);
+}
+export function deleteDeck(id: string) {
+  const s = loadState();
+  s.decks = s.decks.filter((d) => d.id !== id);
+  if (!s.decks.some((d) => d.isActive) && s.decks[0]) s.decks[0].isActive = true;
+  saveState(s);
+}
+
+export type SwapItem = { cardId: string; qty: number };
+
+export function swapDeckCards(deckId: string, remove: SwapItem[], add: SwapItem[]) {
+  const s = loadState();
+  const deck = s.decks.find((d) => d.id === deckId);
+  if (!deck) throw new Error("Deck not found");
+
+  const next: DeckCard[] = deck.cards.map((c) => ({ ...c }));
+  const tmp: Deck = { ...deck, cards: next };
+
+  for (const r of remove) {
+    setQty(tmp, r.cardId, Math.max(0, qtyInDeck(tmp, r.cardId) - r.qty));
+  }
+  for (const a of add) {
+    setQty(tmp, a.cardId, qtyInDeck(tmp, a.cardId) + a.qty);
+  }
+
+  if (sum(tmp.cards) > MAX_DECK_SIZE) throw new Error(`Deck too large (max ${MAX_DECK_SIZE})`);
+  for (const c of tmp.cards) {
+    if (!c.cardId.startsWith("basic_") && c.qty > MAX_COPIES_PER_DECK)
+      throw new Error(`Too many copies of ${c.cardId} (max ${MAX_COPIES_PER_DECK})`);
+    if (!ownAtLeast(s.inventory, c.cardId, 1)) throw new Error(`You don't own ${c.cardId}`);
+  }
+
+  deck.cards = tmp.cards;
+  saveState(s);
+  return deck;
+}
+
+export function addToInventory(items: SwapItem[]) {
+  const s = loadState();
+  for (const it of items) {
+    const i = s.inventory.findIndex((x) => x.cardId === it.cardId);
+    if (i >= 0) s.inventory[i].qty += it.qty;
+    else s.inventory.push({ cardId: it.cardId, qty: it.qty });
+  }
+  saveState(s);
+}

--- a/src/local/singleStore.ts
+++ b/src/local/singleStore.ts
@@ -1,0 +1,60 @@
+import type { LocalState, InventoryItem, Deck } from "../types/profile";
+
+const KEY = "rw:single:state";
+const VERSION = 1;
+
+function uid(prefix = "id") {
+  return `${prefix}_${Math.random().toString(36).slice(2, 8)}${Date.now().toString(36).slice(-4)}`;
+}
+
+const SEED_INVENTORY: InventoryItem[] = [
+  ...Array.from({ length: 10 }, (_, n) => ({ cardId: `basic_${n}`, qty: 4 })),
+  { cardId: "split_-1|+2", qty: 2 },
+  { cardId: "neg_-2", qty: 2 },
+];
+
+const SEED_DECK: Deck = {
+  id: uid("deck"),
+  name: "Starter Deck",
+  isActive: true,
+  cards: Array.from({ length: 10 }, (_, n) => ({ cardId: `basic_${n}`, qty: 1 })),
+};
+
+function seed(): LocalState {
+  return {
+    version: VERSION,
+    profile: { id: uid("user"), displayName: "Local Player", mmr: 1000, createdAt: Date.now() },
+    inventory: SEED_INVENTORY,
+    decks: [SEED_DECK],
+  };
+}
+
+export function loadState(): LocalState {
+  if (typeof localStorage === "undefined") {
+    return seed();
+  }
+  const raw = localStorage.getItem(KEY);
+  if (!raw) {
+    const s = seed();
+    localStorage.setItem(KEY, JSON.stringify(s));
+    return s;
+  }
+  try {
+    const s = JSON.parse(raw) as LocalState;
+    if (!("version" in s)) (s as any).version = VERSION;
+    return s;
+  } catch {
+    const s = seed();
+    localStorage.setItem(KEY, JSON.stringify(s));
+    return s;
+  }
+}
+
+export function saveState(state: LocalState) {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(KEY, JSON.stringify(state));
+}
+export function resetState() {
+  if (typeof localStorage === "undefined") return;
+  localStorage.removeItem(KEY);
+}

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,20 @@
+export type CardId = string;
+
+export type InventoryItem = { cardId: CardId; qty: number };
+export type DeckCard = { cardId: CardId; qty: number };
+export type Deck = { id: string; name: string; isActive: boolean; cards: DeckCard[] };
+
+export type Profile = {
+  id: string;
+  displayName: string;
+  avatarUrl?: string;
+  mmr: number;
+  createdAt: number;
+};
+
+export type LocalState = {
+  version: number;
+  profile: Profile;
+  inventory: InventoryItem[];
+  decks: Deck[];
+};

--- a/ui/RogueWheelHub.tsx
+++ b/ui/RogueWheelHub.tsx
@@ -5,6 +5,7 @@ const ICONS = {
   swords: "⚔️",
   settings: "⚙️",
   power: "⏻",
+  profile: "🧙",
   book: "📖",
 };
 
@@ -22,6 +23,7 @@ export type HubShellProps = {
   onContinue?: () => void;
   onNew?: () => void;
   onMultiplayer?: () => void;
+  onProfile?: () => void;
   onHowTo?: () => void;
   onSettings?: () => void;
   onQuit?: () => void;
@@ -71,11 +73,12 @@ export default function RogueWheelHub(props: HubShellProps) {
         : null,
       { key: "new", label: hasSave ? "New Run" : "Play", onClick: safeOnNew, icon: <span className="h-4 w-4 flex items-center justify-center">{ICONS.swords}</span> },
       { key: "mp", label: "Multiplayer", onClick: props.onMultiplayer, icon: <span className="h-4 w-4 flex items-center justify-center">🧑‍🤝‍🧑</span> },
+      { key: "profile", label: "Profile", onClick: props.onProfile, icon: <span className="h-4 w-4 flex items-center justify-center">{ICONS.profile}</span> },
       { key: "howto", label: "How to Play", onClick: () => { onHowTo?.(); setShowHowTo(true); }, icon: <span className="h-4 w-4 flex items-center justify-center">{ICONS.book}</span> },
       { key: "settings", label: "Options", onClick: () => { onSettings?.(); setShowOptions(true); }, icon: <span className="h-4 w-4 flex items-center justify-center">{ICONS.settings}</span> },
       { key: "quit", label: "Quit", onClick: onQuit, icon: <span className="h-4 w-4 flex items-center justify-center">{ICONS.power}</span> },
     ].filter(Boolean) as MenuItem[],
-    [hasSave, safeOnContinue, safeOnNew, onHowTo, onSettings, onQuit, props.onMultiplayer]
+    [hasSave, safeOnContinue, safeOnNew, onHowTo, onSettings, onQuit, props.onMultiplayer, props.onProfile]
   );
 
   // Keyboard navigation


### PR DESCRIPTION
## Summary
- define shared profile, deck, and inventory types and seed a single-player localStorage store with starter data
- implement local deck/inventory helpers plus a profile management page for editing decks and viewing inventory
- integrate the profile view into the hub navigation and load the active deck for gameplay

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca85fbfc688332bcd8fe19e4130556