### PR TITLE
Fix gauntlet shop inventory and purchases

### DIFF
--- a/src/game/match/useMatchController.ts
+++ b/src/game/match/useMatchController.ts
@@ -350,6 +350,19 @@ useEffect(() => {
     setGauntletState(reset);
   }, []);
 
+  const resetGauntletShops = useCallback(() => {
+    updateGauntletState((prev) => ({
+      player: {
+        ...prev.player,
+        shop: { inventory: [], roll: 0, round: 0, purchases: [] },
+      },
+      enemy: {
+        ...prev.enemy,
+        shop: { inventory: [], roll: 0, round: 0, purchases: [] },
+      },
+    }));
+  }, [updateGauntletState]);
+
   const applyGauntletShopRollFor = useCallback(
     (side: LegacySide, payload: GauntletShopRollPayload) => {
       updateGauntletState((prev) => {
@@ -1375,6 +1388,7 @@ function createInitialGauntletState(): GauntletState {
         setShopInventory({ player: [], enemy: [] });
         setShopPurchases({ player: [], enemy: [] });
         setShopReady({ player: false, enemy: false });
+        resetGauntletShops();
         setActivationTurn(null);
         setActivationPasses({ player: false, enemy: false });
         setActivationLog([]);
@@ -1389,6 +1403,7 @@ function createInitialGauntletState(): GauntletState {
       generateWheelSet,
       isGauntletMode,
       phase,
+      resetGauntletShops,
       setAssign,
       setEnemy,
       setFreezeLayout,
@@ -1956,7 +1971,7 @@ function addPurchasedCardToFighter(fighter: Fighter, card: Card): Fighter {
   const purchased = cloneCardForGauntlet(card);
   return {
     ...fighter,
-    discard: [...fighter.discard, purchased],
+    deck: [purchased, ...fighter.deck],
   };
 }
 

--- a/src/game/modes/gauntlet/GauntletPhasePanel.tsx
+++ b/src/game/modes/gauntlet/GauntletPhasePanel.tsx
@@ -56,7 +56,9 @@ export default function GauntletPhasePanel({
   const localPurchases = shopPurchases[localLegacySide] ?? [];
   const localGauntlet = gauntletState[localLegacySide];
   const currentRoll = localGauntlet?.shop.roll ?? 0;
-  const previousInventory = localGauntlet?.shop.inventory ?? [];
+  const previousRound = localGauntlet?.shop.round ?? 0;
+  const previousInventory =
+    previousRound === round ? localGauntlet?.shop.inventory ?? [] : [];
   const purchasedIds = new Set(localPurchases.map((card) => card.id));
 
   const readyMessage = (() => {
@@ -81,6 +83,7 @@ export default function GauntletPhasePanel({
     if (phase !== "shop") return;
     if (localInventory.length > 0) return;
     if (previousInventory.length === 0) return;
+    if (previousRound !== round) return;
     configureShopInventory({ [localLegacySide]: previousInventory });
   }, [
     configureShopInventory,
@@ -88,6 +91,8 @@ export default function GauntletPhasePanel({
     localLegacySide,
     phase,
     previousInventory,
+    previousRound,
+    round,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure gauntlet shop only reuses previous inventory when revisiting the same round and reset stored shop data between rounds so a fresh set of cards is rolled
- add purchased cards directly to the top of the buyer's deck so they are immediately part of the draw pile

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd963f8d50833287d223f5cf735d06