### PR TITLE
Enhance gauntlet shop flow and rewards

### DIFF
--- a/src/game/modes/gauntlet/GauntletMatch.tsx
+++ b/src/game/modes/gauntlet/GauntletMatch.tsx
@@ -205,6 +205,7 @@ export default function GauntletMatch({
   }, [controllerIsMultiplayer, namesByLegacy, phase, rematchVotes, localLegacySide, remoteLegacySide]);
 
   const localFighter = localLegacySide === "player" ? player : enemy;
+  const localGold = gold[localLegacySide] ?? 0;
   const gauntletPhaseUI = (
     <GauntletPhasePanel
       phase={phase}
@@ -337,15 +338,21 @@ export default function GauntletMatch({
       style={{ gridTemplateRows: "auto auto 1fr auto" }}
     >
       <div className="flex items-center justify-between text-[12px] min-h-[24px]">
-        <div className="flex items-center gap-3">
-          <div>
-            <span className="opacity-70">Round</span> <span className="font-semibold">{round}</span>
+        <div className="flex flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <div>
+              <span className="opacity-70">Round</span> <span className="font-semibold">{round}</span>
+            </div>
+            <div>
+              <span className="opacity-70">Phase</span> <span className="font-semibold">{phase}</span>
+            </div>
+            <div>
+              <span className="opacity-70">Goal</span> <span className="font-semibold">First to {winGoal} wins</span>
+            </div>
           </div>
-          <div>
-            <span className="opacity-70">Phase</span> <span className="font-semibold">{phase}</span>
-          </div>
-          <div>
-            <span className="opacity-70">Goal</span> <span className="font-semibold">First to {winGoal} wins</span>
+          <div className="flex items-center gap-1 text-[11px] text-amber-200/80">
+            <span aria-hidden="true">🪙</span>
+            <span className="tabular-nums font-semibold text-amber-100">{localGold}</span>
           </div>
         </div>
         <div className="flex items-center gap-2 relative">

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -1,6 +1,7 @@
 // src/game/types.ts
 export const SLICES = 16 as const;
 export const TARGET_WINS = 7 as const;
+export const GAUNTLET_TARGET_WINS = 10 as const;
 
 /** New canonical sides for 2P */
 export type Side = "left" | "right";


### PR DESCRIPTION
## Summary
- raise the gauntlet win goal to 10 and pay out reserve gold while auto-readying CPU nemeses between rounds
- overhaul the gauntlet shop into a full-screen overlay that auto-rolls inventory, shows status, and adds a continue button
- surface the player's gold in the gauntlet HUD so it stays visible during the match

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd32d2479883328efde1306a1ccee7