### PR TITLE
Hide hand card titles

### DIFF
--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -19,6 +19,8 @@ export default memo(function StSCard({
   onDragStart,
   onDragEnd,
   onPointerDown,
+  showReserve = true,
+  showName = true,
 }: {
   card: Card;
   disabled?: boolean;
@@ -29,6 +31,8 @@ export default memo(function StSCard({
   onDragStart?: React.DragEventHandler<HTMLButtonElement>;
   onDragEnd?: React.DragEventHandler<HTMLButtonElement>;
   onPointerDown?: React.PointerEventHandler<HTMLButtonElement>;
+  showReserve?: boolean;
+  showName?: boolean;
 }) {
   const dims = size === "lg" ? { w: 120, h: 160 } : size === "md" ? { w: 92, h: 128 } : { w: 72, h: 96 };
   return (
@@ -46,7 +50,12 @@ export default memo(function StSCard({
       <div className="absolute inset-0 rounded-xl border bg-gradient-to-br from-slate-600 to-slate-800 border-slate-400"></div>
       <div className="absolute inset-px rounded-[10px] bg-slate-900/85 backdrop-blur-[1px] border border-slate-700/70" />
       <div className="absolute inset-0 flex flex-col justify-between p-2">
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-200">
+        <div
+          className={`text-[11px] font-semibold uppercase tracking-wide text-slate-200 ${
+            showName ? "" : "invisible"
+          }`}
+          aria-hidden={!showName}
+        >
           {card.name}
         </div>
         <div className="flex-1 flex items-center justify-center">
@@ -68,9 +77,11 @@ export default memo(function StSCard({
           )}
         </div>
         <div className="space-y-1 text-[11px] leading-tight text-slate-200/90">
-          <div className="font-semibold">
-            Reserve {fmtNum(getCardReserveValue(card))}
-          </div>
+          {showReserve && (
+            <div className="font-semibold">
+              Reserve {fmtNum(getCardReserveValue(card))}
+            </div>
+          )}
           {card.reserve?.summary && (
             <div className="text-slate-200/80">{card.reserve.summary}</div>
           )}

--- a/src/components/match/HandDock.tsx
+++ b/src/components/match/HandDock.tsx
@@ -124,7 +124,7 @@ export default function HandDock({
                   aria-pressed={isSelected}
                   aria-label={`Select ${card.name}`}
                 >
-                  <StSCard card={card} />
+                  <StSCard card={card} showReserve={false} showName={false} />
                 </button>
               </motion.div>
             </div>
@@ -145,7 +145,7 @@ export default function HandDock({
           aria-hidden
         >
           <div style={{ transform: "scale(0.9)", filter: "drop-shadow(0 6px 8px rgba(0,0,0,.35))" }}>
-            <StSCard card={pointerDragCard} />
+            <StSCard card={pointerDragCard} showReserve={false} showName={false} />
           </div>
         </div>
       )}

--- a/src/components/match/TouchDragLayer.tsx
+++ b/src/components/match/TouchDragLayer.tsx
@@ -124,7 +124,7 @@ export default function TouchDragLayer({ dragCard, isDragging, pointerPosition }
       aria-hidden
     >
       <div style={{ transform: "scale(0.9)", filter: "drop-shadow(0 6px 8px rgba(0,0,0,.35))" }}>
-        <StSCard card={dragCard} />
+        <StSCard card={dragCard} showReserve={false} showName={false} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add an optional `showName` flag to `StSCard` so the title banner can be suppressed when rendering cards
- hide the card name banner for hand cards and their drag previews to remove the number label

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc80a0bda08332be5bbcc87d19b163