### PR TITLE
Fix gauntlet shop progression and add negative card offerings

### DIFF
--- a/src/game/match/useMatchController.ts
+++ b/src/game/match/useMatchController.ts
@@ -26,6 +26,7 @@ import {
   refillTo,
   freshFive,
   recordMatchResult,
+  rollStoreOfferings,
   type MatchResultSummary,
   type LevelProgress,
 } from "../../player/profileStore";
@@ -960,47 +961,6 @@ function createInitialGauntletState(): GauntletState {
     [applyShopPurchase, emitIntent, isGauntletMode, isMultiplayer, phase],
   );
 
-  const beginActivationPhase = useCallback(() => {
-    if (!isGauntletMode) return;
-    setActivationTurn(initiative);
-    setActivationPasses({ player: false, enemy: false });
-    setActivationLog([]);
-    setPhase("activation");
-  }, [initiative, isGauntletMode]);
-
-  const completeShopForSide = useCallback(
-    (side: LegacySide, opts?: { emit?: boolean }) => {
-      if (!isGauntletMode) return false;
-      if (phase !== "shop") return false;
-      let changed = false;
-      let finalState: { player: boolean; enemy: boolean } | null = null;
-      setShopReady((prev) => {
-        if (prev[side]) {
-          finalState = prev;
-          return prev;
-        }
-        changed = true;
-        const updated = { ...prev, [side]: true };
-        finalState = updated;
-        return updated;
-      });
-      if (!changed) return false;
-      if (opts?.emit && isMultiplayer) {
-        emitIntent({ type: "shopReady", side });
-      }
-      if (finalState?.player && finalState?.enemy) {
-        beginActivationPhase();
-      }
-      return true;
-    },
-    [beginActivationPhase, emitIntent, isGauntletMode, isMultiplayer, phase],
-  );
-
-  const markShopComplete = useCallback(
-    (side: LegacySide) => completeShopForSide(side, { emit: true }),
-    [completeShopForSide],
-  );
-
   const openShopPhase = useCallback(() => {
     if (!isGauntletMode) return false;
     if (round < 3) return false;
@@ -1021,6 +981,28 @@ function createInitialGauntletState(): GauntletState {
     if (phase !== "roundEnd") return;
     openShopPhase();
   }, [openShopPhase, phase, shouldOpenShopThisRound]);
+
+  useEffect(() => {
+    if (!isGauntletMode) return;
+    if (phase !== "shop") return;
+    if (isMultiplayer && localLegacySide !== hostLegacySide) return;
+    const currentInventory = shopInventory[localLegacySide] ?? [];
+    if (currentInventory.length > 0) return;
+    const offerings = rollStoreOfferings();
+    if (offerings.length === 0) return;
+    setShopInventory((prev) => ({
+      ...prev,
+      [localLegacySide]: offerings.map((offer) => offer.card),
+    }));
+  }, [
+    hostLegacySide,
+    isGauntletMode,
+    isMultiplayer,
+    localLegacySide,
+    phase,
+    rollStoreOfferings,
+    shopInventory,
+  ]);
 
   const revealRoundCore = useCallback(() => {
     const allow = phase === "choose" && canReveal;
@@ -1414,6 +1396,49 @@ function createInitialGauntletState(): GauntletState {
 
   const nextRound = nextRoundCore;
 
+  const beginActivationPhase = useCallback(() => {
+    if (!isGauntletMode) return;
+    nextRoundCore({ force: true });
+  }, [isGauntletMode, nextRoundCore]);
+
+  const completeShopForSide = useCallback(
+    (side: LegacySide, opts?: { emit?: boolean }) => {
+      if (!isGauntletMode) return false;
+      if (phase !== "shop") return false;
+      let changed = false;
+      let shouldAdvance = false;
+      setShopReady((prev) => {
+        if (prev[side]) return prev;
+        changed = true;
+        const updated = { ...prev, [side]: true };
+        if (updated.player && updated.enemy) {
+          shouldAdvance = true;
+        }
+        return updated;
+      });
+      if (!changed) return false;
+      if (opts?.emit && isMultiplayer) {
+        emitIntent({ type: "shopReady", side });
+      }
+      if (shouldAdvance) {
+        beginActivationPhase();
+      }
+      return true;
+    },
+    [
+      beginActivationPhase,
+      emitIntent,
+      isGauntletMode,
+      isMultiplayer,
+      phase,
+    ],
+  );
+
+  const markShopComplete = useCallback(
+    (side: LegacySide) => completeShopForSide(side, { emit: true }),
+    [completeShopForSide],
+  );
+
   const finishActivationPhase = useCallback(() => {
     if (!isGauntletMode) return false;
     setPhase("activationComplete");
@@ -1655,6 +1680,7 @@ function createInitialGauntletState(): GauntletState {
   const markRematchVoteRef = useLatestRef(markRematchVote);
   const storeReserveReportRef = useLatestRef(storeReserveReport);
   const applyGauntletPurchaseForRef = useLatestRef(applyGauntletPurchaseFor);
+  const applyGauntletShopRollForRef = useLatestRef(applyGauntletShopRollFor);
   const applyShopPurchaseRef = useLatestRef(applyShopPurchase);
   const completeShopForSideRef = useLatestRef(completeShopForSide);
   const applyGauntletGoldForRef = useLatestRef(applyGauntletGoldFor);
@@ -1712,6 +1738,21 @@ function createInitialGauntletState(): GauntletState {
           break;
         }
 
+        case "shopRoll": {
+          if (msg.side === localLegacySide) break;
+          const applyShopRoll = applyGauntletShopRollForRef.current;
+          applyShopRoll?.(msg.side, {
+            inventory: msg.inventory,
+            round: msg.round,
+            roll: msg.roll,
+          });
+          setShopInventory((prev) => ({
+            ...prev,
+            [msg.side]: msg.inventory.map(cloneCardForGauntlet),
+          }));
+          break;
+        }
+
         case "shopPurchase": {
           if (msg.side === localLegacySide) break;
           if ("cardId" in msg && typeof msg.cardId === "string" && typeof msg.round === "number") {
@@ -1766,6 +1807,7 @@ function createInitialGauntletState(): GauntletState {
       markRematchVoteRef,
       storeReserveReportRef,
       applyGauntletPurchaseForRef,
+      applyGauntletShopRollForRef,
       applyShopPurchaseRef,
       completeShopForSideRef,
       applyGauntletGoldForRef,


### PR DESCRIPTION
## Summary
- add a new set of negative-value card blueprints and ensure the shop roll always includes at least one of them
- auto-populate gauntlet shop inventory when the phase opens and broadcast rolls to remote players
- advance out of the shop as soon as both sides are ready so "Continue to next round" progresses the match

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd4802c4108332a3c4a69028963e13