### PR TITLE
Fix activation phase TDZ error in match controller

### DIFF
--- a/src/game/match/useMatchController.ts
+++ b/src/game/match/useMatchController.ts
@@ -318,6 +318,7 @@ useEffect(() => {
   }, [pendingSwapCardId]);
 
   const activationEnemyPicksRef = useRef<(Card | null)[] | null>(null);
+  const startActivationPhaseRef = useRef<(enemyPicks: (Card | null)[]) => void>(() => {});
 
   const [resolveVotes, setResolveVotes] = useState<{ player: boolean; enemy: boolean }>(
     {
@@ -1128,7 +1129,7 @@ function createInitialGauntletState(): GauntletState {
 
     setSafeTimeout(() => {
       if (!mountedRef.current) return;
-      startActivationPhase(enemyPicks);
+      startActivationPhaseRef.current(enemyPicks);
     }, 600);
 
     return true;
@@ -1141,7 +1142,6 @@ function createInitialGauntletState(): GauntletState {
     isMultiplayer,
     phase,
     setSafeTimeout,
-    startActivationPhase,
     wheelSize,
   ]);
 
@@ -1598,6 +1598,8 @@ function createInitialGauntletState(): GauntletState {
     (side: LegacySide) => completeShopForSide(side, { emit: true }),
     [completeShopForSide],
   );
+
+  startActivationPhaseRef.current = startActivationPhase;
 
   const finishActivationPhase = useCallback(() => {
     if (phase !== "activation") return false;


### PR DESCRIPTION
## Summary
- store `startActivationPhase` in a ref so the reveal logic can safely call it after lazy initialization
- trigger the activation phase via the ref to avoid the temporal-dead-zone error that blanked the match view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdbfe56f448332b5dc68715e193b8e