### PR TITLE
Refactor touch drag layer into dedicated module

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,11 @@ import { isSplit, isNormal, effectiveValue, fmtNum } from "./game/values";
 // components
 import CanvasWheel, { WheelHandle } from "./components/CanvasWheel";
 import StSCard from "./components/StSCard";
+import TouchDragLayer, {
+  calcWheelSize,
+  useTouchDragLayer,
+  MAX_WHEEL,
+} from "./components/match/TouchDragLayer";
 
 type AblyRealtime = InstanceType<typeof Realtime>;
 type AblyChannel = ReturnType<AblyRealtime["channels"]["get"]>;
@@ -69,9 +74,6 @@ type MPIntent =
   | { type: "reserve"; side: LegacySide; reserve: number; round: number };
 
 // ---------------- Constants ----------------
-const MIN_WHEEL = 160;
-const MAX_WHEEL = 200;
-
 const THEME = {
   panelBg:   '#2c1c0e',
   panelBorder:'#5c4326',
@@ -271,97 +273,6 @@ export default function ThreeWheel_WinsOnly({
 
   const [handClearance, setHandClearance] = useState<number>(0);
 
-function calcWheelSize(viewH: number, viewW: number, dockAllowance = 0) {
-  const isMobile = viewW <= 480;
-  const chromeAllowance = viewW >= 1024 ? 200 : 140;
-  const raw = Math.floor((viewH - chromeAllowance - dockAllowance) / 3);
-  const MOBILE_MAX = 188;
-  const DESKTOP_MAX = 220;
-  const maxAllowed = isMobile ? MOBILE_MAX : DESKTOP_MAX;
-  return Math.max(MIN_WHEEL, Math.min(maxAllowed, raw));
-}
-  
-  
-  // --- Mobile pointer-drag support ---
-const [isPtrDragging, setIsPtrDragging] = useState(false);
-const [ptrDragCard, setPtrDragCard] = useState<Card | null>(null);
-const ptrPos = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
-
-function addTouchDragCss(on: boolean) {
-  const root = document.documentElement;
-  if (on) {
-    // store previous to restore later
-    (root as any).__prevTouchAction = root.style.touchAction;
-    (root as any).__prevOverscroll = root.style.overscrollBehavior;
-    root.style.touchAction = 'none';
-    root.style.overscrollBehavior = 'contain';
-  } else {
-    root.style.touchAction = (root as any).__prevTouchAction ?? '';
-    root.style.overscrollBehavior = (root as any).__prevOverscroll ?? '';
-    delete (root as any).__prevTouchAction;
-    delete (root as any).__prevOverscroll;
-  }
-}
-
-function getDropTargetAt(x: number, y: number): { kind: 'wheel' | 'slot'; idx: number } | null {
-  let el = document.elementFromPoint(x, y) as HTMLElement | null;
-  while (el) {
-    const d = (el as HTMLElement).dataset;
-    if (d.drop && d.idx) {
-      if (d.drop === 'wheel') return { kind: 'wheel', idx: Number(d.idx) };
-      if (d.drop === 'slot')  return { kind: 'slot',  idx: Number(d.idx) };
-    }
-    el = el.parentElement;
-  }
-  return null;
-}
-
-function startPointerDrag(card: Card, e: React.PointerEvent) {
-  // only trigger for touch/pen; mouse still uses native DnD you already have
-  if (e.pointerType === 'mouse') return;
-  e.currentTarget.setPointerCapture?.(e.pointerId);
-  setSelectedCardId(card.id);
-  setDragCardId(card.id);
-  setPtrDragCard(card);
-  setIsPtrDragging(true);
-  addTouchDragCss(true);
-  ptrPos.current = { x: e.clientX, y: e.clientY };
-
-  const onMove = (ev: PointerEvent) => {
-    ptrPos.current = { x: ev.clientX, y: ev.clientY };
-    const t = getDropTargetAt(ev.clientX, ev.clientY);
-    setDragOverWheel(t && (t.kind === 'wheel' || t.kind === 'slot') ? t.idx : null);
-    // avoid scroll while dragging
-    ev.preventDefault?.();
-  };
-
-  const onUp = (ev: PointerEvent) => {
-    const t = getDropTargetAt(ev.clientX, ev.clientY);
-    if (t && active[t.idx]) {
-      // assign card to that wheel index (slot clicks already map to a wheel index)
-      assignToWheelLocal(t.idx, card);
-    }
-    cleanup();
-  };
-
-  const onCancel = () => cleanup();
-
-  function cleanup() {
-    window.removeEventListener('pointermove', onMove, { capture: true } as any);
-    window.removeEventListener('pointerup', onUp, { capture: true } as any);
-    window.removeEventListener('pointercancel', onCancel, { capture: true } as any);
-    setIsPtrDragging(false);
-    setPtrDragCard(null);
-    setDragOverWheel(null);
-    setDragCardId(null);
-    addTouchDragCss(false);
-  }
-
-  window.addEventListener('pointermove', onMove, { passive: false, capture: true });
-  window.addEventListener('pointerup', onUp, { passive: false, capture: true });
-  window.addEventListener('pointercancel', onCancel, { passive: false, capture: true });
-}
-  
   // Responsive wheel size
   const [wheelSize, setWheelSize] = useState<number>(() => (typeof window !== 'undefined' ? calcWheelSize(window.innerHeight, window.innerWidth, 0) : MAX_WHEEL));
   useEffect(() => {
@@ -593,6 +504,20 @@ const storeReserveReport = useCallback(
       sendIntent({ type: "clear", lane: i, side: localLegacySide });
     }
   }
+
+
+  const {
+    isDragging: isPtrDragging,
+    dragCard: ptrDragCard,
+    pointerPosition: ptrPos,
+    startPointerDrag,
+  } = useTouchDragLayer({
+    active,
+    assignToWheel: assignToWheelLocal,
+    setDragOverWheel,
+    setDragCardId,
+    setSelectedCardId,
+  });
 
 
 function autoPickEnemy(): (Card | null)[] {
@@ -1479,23 +1404,7 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
           })}
         </div>
 {/* Touch drag ghost (mobile) */}
-{isPtrDragging && ptrDragCard && (
-  <div
-    style={{
-      position: 'fixed',
-      left: 0,
-      top: 0,
-      transform: `translate(${ptrPos.current.x - 48}px, ${ptrPos.current.y - 64}px)`,
-      pointerEvents: 'none',
-      zIndex: 9999,
-    }}
-    aria-hidden
-  >
-    <div style={{ transform: 'scale(0.9)', filter: 'drop-shadow(0 6px 8px rgba(0,0,0,.35))' }}>
-      <StSCard card={ptrDragCard} />
-    </div>
-  </div>
-)}
+<TouchDragLayer dragCard={ptrDragCard} isDragging={isPtrDragging} pointerPosition={ptrPos} />
 
       </div>
     );

--- a/src/components/match/TouchDragLayer.tsx
+++ b/src/components/match/TouchDragLayer.tsx
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { MutableRefObject } from "react";
+import StSCard from "../StSCard";
+import type { Card } from "../../game/types";
+
+export const MIN_WHEEL = 160;
+export const MAX_WHEEL = 200;
+
+export function calcWheelSize(viewH: number, viewW: number, dockAllowance = 0) {
+  const isMobile = viewW <= 480;
+  const chromeAllowance = viewW >= 1024 ? 200 : 140;
+  const raw = Math.floor((viewH - chromeAllowance - dockAllowance) / 3);
+  const MOBILE_MAX = 188;
+  const DESKTOP_MAX = 220;
+  const maxAllowed = isMobile ? MOBILE_MAX : DESKTOP_MAX;
+  return Math.max(MIN_WHEEL, Math.min(maxAllowed, raw));
+}
+
+type DropTarget = { kind: "wheel" | "slot"; idx: number };
+
+type UseTouchDragLayerOptions = {
+  active: readonly boolean[];
+  assignToWheel: (index: number, card: Card) => void;
+  setDragOverWheel: (index: number | null) => void;
+  setDragCardId: (id: string | null) => void;
+  setSelectedCardId: (id: string | null) => void;
+};
+
+type PointerPositionRef = MutableRefObject<{ x: number; y: number }>;
+
+type CleanupFn = () => void;
+
+export function useTouchDragLayer({
+  active,
+  assignToWheel,
+  setDragOverWheel,
+  setDragCardId,
+  setSelectedCardId,
+}: UseTouchDragLayerOptions) {
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragCard, setDragCard] = useState<Card | null>(null);
+  const pointerPosition = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+  const cleanupRef = useRef<CleanupFn | null>(null);
+  const activeRef = useRef(active);
+  const assignRef = useRef(assignToWheel);
+
+  useEffect(() => {
+    activeRef.current = active;
+  }, [active]);
+
+  useEffect(() => {
+    assignRef.current = assignToWheel;
+  }, [assignToWheel]);
+
+  useEffect(() => {
+    return () => {
+      cleanupRef.current?.();
+    };
+  }, []);
+
+  const startPointerDrag = useCallback(
+    (card: Card, event: React.PointerEvent) => {
+      if (event.pointerType === "mouse") return;
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+      setSelectedCardId(card.id);
+      setDragCardId(card.id);
+      setDragCard(card);
+      setIsDragging(true);
+      pointerPosition.current = { x: event.clientX, y: event.clientY };
+      addTouchDragCss(true);
+
+      const handleMove = (ev: PointerEvent) => {
+        pointerPosition.current = { x: ev.clientX, y: ev.clientY };
+        const target = getDropTargetAt(ev.clientX, ev.clientY);
+        setDragOverWheel(target && (target.kind === "wheel" || target.kind === "slot") ? target.idx : null);
+        ev.preventDefault?.();
+      };
+
+      const cleanup = () => {
+        window.removeEventListener("pointermove", handleMove, listenerOptions);
+        window.removeEventListener("pointerup", handleUp, listenerOptions);
+        window.removeEventListener("pointercancel", handleCancel, listenerOptions);
+        setIsDragging(false);
+        setDragCard(null);
+        setDragOverWheel(null);
+        setDragCardId(null);
+        addTouchDragCss(false);
+      };
+
+      const handleUp = (ev: PointerEvent) => {
+        pointerPosition.current = { x: ev.clientX, y: ev.clientY };
+        const target = getDropTargetAt(ev.clientX, ev.clientY);
+        if (target && activeRef.current[target.idx]) {
+          assignRef.current(target.idx, card);
+        }
+        cleanup();
+      };
+
+      const handleCancel = () => {
+        cleanup();
+      };
+
+      cleanupRef.current = cleanup;
+
+      window.addEventListener("pointermove", handleMove, listenerOptions);
+      window.addEventListener("pointerup", handleUp, listenerOptions);
+      window.addEventListener("pointercancel", handleCancel, listenerOptions);
+    },
+    [setDragCardId, setDragOverWheel, setSelectedCardId]
+  );
+
+  return { isDragging, dragCard, pointerPosition, startPointerDrag };
+}
+
+type TouchDragLayerProps = {
+  dragCard: Card | null;
+  isDragging: boolean;
+  pointerPosition: PointerPositionRef;
+};
+
+export default function TouchDragLayer({ dragCard, isDragging, pointerPosition }: TouchDragLayerProps) {
+  if (!isDragging || !dragCard) return null;
+
+  const { x, y } = pointerPosition.current;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        left: 0,
+        top: 0,
+        transform: `translate(${x - 48}px, ${y - 64}px)`,
+        pointerEvents: "none",
+        zIndex: 9999,
+      }}
+      aria-hidden
+    >
+      <div style={{ transform: "scale(0.9)", filter: "drop-shadow(0 6px 8px rgba(0,0,0,.35))" }}>
+        <StSCard card={dragCard} />
+      </div>
+    </div>
+  );
+}
+
+const listenerOptions = { passive: false, capture: true } as const;
+
+function addTouchDragCss(on: boolean) {
+  const root = document.documentElement;
+  if (on) {
+    (root as any).__prevTouchAction = root.style.touchAction;
+    (root as any).__prevOverscroll = root.style.overscrollBehavior;
+    root.style.touchAction = "none";
+    root.style.overscrollBehavior = "contain";
+  } else {
+    root.style.touchAction = (root as any).__prevTouchAction ?? "";
+    root.style.overscrollBehavior = (root as any).__prevOverscroll ?? "";
+    delete (root as any).__prevTouchAction;
+    delete (root as any).__prevOverscroll;
+  }
+}
+
+function getDropTargetAt(x: number, y: number): DropTarget | null {
+  let el = document.elementFromPoint(x, y) as HTMLElement | null;
+  while (el) {
+    const data = el.dataset;
+    if (data.drop && data.idx) {
+      if (data.drop === "wheel") return { kind: "wheel", idx: Number(data.idx) };
+      if (data.drop === "slot") return { kind: "slot", idx: Number(data.idx) };
+    }
+    el = el.parentElement;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- extract the touch-drag helpers and calcWheelSize into a new TouchDragLayer module
- provide a hook and floating ghost component for the match UI to consume
- update ThreeWheel_WinsOnly to use the shared helpers and render the new TouchDragLayer component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc2c962534833282bb6c46f468d806