### PR TITLE
Ensure host join order uses server timestamps

### DIFF
--- a/src/MultiplayerRoute.tsx
+++ b/src/MultiplayerRoute.tsx
@@ -84,10 +84,19 @@ export default function MultiplayerRoute({
         if (!msg?.clientId) continue;
         const data = (msg.data ?? {}) as any;
         const rawTargetWins = data?.targetWins;
+        const prev = memberMapRef.current.get(msg.clientId);
+        const serverTs = typeof msg.timestamp === "number" ? msg.timestamp : undefined;
+        const ts =
+          serverTs !== undefined
+            ? prev?.ts !== undefined
+              ? Math.min(prev.ts, serverTs)
+              : serverTs
+            : prev?.ts ?? Date.now();
+
         next.set(msg.clientId, {
           clientId: msg.clientId,
           name: data?.name ?? "Player",
-          ts: msg.timestamp ?? Date.now(),
+          ts,
           targetWins:
             typeof rawTargetWins === "number" && Number.isFinite(rawTargetWins)
               ? clampTargetWins(rawTargetWins)
@@ -102,10 +111,22 @@ export default function MultiplayerRoute({
   const applyPresenceUpdate = useCallback((msg: PresenceMessage | null | undefined) => {
     if (!msg?.clientId) return;
     const action = msg.action;
-    const ts = msg.timestamp ?? Date.now();
     const map = new Map(memberMapRef.current);
     const data = (msg.data ?? {}) as any;
     const existing = map.get(msg.clientId);
+    const serverTs = typeof msg.timestamp === "number" ? msg.timestamp : undefined;
+    const isJoinAction = action === "enter" || action === "present";
+    const ts = (() => {
+      if (isJoinAction) {
+        if (serverTs !== undefined) {
+          return existing?.ts !== undefined ? Math.min(existing.ts, serverTs) : serverTs;
+        }
+        return existing?.ts ?? Date.now();
+      }
+      if (existing?.ts !== undefined) return existing.ts;
+      if (serverTs !== undefined) return serverTs;
+      return Date.now();
+    })();
     const name = data?.name ?? existing?.name ?? "Player";
     const rawTargetWins = data?.targetWins;
     const memberTargetWins =


### PR DESCRIPTION
## Summary
- normalize presence snapshot timestamps against existing entries so the host keeps the earliest join record
- prefer Ably-provided timestamps for enter/present updates to prevent local clock skew from reordering players

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb0f83c4a48332a57b3c9f65cc0512