### PR TITLE
Adjust gauntlet shop timing

### DIFF
--- a/src/game/match/useMatchController.ts
+++ b/src/game/match/useMatchController.ts
@@ -241,6 +241,10 @@ useEffect(() => {
     enemy: 0,
   });
   const [round, setRound] = useState(1);
+  const shouldOpenShopThisRound = useMemo(
+    () => isGauntletMode && round > 0 && round % 3 === 0,
+    [isGauntletMode, round],
+  );
 
   const [freezeLayout, setFreezeLayout] = useState(false);
   const [lockedWheelSize, setLockedWheelSize] = useState<number | null>(null);
@@ -1002,6 +1006,12 @@ function createInitialGauntletState(): GauntletState {
     return true;
   }, [isGauntletMode, phase]);
 
+  useEffect(() => {
+    if (!shouldOpenShopThisRound) return;
+    if (phase !== "roundEnd") return;
+    openShopPhase();
+  }, [openShopPhase, phase, shouldOpenShopThisRound]);
+
   const revealRoundCore = useCallback(() => {
     const allow = phase === "choose" && canReveal;
     if (!allow) return false;
@@ -1488,7 +1498,7 @@ function createInitialGauntletState(): GauntletState {
 
   const handleNextClick = useCallback(() => {
     if (isGauntletMode) {
-      if (phase === "roundEnd") {
+      if (phase === "roundEnd" && shouldOpenShopThisRound) {
         openShopPhase();
         return;
       }


### PR DESCRIPTION
## Summary
- automatically trigger the gauntlet shop after resolve when the current round is a multiple of three
- prevent the manual "Next" action from opening the shop on rounds that are not scheduled for shopping

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc9147a0608332bfe3ec0d36ebe831