### PR TITLE
Remove reserve value hint from card ability tooltip

### DIFF
--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -220,9 +220,6 @@ const statusTone: CardAdjustmentStatusTone = adjustment?.status?.tone ?? "info";
   const uniqueActivationSummaries = Array.from(new Set(activationSummaries));
 
   const abilityHintParts: string[] = [];
-  if (typeof reserveValue === "number" && Number.isFinite(reserveValue) && reserveValue !== 0) {
-    abilityHintParts.push(`Reserve ${fmtNum(reserveValue)}`);
-  }
   if (card.reserve?.summary) {
     abilityHintParts.push(card.reserve.summary);
   }


### PR DESCRIPTION
## Summary
- stop including the computed reserve value when building the card ability hint tooltip text

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cdccc3fce08332b59880c8079117bc