### PR TITLE
Add multiplayer win target configuration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,6 +89,7 @@ export default function ThreeWheel_WinsOnly({
   seed,
   roomCode,
   hostId,
+  targetWins,
   onExit,
 }: {
   localSide: TwoSide;
@@ -97,6 +98,7 @@ export default function ThreeWheel_WinsOnly({
   seed: number;
   roomCode?: string;
   hostId?: string;
+  targetWins?: number;
   onExit?: () => void;
 }) {
   const mountedRef = useRef(true);
@@ -116,6 +118,11 @@ export default function ThreeWheel_WinsOnly({
     player: players.left.name,
     enemy: players.right.name,
   };
+
+  const winGoal =
+    typeof targetWins === "number" && Number.isFinite(targetWins)
+      ? Math.max(1, Math.min(15, Math.round(targetWins)))
+      : TARGET_WINS;
 
 
   const hostLegacySide: LegacySide = (() => {
@@ -208,7 +215,7 @@ export default function ThreeWheel_WinsOnly({
   const hasRecordedResultRef = useRef(false);
 
   const matchWinner: LegacySide | null =
-    wins.player >= TARGET_WINS ? "player" : wins.enemy >= TARGET_WINS ? "enemy" : null;
+    wins.player >= winGoal ? "player" : wins.enemy >= winGoal ? "enemy" : null;
   const localWinsCount = localLegacySide === "player" ? wins.player : wins.enemy;
   const remoteWinsCount = localLegacySide === "player" ? wins.enemy : wins.player;
   const localWon = matchWinner ? matchWinner === localLegacySide : false;
@@ -832,12 +839,12 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
       setReserveSums({ player: pReserve, enemy: eReserve });
       clearAdvanceVotes();
       setPhase("roundEnd");
-      if (pWins >= TARGET_WINS || eWins >= TARGET_WINS) {
+      if (pWins >= winGoal || eWins >= winGoal) {
         clearRematchVotes();
         setPhase("ended");
         const localWins = localLegacySide === "player" ? pWins : eWins;
         appendLog(
-          localWins >= TARGET_WINS
+          localWins >= winGoal
             ? "You win the match!"
             : `${namesByLegacy[remoteLegacySide]} wins the match!`
         );
@@ -1653,7 +1660,7 @@ const HUDPanels = () => {
         <div className="flex items-center gap-3">
           <div><span className="opacity-70">Round</span> <span className="font-semibold">{round}</span></div>
           <div><span className="opacity-70">Phase</span> <span className="font-semibold">{phase}</span></div>
-          <div><span className="opacity-70">Goal</span> <span className="font-semibold">First to {TARGET_WINS} wins</span></div>
+          <div><span className="opacity-70">Goal</span> <span className="font-semibold">First to {winGoal} wins</span></div>
         </div>
         <div className="flex items-center gap-2 relative">
           <button onClick={() => setShowRef((v) => !v)} className="px-2.5 py-0.5 rounded bg-slate-700 text-white border border-slate-600 hover:bg-slate-600">Reference</button>
@@ -1661,7 +1668,7 @@ const HUDPanels = () => {
             <div className="absolute top-[110%] right-0 w-80 rounded-lg border border-slate-700 bg-slate-800/95 shadow-xl p-3 z-50">
               <div className="flex items-center justify-between mb-1"><div className="font-semibold">Reference</div><button onClick={() => setShowRef(false)} className="text-xl leading-none text-slate-300 hover:text-white">×</button></div>
               <div className="text-[12px] space-y-2">
-                <div>Place <span className="font-semibold">1 card next to each wheel</span>, then <span className="font-semibold">press the Resolve button</span>. Where the <span className="font-semibold">token stops</span> decides the winnning rule, and the player who matches it gets <span className="font-semibold">1 win</span>. First to <span className="font-semibold">7</span> wins takes the match.</div>
+                <div>Place <span className="font-semibold">1 card next to each wheel</span>, then <span className="font-semibold">press the Resolve button</span>. Where the <span className="font-semibold">token stops</span> decides the winnning rule, and the player who matches it gets <span className="font-semibold">1 win</span>. First to <span className="font-semibold">{winGoal}</span> wins takes the match.</div>
                 <ul className="list-disc pl-5 space-y-1">
                   <li>💥 Strongest — higher value wins</li>
                   <li>🦊 Weakest — lower value wins</li>
@@ -1781,8 +1788,8 @@ const HUDPanels = () => {
 
           <div className="text-sm text-slate-200">
             {localWon
-              ? `You reached ${TARGET_WINS} wins.`
-              : `${winnerName ?? remoteName} reached ${TARGET_WINS} wins.`}
+              ? `You reached ${winGoal} wins.`
+              : `${winnerName ?? remoteName} reached ${winGoal} wins.`}
           </div>
 
           <div className="rounded-md border border-slate-700 bg-slate-800/80 px-4 py-3 text-sm text-slate-100">

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -7,6 +7,10 @@ import MultiplayerRoute from "./MultiplayerRoute";
 import type { Players, Side } from "./game/types";
 import ProfilePage from "./ProfilePage";
 
+type MPStartPayload = Parameters<
+  NonNullable<React.ComponentProps<typeof MultiplayerRoute>["onStart"]>
+>[0];
+
 type View =
   | { key: "hub" }
   | { key: "mp" }
@@ -59,7 +63,7 @@ export default function AppShell() {
   let players: Players;
   let localSide: Side;
   let localPlayerId: string;
-  let extraProps: { roomCode?: string; hostId?: string } = {};
+  let extraProps: { roomCode?: string; hostId?: string; targetWins?: number } = {};
 
   if (view.mode === "mp" && (view.mpPayload ?? mpPayload)) {
     const mp = (view.mpPayload ?? mpPayload)!;
@@ -67,7 +71,7 @@ export default function AppShell() {
     players = mp.players;
     localSide = mp.localSide;
     localPlayerId = mp.players[localSide].id;
-    extraProps = { roomCode: mp.roomCode, hostId: mp.hostId };
+    extraProps = { roomCode: mp.roomCode, hostId: mp.hostId, targetWins: mp.targetWins };
   } else {
     seed = Math.floor(Math.random() * 2 ** 31);
     players = {

--- a/src/MultiplayerRoute.tsx
+++ b/src/MultiplayerRoute.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Realtime } from "ably";
 import type { PresenceMessage } from "ably";
-import type { Players, Side } from "./game/types";
+import { TARGET_WINS, type Players, type Side } from "./game/types";
 
 // ----- Start payload now includes a Players map and localSide -----
 type StartMessagePayload = {
@@ -10,6 +10,7 @@ type StartMessagePayload = {
   hostId: string;
   players: Players;          // { left: {id,name,color}, right: {…} }
   playersArr?: { clientId: string; name: string }[]; // optional: raw list for debugging
+  targetWins: number;
 };
 
 type StartPayload = StartMessagePayload & {
@@ -37,35 +38,56 @@ export default function MultiplayerRoute({
   const [joinCode, setJoinCode] = useState("");
   const [name, setName] = useState<string>(() => defaultName());
   const [status, setStatus] = useState<string>("");
+  const [targetWins, setTargetWins] = useState<number>(TARGET_WINS);
 
   // ---- Ably core refs ----
   const ablyRef = useRef<Realtime | null>(null);
   const channelRef = useRef<ReturnType<Realtime["channels"]["get"]> | null>(null);
-  const [members, setMembers] = useState<{ clientId: string; name: string }[]>([]);
+  const [members, setMembers] = useState<
+    { clientId: string; name: string; targetWins?: number }[]
+  >([]);
   const clientId = useMemo(() => uid4(), []);
 
-  type MemberEntry = { clientId: string; name: string; ts: number };
+  type MemberEntry = {
+    clientId: string;
+    name: string;
+    ts: number;
+    targetWins?: number;
+  };
   const memberMapRef = useRef<Map<string, MemberEntry>>(new Map());
 
   const commitMembers = useCallback((map: Map<string, MemberEntry>) => {
-    const ordered = Array.from(map.values())
-      .sort((a, b) => {
-        if (a.ts !== b.ts) return a.ts - b.ts;
-        return a.clientId.localeCompare(b.clientId);
-      })
-      .map(({ clientId, name }) => ({ clientId, name }));
-    setMembers(ordered);
-  }, []);
+    const ordered = Array.from(map.values()).sort((a, b) => {
+      if (a.ts !== b.ts) return a.ts - b.ts;
+      return a.clientId.localeCompare(b.clientId);
+    });
+
+    setMembers(
+      ordered.map(({ clientId, name, targetWins }) => ({ clientId, name, targetWins }))
+    );
+
+    const host = ordered[0];
+    const hostTargetWins = host?.targetWins;
+    if (typeof hostTargetWins === "number" && Number.isFinite(hostTargetWins)) {
+      setTargetWins(clampTargetWins(hostTargetWins));
+    }
+  }, [setMembers, setTargetWins]);
 
   const applySnapshot = useCallback((list: PresenceMessage[] | undefined | null) => {
     const next = new Map<string, MemberEntry>();
     if (Array.isArray(list)) {
       for (const msg of list) {
         if (!msg?.clientId) continue;
+        const data = (msg.data ?? {}) as any;
+        const rawTargetWins = data?.targetWins;
         next.set(msg.clientId, {
           clientId: msg.clientId,
-          name: (msg.data as any)?.name ?? "Player",
+          name: data?.name ?? "Player",
           ts: msg.timestamp ?? Date.now(),
+          targetWins:
+            typeof rawTargetWins === "number" && Number.isFinite(rawTargetWins)
+              ? clampTargetWins(rawTargetWins)
+              : undefined,
         });
       }
     }
@@ -78,12 +100,19 @@ export default function MultiplayerRoute({
     const action = msg.action;
     const ts = msg.timestamp ?? Date.now();
     const map = new Map(memberMapRef.current);
-    const name = (msg.data as any)?.name ?? map.get(msg.clientId)?.name ?? "Player";
+    const data = (msg.data ?? {}) as any;
+    const existing = map.get(msg.clientId);
+    const name = data?.name ?? existing?.name ?? "Player";
+    const rawTargetWins = data?.targetWins;
+    const memberTargetWins =
+      typeof rawTargetWins === "number" && Number.isFinite(rawTargetWins)
+        ? clampTargetWins(rawTargetWins)
+        : existing?.targetWins;
 
     if (action === "leave" || action === "absent") {
       map.delete(msg.clientId);
     } else if (action === "enter" || action === "present" || action === "update") {
-      map.set(msg.clientId, { clientId: msg.clientId, name, ts });
+      map.set(msg.clientId, { clientId: msg.clientId, name, ts, targetWins: memberTargetWins });
     }
 
     memberMapRef.current = map;
@@ -125,29 +154,11 @@ export default function MultiplayerRoute({
     try {
       const page = await chan.presence.get({ waitForSync: true } as any);
       const list = Array.isArray(page) ? page : page?.items ?? [];
+      const sorted = Array.from(list).sort(
+        (a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0)
+      );
 
-      
-// (optionally, at top of file if you need the type)
-/*
-import type { Types as AblyTypes } from "ably";
-*/
-
-const sorted = Array.from(list).sort(
-  (a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0)
-);
-
-// keep your presence snapshot logic from the feature branch
-// applySnapshot(sorted as AblyTypes.PresenceMessage[]); // <- if you use the type
-applySnapshot(sorted as any); // <- or keep your original if you don't import the type
-
-// keep the UI mapping from main
-const mapped = sorted.map((p) => ({
-  clientId: p.clientId!,
-  name: (p.data as any)?.name ?? "Player",
-}));
-setMembers(mapped);
-
-
+      applySnapshot(sorted as any);
     } catch (e: any) {
       setStatus(`Presence get error: ${e?.message ?? e}`);
     }
@@ -201,11 +212,16 @@ setMembers(mapped);
       chan.presence.subscribe(onPresence);
 
       // 3) Enter presence with the current name
-      await chan.presence.enter({ name });
+      await chan.presence.enter({ name, targetWins });
 
       {
         const map = new Map(memberMapRef.current);
-        map.set(clientId, { clientId, name, ts: Date.now() });
+        map.set(clientId, {
+          clientId,
+          name,
+          ts: Date.now(),
+          targetWins,
+        });
         memberMapRef.current = map;
         commitMembers(map);
       }
@@ -302,22 +318,22 @@ setMembers(mapped);
     (async () => {
       if (mode === "in-room" && channelRef.current) {
         try {
-          await channelRef.current.presence.update({ name });
+          await channelRef.current.presence.update({ name, targetWins });
 
           const current = memberMapRef.current.get(clientId);
-          if (current && current.name !== name) {
-            const map = new Map(memberMapRef.current);
-            map.set(clientId, { ...current, name });
-            memberMapRef.current = map;
-            commitMembers(map);
-          }
-
-          await refreshMembers(channelRef.current);
+          const map = new Map(memberMapRef.current);
+          map.set(clientId, {
+            clientId,
+            name,
+            targetWins,
+            ts: current?.ts ?? Date.now(),
+          });
+          memberMapRef.current = map;
+          commitMembers(map);
         } catch { /* no-op */ }
       }
     })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [name]);
+  }, [clientId, commitMembers, mode, name, targetWins]);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -396,6 +412,7 @@ async function onCreateRoom() {
     setMode("idle");
     setRoomCode("");
     setJoinCode("");
+    setTargetWins(TARGET_WINS);
   }
 
   async function onStartGame() {
@@ -408,6 +425,7 @@ async function onCreateRoom() {
     // --- Assign sides deterministically: host=left, first joiner=right
     const players = assignSides(members);
 
+    const winsGoal = clampTargetWins(targetWins);
     const seed = Math.floor(Math.random() * 2 ** 31);
     const payload: StartMessagePayload = {
       roomCode,
@@ -415,6 +433,7 @@ async function onCreateRoom() {
       players,
       hostId: members[0].clientId, // first in presence is host
       playersArr: members,         // optional, for debugging/analytics
+      targetWins: winsGoal,
     };
 
     await channelRef.current?.publish("start", payload);
@@ -488,6 +507,32 @@ async function onCreateRoom() {
             </div>
 
             <div className="rounded-lg bg-black/30 px-3 py-2 ring-1 ring-white/10">
+              <div className="text-sm opacity-80 mb-1">Rounds to win</div>
+              <div className="flex items-center gap-2">
+                <input
+                  type="number"
+                  min={1}
+                  max={15}
+                  value={targetWins}
+                  onChange={(e) => {
+                    const next = Number.parseInt(e.target.value, 10);
+                    setTargetWins(
+                      Number.isFinite(next) ? clampTargetWins(next) : TARGET_WINS
+                    );
+                  }}
+                  disabled={!isHost}
+                  className="w-24 rounded-lg bg-black/40 px-3 py-2 text-center ring-1 ring-white/10 disabled:opacity-60"
+                />
+                {!isHost && (
+                  <span className="rounded bg-white/10 px-2 py-0.5 text-xs">Host controls this</span>
+                )}
+              </div>
+              <div className="mt-1 text-xs opacity-70">
+                First player to reach {targetWins} round wins takes the match.
+              </div>
+            </div>
+
+            <div className="rounded-lg bg-black/30 px-3 py-2 ring-1 ring-white/10">
               <div className="text-sm opacity-80 mb-1">Players</div>
               <ul className="text-sm grid gap-1">
                 {members.map((m, i) => (
@@ -554,6 +599,13 @@ function uid4() {
 function defaultName() {
   const animals = ["Fox", "Bear", "Lynx", "Hawk", "Otter", "Wolf", "Drake"];
   return `Player ${animals[Math.floor(Math.random() * animals.length)]}`;
+}
+
+function clampTargetWins(value: number) {
+  if (!Number.isFinite(value)) return TARGET_WINS;
+  const rounded = Math.round(value);
+  const clamped = Math.max(1, Math.min(15, rounded));
+  return clamped;
 }
 
 // Assign sides from presence order (host=left, first joiner=right)


### PR DESCRIPTION
## Summary
- add a rounds-to-win control to the multiplayer room and sync it through presence and the start payload
- plumb the configured win target into the game shell when starting multiplayer
- respect the selected win goal in match resolution messaging and HUD details

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caf3f2b5d08332a7b0705c5b52b4ff