### PR TITLE
Add activation phase with card behaviors

### DIFF
--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -3,6 +3,7 @@ import React, { memo } from "react";
 import { Card } from "../game/types";
 import {
   fmtNum,
+  getCardBehavior,
   getCardPlayValue,
   getCardReserveValue,
   getSplitFaces,
@@ -130,6 +131,10 @@ const framesByKind: Record<Kind, string> = {
 const cardBackground = backgroundsByKind[cardKind];
 const frameBorder = framesByKind[cardKind];
 
+const behavior = getCardBehavior(card);
+const behaviorIcon =
+  behavior === "split" ? "✂️" : behavior === "boost" ? "⚡" : behavior === "swap" ? "🔄" : null;
+
 /* ==== END MERGE-RESOLVED ==== */
 
   return (
@@ -164,6 +169,12 @@ const frameBorder = framesByKind[cardKind];
       {debugKind && (
         <div className="pointer-events-none absolute right-1 top-1 rounded bg-black/50 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-white/80">
           {cardKind}
+        </div>
+      )}
+
+      {behaviorIcon && (
+        <div className="pointer-events-none absolute left-1 top-1 text-lg leading-none drop-shadow-[0_1px_1px_rgba(0,0,0,0.65)]">
+          {behaviorIcon}
         </div>
       )}
 

--- a/src/components/match/ActivationPhaseOverlay.tsx
+++ b/src/components/match/ActivationPhaseOverlay.tsx
@@ -1,0 +1,234 @@
+import { useMemo } from "react";
+
+import StSCard from "../StSCard";
+import type { Card } from "../../game/types";
+import type {
+  LegacySide,
+  Phase,
+} from "../../game/match/useMatchController";
+
+export interface ActivationPhaseOverlayProps {
+  phase: Phase;
+  activationTurn: LegacySide | null;
+  activationAvailable: Record<LegacySide, string[]>;
+  activationInitial: Record<LegacySide, string[]>;
+  activationPasses: { player: boolean; enemy: boolean };
+  activationLog: { side: LegacySide; action: "activate" | "pass"; cardId?: string }[];
+  activationAdjustments: Record<string, { type: "split" | "boost" }>;
+  activationSwapPairs: Array<[string, string]>;
+  pendingSwapCardId: string | null;
+  assign: { player: (Card | null)[]; enemy: (Card | null)[] };
+  localLegacySide: LegacySide;
+  namesByLegacy: Record<LegacySide, string>;
+  onActivateCard: (cardId: string) => void;
+  onPass: () => void;
+}
+
+const panelClass =
+  "max-w-4xl w-full space-y-4 rounded-xl border border-emerald-400/40 bg-slate-950/85 p-6 text-slate-100 shadow-2xl";
+
+export default function ActivationPhaseOverlay({
+  phase,
+  activationTurn,
+  activationAvailable,
+  activationInitial,
+  activationPasses,
+  activationLog,
+  activationAdjustments,
+  activationSwapPairs,
+  pendingSwapCardId,
+  assign,
+  localLegacySide,
+  namesByLegacy,
+  onActivateCard,
+  onPass,
+}: ActivationPhaseOverlayProps) {
+  if (phase !== "activation") return null;
+
+  const remoteLegacySide: LegacySide = localLegacySide === "player" ? "enemy" : "player";
+
+  const availableLocal = useMemo(
+    () => new Set(activationAvailable[localLegacySide] ?? []),
+    [activationAvailable, localLegacySide],
+  );
+  const initialLocal = useMemo(
+    () => new Set(activationInitial[localLegacySide] ?? []),
+    [activationInitial, localLegacySide],
+  );
+  const availableRemote = useMemo(
+    () => new Set(activationAvailable[remoteLegacySide] ?? []),
+    [activationAvailable, remoteLegacySide],
+  );
+  const initialRemote = useMemo(
+    () => new Set(activationInitial[remoteLegacySide] ?? []),
+    [activationInitial, remoteLegacySide],
+  );
+
+  const allCardsById = useMemo(() => {
+    const map = new Map<string, Card>();
+    for (const card of assign.player) {
+      if (card) map.set(card.id, card);
+    }
+    for (const card of assign.enemy) {
+      if (card) map.set(card.id, card);
+    }
+    return map;
+  }, [assign.enemy, assign.player]);
+
+  const localCards = assign[localLegacySide].filter(
+    (card): card is Card => !!card && initialLocal.has(card.id),
+  );
+  const remoteCards = assign[remoteLegacySide].filter(
+    (card): card is Card => !!card && initialRemote.has(card.id),
+  );
+
+  const isLocalTurn = activationTurn === localLegacySide;
+  const localHasActions = availableLocal.size > 0;
+  const localHasPassed = activationPasses[localLegacySide];
+  const remoteHasPassed = activationPasses[remoteLegacySide];
+
+  const swapPairs = activationSwapPairs.map(([a, b]) => new Set([a, b]));
+
+  const describeLogEntry = (entry: ActivationPhaseOverlayProps["activationLog"][number]) => {
+    const actorName = namesByLegacy[entry.side];
+    if (entry.action === "pass") {
+      return `${actorName} passes.`;
+    }
+    const cardName = entry.cardId ? allCardsById.get(entry.cardId)?.name ?? "Card" : "Card";
+    return `${actorName} activates ${cardName}.`;
+  };
+
+  const renderCard = (card: Card, isLocal: boolean) => {
+    const availableSet = isLocal ? availableLocal : availableRemote;
+    const initialSet = isLocal ? initialLocal : initialRemote;
+    const activated = initialSet.has(card.id) && !availableSet.has(card.id);
+    const canActivate = isLocal && isLocalTurn && availableSet.has(card.id);
+    const adjustment = activationAdjustments[card.id]?.type ?? null;
+    const isSwapTarget =
+      pendingSwapCardId === card.id || swapPairs.some((pair) => pair.has(card.id));
+
+    const statusLabel = (() => {
+      if (pendingSwapCardId === card.id) return "Waiting";
+      if (adjustment === "split") return "Halved";
+      if (adjustment === "boost") return "Boosted";
+      if (activated) return "Used";
+      return canActivate ? "Ready" : null;
+    })();
+
+    return (
+      <div key={card.id} className="relative flex flex-col items-center gap-2">
+        <StSCard
+          card={card}
+          size="sm"
+          variant="minimal"
+          onPick={canActivate ? () => onActivateCard(card.id) : undefined}
+          disabled={!canActivate}
+        />
+        {statusLabel ? (
+          <span
+            className={`text-[11px] uppercase tracking-wide ${
+              statusLabel === "Ready"
+                ? "text-emerald-300"
+                : statusLabel === "Used"
+                ? "text-slate-300"
+                : "text-amber-300"
+            }`}
+          >
+            {statusLabel}
+          </span>
+        ) : null}
+        {isSwapTarget && statusLabel !== "Waiting" ? (
+          <span className="text-[10px] uppercase tracking-wide text-sky-300">Swapped</span>
+        ) : null}
+      </div>
+    );
+  };
+
+  const localStatus = isLocalTurn
+    ? localHasActions
+      ? "Select a card to activate."
+      : "No cards left — pass when ready."
+    : `Waiting for ${namesByLegacy[activationTurn ?? remoteLegacySide]}.`;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/90 backdrop-blur-sm p-4">
+      <div className={panelClass}>
+        <header className="space-y-1">
+          <div className="text-xs uppercase tracking-wide text-emerald-200/80">Activation Phase</div>
+          <h2 className="text-2xl font-semibold text-emerald-100">
+            {isLocalTurn ? "Your turn" : `${namesByLegacy[activationTurn ?? remoteLegacySide]} to act`}
+          </h2>
+          <p className="text-sm text-emerald-100/80">{localStatus}</p>
+          {pendingSwapCardId ? (
+            <p className="text-[12px] text-sky-200/80">
+              Swap primed: the next activation will exchange values with your swap card.
+            </p>
+          ) : null}
+        </header>
+
+        <section className="grid gap-6 lg:grid-cols-2">
+          <div>
+            <h3 className="text-sm font-semibold text-emerald-200/80 uppercase tracking-wide">
+              {namesByLegacy[localLegacySide]}&rsquo;s cards
+            </h3>
+            {localCards.length === 0 ? (
+              <p className="mt-2 text-sm text-slate-200/70">No cards available to activate.</p>
+            ) : (
+              <div className="mt-3 flex flex-wrap gap-4">
+                {localCards.map((card) => renderCard(card, true))}
+              </div>
+            )}
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-emerald-200/60 uppercase tracking-wide">
+              {namesByLegacy[remoteLegacySide]}&rsquo;s cards
+            </h3>
+            {remoteCards.length === 0 ? (
+              <p className="mt-2 text-sm text-slate-200/60">No cards awaiting activation.</p>
+            ) : (
+              <div className="mt-3 flex flex-wrap gap-4">
+                {remoteCards.map((card) => renderCard(card, false))}
+              </div>
+            )}
+          </div>
+        </section>
+
+        <footer className="flex flex-col gap-3">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-emerald-100/80">
+              {localHasPassed ? "You have passed." : localHasActions ? "" : "No actions available."}
+            </span>
+            <button
+              type="button"
+              onClick={onPass}
+              disabled={!isLocalTurn || localHasPassed}
+              className="rounded bg-emerald-500 px-4 py-1.5 text-sm font-semibold text-slate-900 disabled:opacity-50"
+            >
+              {localHasPassed ? "Passed" : "Pass"}
+            </button>
+          </div>
+
+          <div className="rounded-lg border border-emerald-400/30 bg-emerald-950/50 p-3 text-sm">
+            <div className="text-[11px] uppercase tracking-wide text-emerald-200/70">Activity</div>
+            {activationLog.length === 0 ? (
+              <p className="mt-1 text-xs text-emerald-100/70">No actions yet this phase.</p>
+            ) : (
+              <ul className="mt-1 space-y-1 text-xs text-emerald-100/85">
+                {activationLog.map((entry, idx) => (
+                  <li key={`${entry.side}-${entry.action}-${entry.cardId ?? "none"}-${idx}`}>
+                    • {describeLogEntry(entry)}
+                  </li>
+                ))}
+              </ul>
+            )}
+            {remoteHasPassed && !localHasPassed ? (
+              <p className="mt-2 text-[11px] text-emerald-100/70">
+                {namesByLegacy[remoteLegacySide]} has passed.
+              </p>
+            ) : null}
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/game/modes/classic/ClassicMatch.tsx
+++ b/src/game/modes/classic/ClassicMatch.tsx
@@ -5,6 +5,7 @@ import HandDock from "../../../components/match/HandDock";
 import TouchDragLayer, {
   useTouchDragLayer,
 } from "../../../components/match/TouchDragLayer";
+import ActivationPhaseOverlay from "../../../components/match/ActivationPhaseOverlay";
 import GauntletPhasePanel from "../gauntlet/GauntletPhasePanel";
 import type { Players, Side as TwoSide } from "../../types";
 import useMultiplayerChannel from "../../match/useMultiplayerChannel";
@@ -133,6 +134,16 @@ export default function ClassicMatch({
     purchaseFromShop,
     gauntletRollShop,
     gauntletState,
+    activationTurn,
+    activationPasses,
+    activationLog,
+    activationAvailable,
+    activationInitial,
+    activationSwapPairs,
+    activationAdjustments,
+    pendingSwapCardId,
+    activateCurrent,
+    passActivation,
   } = controller;
 
   const {
@@ -225,6 +236,25 @@ export default function ClassicMatch({
       markShopComplete={markShopComplete}
     />
   ) : null;
+
+  const activationOverlay = (
+    <ActivationPhaseOverlay
+      phase={phase as Phase}
+      activationTurn={activationTurn}
+      activationAvailable={activationAvailable}
+      activationInitial={activationInitial}
+      activationPasses={activationPasses}
+      activationLog={activationLog}
+      activationAdjustments={activationAdjustments}
+      activationSwapPairs={activationSwapPairs}
+      pendingSwapCardId={pendingSwapCardId}
+      assign={assign}
+      localLegacySide={localLegacySide}
+      namesByLegacy={namesByLegacy}
+      onActivateCard={(cardId) => activateCurrent(localLegacySide, cardId)}
+      onPass={() => passActivation(localLegacySide)}
+    />
+  );
 
   const HUDPanels = useCallback(() => {
     const rsPlayer = reserveSums ? reserveSums.player : null;
@@ -414,13 +444,14 @@ export default function ClassicMatch({
       </div>
 
       <div className="relative z-10">
-        <HUDPanels />
-      </div>
+      <HUDPanels />
+    </div>
 
-      {gauntletPhaseUI}
+    {gauntletPhaseUI}
+    {activationOverlay}
 
-      <div className="relative z-0" style={{ paddingBottom: handClearance }}>
-        <MatchBoard
+    <div className="relative z-0" style={{ paddingBottom: handClearance }}>
+      <MatchBoard
           theme={THEME}
           active={active}
           assign={assign}

--- a/src/game/modes/gauntlet/GauntletMatch.tsx
+++ b/src/game/modes/gauntlet/GauntletMatch.tsx
@@ -5,6 +5,7 @@ import HandDock from "../../../components/match/HandDock";
 import TouchDragLayer, {
   useTouchDragLayer,
 } from "../../../components/match/TouchDragLayer";
+import ActivationPhaseOverlay from "../../../components/match/ActivationPhaseOverlay";
 import GauntletPhasePanel from "./GauntletPhasePanel";
 import type { Players, Side as TwoSide } from "../../types";
 import useMultiplayerChannel from "../../match/useMultiplayerChannel";
@@ -127,6 +128,16 @@ export default function GauntletMatch({
     purchaseFromShop,
     gauntletRollShop,
     gauntletState,
+    activationTurn,
+    activationPasses,
+    activationLog,
+    activationAvailable,
+    activationInitial,
+    activationSwapPairs,
+    activationAdjustments,
+    pendingSwapCardId,
+    activateCurrent,
+    passActivation,
   } = controller;
 
   const {
@@ -216,6 +227,25 @@ export default function GauntletMatch({
       configureShopInventory={configureShopInventory}
       purchaseFromShop={purchaseFromShop}
       markShopComplete={markShopComplete}
+    />
+  );
+
+  const activationOverlay = (
+    <ActivationPhaseOverlay
+      phase={phase}
+      activationTurn={activationTurn}
+      activationAvailable={activationAvailable}
+      activationInitial={activationInitial}
+      activationPasses={activationPasses}
+      activationLog={activationLog}
+      activationAdjustments={activationAdjustments}
+      activationSwapPairs={activationSwapPairs}
+      pendingSwapCardId={pendingSwapCardId}
+      assign={assign}
+      localLegacySide={localLegacySide}
+      namesByLegacy={namesByLegacy}
+      onActivateCard={(cardId) => activateCurrent(localLegacySide, cardId)}
+      onPass={() => passActivation(localLegacySide)}
     />
   );
 
@@ -419,6 +449,7 @@ export default function GauntletMatch({
       </div>
 
       {gauntletPhaseUI}
+      {activationOverlay}
 
       <div className="relative z-0" style={{ paddingBottom: handClearance }}>
         <MatchBoard

--- a/src/game/modes/gauntlet/GauntletPhasePanel.tsx
+++ b/src/game/modes/gauntlet/GauntletPhasePanel.tsx
@@ -56,7 +56,9 @@ export default function GauntletPhasePanel({
   const localPurchases = shopPurchases[localLegacySide] ?? [];
   const localGauntlet = gauntletState[localLegacySide];
   const currentRoll = localGauntlet?.shop.roll ?? 0;
-  const previousInventory = localGauntlet?.shop.inventory ?? [];
+  const previousRound = localGauntlet?.shop.round ?? 0;
+  const previousInventory =
+    previousRound === round ? localGauntlet?.shop.inventory ?? [] : [];
   const purchasedIds = new Set(localPurchases.map((card) => card.id));
 
   const readyMessage = (() => {
@@ -81,6 +83,7 @@ export default function GauntletPhasePanel({
     if (phase !== "shop") return;
     if (localInventory.length > 0) return;
     if (previousInventory.length === 0) return;
+    if (previousRound !== round) return;
     configureShopInventory({ [localLegacySide]: previousInventory });
   }, [
     configureShopInventory,
@@ -88,6 +91,8 @@ export default function GauntletPhasePanel({
     localLegacySide,
     phase,
     previousInventory,
+    previousRound,
+    round,
   ]);
 
   useEffect(() => {
@@ -227,7 +232,7 @@ export default function GauntletPhasePanel({
                         </div>
                       ) : isPurchased ? (
                         <div className="text-[11px] text-emerald-200/70">
-                          Added to your deck.
+                          Added to your discard.
                         </div>
                       ) : null}
                     </div>

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -30,6 +30,8 @@ export type TagId = "oddshift" | "parityflip" | "echoreserve";
 
 export type CardType = "normal" | "split";
 
+export type CardBehavior = "split" | "boost" | "swap";
+
 export type CardRarity = "common" | "uncommon" | "rare" | "legendary";
 
 export type SplitFaceId = "left" | "right";
@@ -75,6 +77,7 @@ export type Card = {
   number?: number;      // when type === "normal"
   split?: CardSplit;    // when type === "split"
   activation?: ActivationAbility[];
+  behavior?: CardBehavior;
   reserve?: ReserveBehavior;
   tags: TagId[];
   cost?: number;

--- a/src/game/values.ts
+++ b/src/game/values.ts
@@ -2,6 +2,7 @@
 import {
   ActivationAbility,
   Card,
+  CardBehavior,
   CardSplitFace,
   ReserveBehavior,
   SplitChoiceMap,
@@ -14,6 +15,13 @@ export const isSplit = (
   c: Card | null | undefined,
 ): c is Card & { type: "split"; split: NonNullable<Card["split"]> } =>
   !!c && c.type === "split" && !!c.split;
+
+export const getCardBehavior = (
+  card: Card | null | undefined,
+): CardBehavior | null => {
+  if (!card) return null;
+  return card.behavior ?? null;
+};
 
 export const isNormal = (
   c: Card | null | undefined,

--- a/src/player/profileStore.tsx
+++ b/src/player/profileStore.tsx
@@ -8,6 +8,7 @@ export { expRequiredForLevel } from "./leveling";
 import type {
   ActivationAbility,
   Card,
+  CardBehavior,
   CardRarity,
   CardSplit,
   CardSplitFace,
@@ -85,6 +86,7 @@ export type CardBlueprint = {
   number?: number;
   split?: CardSplit;
   activation?: ActivationAbility[];
+  behavior?: CardBehavior;
   reserve?: ReserveBehavior;
   tags?: TagId[];
   cost: number;
@@ -117,6 +119,7 @@ const instantiateCard = (blueprint: CardBlueprint): Card => ({
   number: blueprint.number,
   split: blueprint.split ? cloneSplit(blueprint.split) : undefined,
   activation: blueprint.activation ? blueprint.activation.map(cloneActivation) : undefined,
+  behavior: blueprint.behavior,
   reserve: blueprint.reserve ? { ...blueprint.reserve } : undefined,
   tags: blueprint.tags ? [...blueprint.tags] : [],
   cost: blueprint.cost,
@@ -351,10 +354,47 @@ const ADVANCED_BLUEPRINTS: CardBlueprint[] = [
   },
 ];
 
+const BEHAVIOR_BLUEPRINTS: CardBlueprint[] = [
+  {
+    id: "split_edge",
+    name: "Split Edge",
+    type: "normal",
+    number: 8,
+    behavior: "split",
+    tags: [],
+    cost: 30,
+    rarity: "uncommon",
+    effectSummary: "Activation: halves its value before the wheel resolves.",
+  },
+  {
+    id: "boost_core",
+    name: "Boost Core",
+    type: "normal",
+    number: 3,
+    behavior: "boost",
+    tags: [],
+    cost: 28,
+    rarity: "uncommon",
+    effectSummary: "Activation: doubles its value for this round.",
+  },
+  {
+    id: "swap_token",
+    name: "Swap Token",
+    type: "normal",
+    number: 5,
+    behavior: "swap",
+    tags: [],
+    cost: 32,
+    rarity: "rare",
+    effectSummary: "Activation: swaps its value with the next card that is activated.",
+  },
+];
+
 const CARD_BLUEPRINTS: CardBlueprint[] = [
   ...BASIC_BLUEPRINTS,
   ...NEGATIVE_BLUEPRINTS,
   ...ADVANCED_BLUEPRINTS,
+  ...BEHAVIOR_BLUEPRINTS,
 ];
 
 const NEGATIVE_BLUEPRINT_IDS = new Set(NEGATIVE_BLUEPRINTS.map((entry) => entry.id));


### PR DESCRIPTION
## Summary
- extend card types with explicit behaviors and add new split, boost, and swap card blueprints for the shop
- build a full activation phase workflow that alternates turns, tracks pending swaps, and applies activation effects during round resolution
- surface the new activation interactions in the UI with an overlay and behavior icons on cards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd963f8d50833287d223f5cf735d06