### PR TITLE
Add round advance gating and match rematch flow

### DIFF
--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -23,7 +23,6 @@ export default function AppShell() {
         onStart={() => setView({ key: "game", mode: "solo" })}
         onMultiplayer={() => setView({ key: "mp" })}
         onProfile={() => setView({ key: "profile" })}
-        onProfile={() => { console.log("→ profile"); setView({ key: "profile" }); }}
       />
     );
   }
@@ -79,12 +78,18 @@ export default function AppShell() {
     localPlayerId = "local";
   }
 
+  const exitToMenu = () => {
+    setView({ key: "hub" });
+    setMpPayload(null);
+  };
+
   return (
     <App
       localSide={localSide}
       localPlayerId={localPlayerId}
       players={players}
       seed={seed}
+      onExit={exitToMenu}
       {...extraProps}
     />
   );


### PR DESCRIPTION
## Summary
- require both players to signal before advancing rounds in multiplayer and reset the match state cleanly when starting over
- present a match-complete overlay with the final score, coordinated rematch option, and exit control
- allow the shell to exit back to the hub when a match ends

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caa34c3f548332bade80cb7d139eef