### PR TITLE
Lazy load heavy routes to reduce startup cost

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,30 @@
-import ClassicMatch, { type ClassicMatchProps } from "./game/modes/classic/ClassicMatch";
-import GauntletMatch, { type GauntletMatchProps } from "./game/modes/gauntlet/GauntletMatch";
+import { Suspense, lazy } from "react";
+import type { ClassicMatchProps } from "./game/modes/classic/ClassicMatch";
+import type { GauntletMatchProps } from "./game/modes/gauntlet/GauntletMatch";
+
+const ClassicMatch = lazy(() => import("./game/modes/classic/ClassicMatch"));
+const GauntletMatch = lazy(() => import("./game/modes/gauntlet/GauntletMatch"));
 
 export type AppProps =
   | ({ mode: "classic" } & ClassicMatchProps)
   | ({ mode: "gauntlet" } & GauntletMatchProps);
 
-export default function App(props: AppProps) {
-  const { mode, ...matchProps } = props;
+const MATCH_FALLBACK = <div>Loading match…</div>;
 
-  if (mode === "gauntlet") {
-    return <GauntletMatch {...matchProps} />;
+export default function App(props: AppProps) {
+  if (props.mode === "gauntlet") {
+    const { mode: _mode, ...matchProps } = props;
+    return (
+      <Suspense fallback={MATCH_FALLBACK}>
+        <GauntletMatch {...matchProps} />
+      </Suspense>
+    );
   }
 
-  return <ClassicMatch {...matchProps} />;
-
+  const { mode: _mode, ...matchProps } = props;
+  return (
+    <Suspense fallback={MATCH_FALLBACK}>
+      <ClassicMatch {...matchProps} />
+    </Suspense>
+  );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { Suspense, lazy } from "react";
+import LoadingScreen from "./components/LoadingScreen";
 import type { ClassicMatchProps } from "./game/modes/classic/ClassicMatch";
 import type { GauntletMatchProps } from "./game/modes/gauntlet/GauntletMatch";
 
@@ -9,7 +10,7 @@ export type AppProps =
   | ({ mode: "classic" } & ClassicMatchProps)
   | ({ mode: "gauntlet" } & GauntletMatchProps);
 
-const MATCH_FALLBACK = <div>Loading match…</div>;
+const MATCH_FALLBACK = <LoadingScreen />;
 
 export default function App(props: AppProps) {
   if (props.mode === "gauntlet") {

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -1,14 +1,16 @@
 // src/AppShell.tsx
-import React, { useCallback, useEffect, useState } from "react";
-import App from "./App";
+import React, { Suspense, lazy, useCallback, useEffect, useState } from "react";
 import HubRoute from "./HubRoute";
-import MultiplayerRoute from "./MultiplayerRoute";
 import type { Players, Side } from "./game/types";
-import ProfilePage from "./ProfilePage";
-import SoloModeRoute from "./SoloModeRoute";
+import type { default as MultiplayerRouteComponent } from "./MultiplayerRoute";
+
+const App = lazy(() => import("./App"));
+const MultiplayerRoute = lazy(() => import("./MultiplayerRoute"));
+const ProfilePage = lazy(() => import("./ProfilePage"));
+const SoloModeRoute = lazy(() => import("./SoloModeRoute"));
 
 type MPStartPayload = Parameters<
-  NonNullable<React.ComponentProps<typeof MultiplayerRoute>["onStart"]>
+  NonNullable<React.ComponentProps<MultiplayerRouteComponent>["onStart"]>
 >[0];
 
 type View =
@@ -51,23 +53,27 @@ export default function AppShell() {
 
   if (view.key === "soloMenu") {
     return (
-      <SoloModeRoute
-        onBack={goToHub}
-        onSelectClassic={startClassic}
-        onSelectGauntlet={startGauntlet}
-      />
+      <Suspense fallback={<div>Loading modes…</div>}>
+        <SoloModeRoute
+          onBack={goToHub}
+          onSelectClassic={startClassic}
+          onSelectGauntlet={startGauntlet}
+        />
+      </Suspense>
     );
   }
 
   if (view.key === "mp") {
     return (
-      <MultiplayerRoute
-        onBack={goToHub}
-        onStart={(payload) => {
-          setMpPayload(payload);
-          setView({ key: "game", mode: "mp", mpPayload: payload });
-        }}
-      />
+      <Suspense fallback={<div>Loading multiplayer…</div>}>
+        <MultiplayerRoute
+          onBack={goToHub}
+          onStart={(payload) => {
+            setMpPayload(payload);
+            setView({ key: "game", mode: "mp", mpPayload: payload });
+          }}
+        />
+      </Suspense>
     );
   }
 
@@ -79,7 +85,9 @@ export default function AppShell() {
             ← Back to Main Menu
           </button>
         </div>
-        <ProfilePage />
+        <Suspense fallback={<div className="p-4">Loading profile…</div>}>
+          <ProfilePage />
+        </Suspense>
       </div>
     );
   }
@@ -114,14 +122,16 @@ export default function AppShell() {
   };
 
   return (
-    <App
-      mode={view.mode === "gauntlet" ? "gauntlet" : "classic"}
-      localSide={localSide}
-      localPlayerId={localPlayerId}
-      players={players}
-      seed={seed}
-      onExit={exitToMenu}
-      {...extraProps}
-    />
+    <Suspense fallback={<div>Loading match…</div>}>
+      <App
+        mode={view.mode === "gauntlet" ? "gauntlet" : "classic"}
+        localSide={localSide}
+        localPlayerId={localPlayerId}
+        players={players}
+        seed={seed}
+        onExit={exitToMenu}
+        {...extraProps}
+      />
+    </Suspense>
   );
 }

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -1,5 +1,6 @@
 // src/AppShell.tsx
 import React, { Suspense, lazy, useCallback, useEffect, useState } from "react";
+import LoadingScreen from "./components/LoadingScreen";
 import HubRoute from "./HubRoute";
 import type { Players, Side } from "./game/types";
 import type { default as MultiplayerRouteComponent } from "./MultiplayerRoute";
@@ -53,7 +54,7 @@ export default function AppShell() {
 
   if (view.key === "soloMenu") {
     return (
-      <Suspense fallback={<div>Loading modes…</div>}>
+      <Suspense fallback={<LoadingScreen />}>
         <SoloModeRoute
           onBack={goToHub}
           onSelectClassic={startClassic}
@@ -65,7 +66,7 @@ export default function AppShell() {
 
   if (view.key === "mp") {
     return (
-      <Suspense fallback={<div>Loading multiplayer…</div>}>
+      <Suspense fallback={<LoadingScreen />}>
         <MultiplayerRoute
           onBack={goToHub}
           onStart={(payload) => {
@@ -85,7 +86,11 @@ export default function AppShell() {
             ← Back to Main Menu
           </button>
         </div>
-        <Suspense fallback={<div className="p-4">Loading profile…</div>}>
+        <Suspense
+          fallback={
+            <LoadingScreen className="flex-1" fullScreen={false} />
+          }
+        >
           <ProfilePage />
         </Suspense>
       </div>
@@ -122,7 +127,7 @@ export default function AppShell() {
   };
 
   return (
-    <Suspense fallback={<div>Loading match…</div>}>
+    <Suspense fallback={<LoadingScreen />}>
       <App
         mode={view.mode === "gauntlet" ? "gauntlet" : "classic"}
         localSide={localSide}

--- a/src/HubRoute.tsx
+++ b/src/HubRoute.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import { useEffect, useState } from "react";
 import RogueWheelHub from "../ui/RogueWheelHub";
-import { getProfileBundle, expRequiredForLevel } from "./player/profileStore";
+import { expRequiredForLevel } from "./player/leveling";
+import type { Profile } from "./player/profileStore";
 
 type Props = {
   onStart: () => void;
@@ -8,8 +9,54 @@ type Props = {
   onProfile: () => void;
 };
 
+type ProfilePreview = Pick<Profile, "displayName" | "level" | "exp">;
+
 export default function HubRoute({ onStart, onMultiplayer, onProfile }: Props) {
-  const { profile } = getProfileBundle();
+  const [profile, setProfile] = useState<ProfilePreview | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    import("./player/profileStore")
+      .then(({ getProfileBundle }) => {
+        if (cancelled) return;
+        const { profile } = getProfileBundle();
+        if (!profile) {
+          setProfile(null);
+          return;
+        }
+        setProfile({
+          displayName: profile.displayName,
+          level: profile.level,
+          exp: profile.exp,
+        });
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.error("Failed to load profile store", error);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    const warmBundles = async () => {
+      try {
+        await Promise.all([
+          import("./game/modes/classic/ClassicMatch"),
+          import("./game/modes/gauntlet/GauntletMatch"),
+        ]);
+      } catch (error) {
+        console.error("Failed to preload game modes", error);
+      }
+    };
+
+    void warmBundles();
+  }, []);
+
   const displayName = profile?.displayName ?? "Adventurer";
   const level = profile?.level ?? 1;
   const expToNext = expRequiredForLevel(level);

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,0 +1,38 @@
+import type { ComponentProps } from "react";
+
+type LoadingScreenProps = {
+  className?: string;
+  fullScreen?: boolean;
+  imgProps?: ComponentProps<"img">;
+};
+
+export default function LoadingScreen({
+  className = "",
+  fullScreen = true,
+  imgProps,
+}: LoadingScreenProps) {
+  const { className: imgClassName = "", ...restImgProps } = imgProps ?? {};
+
+  const containerClassName = [
+    fullScreen ? "fixed inset-0" : "",
+    "flex items-center justify-center bg-black",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const imageClassName = ["max-w-[240px] w-2/3 h-auto", imgClassName]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={containerClassName}>
+      <img
+        src="/rotogo_snap_logo_2.png"
+        alt="Rotogo Snap logo"
+        className={imageClassName}
+        {...restImgProps}
+      />
+    </div>
+  );
+}

--- a/src/player/leveling.ts
+++ b/src/player/leveling.ts
@@ -1,0 +1,7 @@
+const EXP_BASE = 100;
+
+export function expRequiredForLevel(level: number): number {
+  return (level + 1) * EXP_BASE;
+}
+
+export { EXP_BASE };

--- a/src/player/profileStore.tsx
+++ b/src/player/profileStore.tsx
@@ -2,6 +2,9 @@
 // to match your existing game types/functions.
 
 import { shuffle } from "../game/math";
+import { expRequiredForLevel } from "./leveling";
+
+export { expRequiredForLevel } from "./leveling";
 import type {
   ActivationAbility,
   Card,
@@ -642,14 +645,8 @@ const validateGauntletDeck = (cards: DeckCard[]) => {
   }
 };
 
-const EXP_BASE = 100;
-
 export type LevelProgress = { level: number; exp: number; expToNext: number; percent: number };
 export type LevelProgressSegment = LevelProgress & { leveledUp?: boolean };
-
-export function expRequiredForLevel(level: number): number {
-  return (level + 1) * EXP_BASE;
-}
 
 const toLevelProgress = (profile: Profile): LevelProgress => {
   const expToNext = expRequiredForLevel(profile.level);


### PR DESCRIPTION
## Summary
- lazy-load the classic and gauntlet match views so their bundles are fetched on demand
- defer loading of the heavy profile store until the hub has mounted and preload match bundles in the background
- split profile leveling helpers into a light module and lazy-load the main routes that use the store

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cd8f32c0bc83329b7ce6985c944d34