### PR TITLE
Hide reserve values on hand cards

### DIFF
--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -19,6 +19,7 @@ export default memo(function StSCard({
   onDragStart,
   onDragEnd,
   onPointerDown,
+  showReserve = true,
 }: {
   card: Card;
   disabled?: boolean;
@@ -29,6 +30,7 @@ export default memo(function StSCard({
   onDragStart?: React.DragEventHandler<HTMLButtonElement>;
   onDragEnd?: React.DragEventHandler<HTMLButtonElement>;
   onPointerDown?: React.PointerEventHandler<HTMLButtonElement>;
+  showReserve?: boolean;
 }) {
   const dims = size === "lg" ? { w: 120, h: 160 } : size === "md" ? { w: 92, h: 128 } : { w: 72, h: 96 };
   return (
@@ -68,9 +70,11 @@ export default memo(function StSCard({
           )}
         </div>
         <div className="space-y-1 text-[11px] leading-tight text-slate-200/90">
-          <div className="font-semibold">
-            Reserve {fmtNum(getCardReserveValue(card))}
-          </div>
+          {showReserve && (
+            <div className="font-semibold">
+              Reserve {fmtNum(getCardReserveValue(card))}
+            </div>
+          )}
           {card.reserve?.summary && (
             <div className="text-slate-200/80">{card.reserve.summary}</div>
           )}

--- a/src/components/match/HandDock.tsx
+++ b/src/components/match/HandDock.tsx
@@ -124,7 +124,7 @@ export default function HandDock({
                   aria-pressed={isSelected}
                   aria-label={`Select ${card.name}`}
                 >
-                  <StSCard card={card} />
+                  <StSCard card={card} showReserve={false} />
                 </button>
               </motion.div>
             </div>
@@ -145,7 +145,7 @@ export default function HandDock({
           aria-hidden
         >
           <div style={{ transform: "scale(0.9)", filter: "drop-shadow(0 6px 8px rgba(0,0,0,.35))" }}>
-            <StSCard card={pointerDragCard} />
+            <StSCard card={pointerDragCard} showReserve={false} />
           </div>
         </div>
       )}

--- a/src/components/match/TouchDragLayer.tsx
+++ b/src/components/match/TouchDragLayer.tsx
@@ -124,7 +124,7 @@ export default function TouchDragLayer({ dragCard, isDragging, pointerPosition }
       aria-hidden
     >
       <div style={{ transform: "scale(0.9)", filter: "drop-shadow(0 6px 8px rgba(0,0,0,.35))" }}>
-        <StSCard card={dragCard} />
+        <StSCard card={dragCard} showReserve={false} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a flag on `StSCard` to hide the reserve line when desired
- suppress the reserve text for cards rendered in the player's hand and its drag previews

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc80a0bda08332be5bbcc87d19b163