### PR TITLE
Fix gauntlet shop exit not advancing round

### DIFF
--- a/src/game/match/useMatchController.ts
+++ b/src/game/match/useMatchController.ts
@@ -1442,6 +1442,13 @@ function createInitialGauntletState(): GauntletState {
     ],
   );
 
+  useEffect(() => {
+    if (!isGauntletMode) return;
+    if (phase !== "shop") return;
+    if (!shopReady.player || !shopReady.enemy) return;
+    beginActivationPhase();
+  }, [beginActivationPhase, isGauntletMode, phase, shopReady.enemy, shopReady.player]);
+
   const markShopComplete = useCallback(
     (side: LegacySide) => completeShopForSide(side, { emit: true }),
     [completeShopForSide],


### PR DESCRIPTION
## Summary
- automatically trigger the gauntlet activation/next round transition once both sides mark the shop as ready

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd73358d388332a167ce82722555c1