### PR TITLE
Seed gauntlet shop inventory on phase entry

### DIFF
--- a/src/game/modes/classic/ClassicMatch.tsx
+++ b/src/game/modes/classic/ClassicMatch.tsx
@@ -128,6 +128,7 @@ export default function ClassicMatch({
     shopInventory,
     shopPurchases,
     shopReady,
+    configureShopInventory,
     markShopComplete,
     purchaseFromShop,
     gauntletRollShop,
@@ -227,6 +228,7 @@ export default function ClassicMatch({
       namesByLegacy={namesByLegacy}
       gauntletState={gauntletState}
       gauntletRollShop={gauntletRollShop}
+      configureShopInventory={configureShopInventory}
       purchaseFromShop={purchaseFromShop}
       markShopComplete={markShopComplete}
       activationTurn={activationTurn}

--- a/src/game/modes/gauntlet/GauntletMatch.tsx
+++ b/src/game/modes/gauntlet/GauntletMatch.tsx
@@ -122,6 +122,7 @@ export default function GauntletMatch({
     shopInventory,
     shopPurchases,
     shopReady,
+    configureShopInventory,
     markShopComplete,
     purchaseFromShop,
     gauntletRollShop,
@@ -219,6 +220,7 @@ export default function GauntletMatch({
       namesByLegacy={namesByLegacy}
       gauntletState={gauntletState}
       gauntletRollShop={gauntletRollShop}
+      configureShopInventory={configureShopInventory}
       purchaseFromShop={purchaseFromShop}
       markShopComplete={markShopComplete}
       activationTurn={activationTurn}

--- a/src/game/modes/gauntlet/GauntletPhasePanel.tsx
+++ b/src/game/modes/gauntlet/GauntletPhasePanel.tsx
@@ -19,6 +19,9 @@ export type GauntletPhasePanelProps = {
   shopReady: { player: boolean; enemy: boolean };
   gauntletState: GauntletState;
   gauntletRollShop: (inventory: Card[], round: number, roll?: number) => void;
+  configureShopInventory: (
+    inventory: Partial<Record<LegacySide, Card[]>>,
+  ) => void;
   purchaseFromShop: (side: LegacySide, card: Card, cost?: number) => boolean;
   markShopComplete: (side: LegacySide) => boolean;
   activationTurn: LegacySide | null;
@@ -42,6 +45,7 @@ export default function GauntletPhasePanel({
   shopReady,
   gauntletState,
   gauntletRollShop,
+  configureShopInventory,
   purchaseFromShop,
   markShopComplete,
   activationTurn,
@@ -84,6 +88,19 @@ export default function GauntletPhasePanel({
 
   const inventoryForRoll = localInventory.length > 0 ? localInventory : previousInventory;
   const canRollInventory = inventoryForRoll.length > 0;
+
+  useEffect(() => {
+    if (phase !== "shop") return;
+    if (localInventory.length > 0) return;
+    if (previousInventory.length === 0) return;
+    configureShopInventory({ [localLegacySide]: previousInventory });
+  }, [
+    configureShopInventory,
+    localInventory.length,
+    localLegacySide,
+    phase,
+    previousInventory,
+  ]);
 
   useEffect(() => {
     if (phase !== "shop") return;


### PR DESCRIPTION
## Summary
- pass the match controller's configureShopInventory callback down to the GauntletPhasePanel
- when the shop phase opens with a prepared gauntlet inventory but empty UI state, seed the local inventory via configureShopInventory
- ensure the first gauntlet shop roll is triggered automatically once inventory is available

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd3868e6a08332b3fd08ddbbdc813f