### PR TITLE
Use negative card frame for negative cards

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -79,6 +79,9 @@ button[aria-label^="Card"] {
   background-position: center;
   border: none;
 }
+button[aria-label^="Card"][data-card-kind="negative"] {
+  background-image: url("/assets/negative-card-frame.png");
+}
 button[aria-label^="Card"] > div:first-child {
   opacity: 0;
 }


### PR DESCRIPTION
## Summary
- update the shared card button styles to look at the computed card kind
- use the new negative card frame image for cards marked as negative

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd84d0d7788332a3594555a1bc0efa