### PR TITLE
Remove reserve footer label from cards

### DIFF
--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -328,11 +328,6 @@ const statusTone: CardAdjustmentStatusTone = adjustment?.status?.tone ?? "info";
 
         {showFooter && (
           <div className="space-y-1 text-[11px] leading-tight text-slate-200/90">
-            {showReserve && (
-              <div className="font-semibold">
-                Reserve {fmtNum(getCardReserveValue(card))}
-              </div>
-            )}
             {card.reserve?.summary && (
               <div className="text-slate-200/80">{card.reserve.summary}</div>
             )}


### PR DESCRIPTION
## Summary
- stop rendering the reserve value label in the card footer to remove the "Reserve X" text

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdc83b9d4c833295b71dec8c1f59ba