### PR TITLE
Add minimal card ability hints

### DIFF
--- a/src/components/match/HandDock.tsx
+++ b/src/components/match/HandDock.tsx
@@ -124,7 +124,12 @@ export default function HandDock({
                   aria-pressed={isSelected}
                   aria-label={`Select ${card.name}`}
                 >
-                  <StSCard card={card} showReserve={false} variant="minimal" />
+                  <StSCard
+                    card={card}
+                    showReserve={false}
+                    variant="minimal"
+                    showAbilityHint
+                  />
                 </button>
               </motion.div>
             </div>
@@ -145,7 +150,12 @@ export default function HandDock({
           aria-hidden
         >
           <div style={{ transform: "scale(0.9)", filter: "drop-shadow(0 6px 8px rgba(0,0,0,.35))" }}>
-            <StSCard card={pointerDragCard} showReserve={false} variant="minimal" />
+            <StSCard
+              card={pointerDragCard}
+              showReserve={false}
+              variant="minimal"
+              showAbilityHint
+            />
           </div>
         </div>
       )}

--- a/src/components/match/MatchBoard.tsx
+++ b/src/components/match/MatchBoard.tsx
@@ -154,6 +154,7 @@ export default function MatchBoard({
               showReserve={false}
 
               variant="minimal"
+              showAbilityHint
             />
           );
         };


### PR DESCRIPTION
## Summary
- add an inline ability/reserve hint option for minimal StSCard usage and expose a showAbilityHint prop
- show condensed card hints on hover/touch via a badge without breaking drag interactions
- enable the hint for minimal cards in the hand dock and on the match board

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cdc0595df083328c8fe0f71230be48