### PR TITLE
Add branded loading screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { Suspense, lazy } from "react";
+import LoadingScreen from "./components/LoadingScreen";
 import type { ClassicMatchProps } from "./game/modes/classic/ClassicMatch";
 import type { GauntletMatchProps } from "./game/modes/gauntlet/GauntletMatch";
 
@@ -9,7 +10,7 @@ export type AppProps =
   | ({ mode: "classic" } & ClassicMatchProps)
   | ({ mode: "gauntlet" } & GauntletMatchProps);
 
-const MATCH_FALLBACK = <div>Loading match…</div>;
+const MATCH_FALLBACK = <LoadingScreen />;
 
 export default function App(props: AppProps) {
   if (props.mode === "gauntlet") {

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -1,5 +1,6 @@
 // src/AppShell.tsx
 import React, { Suspense, lazy, useCallback, useEffect, useState } from "react";
+import LoadingScreen from "./components/LoadingScreen";
 import HubRoute from "./HubRoute";
 import type { Players, Side } from "./game/types";
 import type { default as MultiplayerRouteComponent } from "./MultiplayerRoute";
@@ -53,7 +54,7 @@ export default function AppShell() {
 
   if (view.key === "soloMenu") {
     return (
-      <Suspense fallback={<div>Loading modes…</div>}>
+      <Suspense fallback={<LoadingScreen />}>
         <SoloModeRoute
           onBack={goToHub}
           onSelectClassic={startClassic}
@@ -65,7 +66,7 @@ export default function AppShell() {
 
   if (view.key === "mp") {
     return (
-      <Suspense fallback={<div>Loading multiplayer…</div>}>
+      <Suspense fallback={<LoadingScreen />}>
         <MultiplayerRoute
           onBack={goToHub}
           onStart={(payload) => {
@@ -85,7 +86,11 @@ export default function AppShell() {
             ← Back to Main Menu
           </button>
         </div>
-        <Suspense fallback={<div className="p-4">Loading profile…</div>}>
+        <Suspense
+          fallback={
+            <LoadingScreen className="flex-1" fullScreen={false} />
+          }
+        >
           <ProfilePage />
         </Suspense>
       </div>
@@ -122,7 +127,7 @@ export default function AppShell() {
   };
 
   return (
-    <Suspense fallback={<div>Loading match…</div>}>
+    <Suspense fallback={<LoadingScreen />}>
       <App
         mode={view.mode === "gauntlet" ? "gauntlet" : "classic"}
         localSide={localSide}

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,0 +1,38 @@
+import type { ComponentProps } from "react";
+
+type LoadingScreenProps = {
+  className?: string;
+  fullScreen?: boolean;
+  imgProps?: ComponentProps<"img">;
+};
+
+export default function LoadingScreen({
+  className = "",
+  fullScreen = true,
+  imgProps,
+}: LoadingScreenProps) {
+  const { className: imgClassName = "", ...restImgProps } = imgProps ?? {};
+
+  const containerClassName = [
+    fullScreen ? "fixed inset-0" : "",
+    "flex items-center justify-center bg-black",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const imageClassName = ["max-w-[240px] w-2/3 h-auto", imgClassName]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={containerClassName}>
+      <img
+        src="/rotogo_snap_logo_2.png"
+        alt="Rotogo Snap logo"
+        className={imageClassName}
+        {...restImgProps}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable LoadingScreen component that centers the Rotogo Snap logo on a black backdrop
- replace Suspense fallbacks across the shell and match loaders to show the branded loading screen

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd91d398148332bab005df81cc627a