### PR TITLE
Expand gauntlet shop offerings and adjust purchase handling

### DIFF
--- a/src/game/match/useMatchController.ts
+++ b/src/game/match/useMatchController.ts
@@ -2243,7 +2243,7 @@ function addPurchasedCardToFighter(fighter: Fighter, card: Card): Fighter {
   const purchased = cloneCardForGauntlet(card);
   return {
     ...fighter,
-    deck: [purchased, ...fighter.deck],
+    discard: [purchased, ...fighter.discard],
   };
 }
 


### PR DESCRIPTION
## Summary
- expand each shop roll to six cards, reserving the top three slots for ability behaviors before filling the weighted slots (including a guaranteed negative)
- route purchased cards into the discard pile so they reliably enter the next draw cycle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdda1aa7108332a2696206e0c57fa4