### PR TITLE
Fix single-player enemy reserve calculation

### DIFF
--- a/src/game/match/useMatchController.ts
+++ b/src/game/match/useMatchController.ts
@@ -1196,8 +1196,10 @@ function createInitialGauntletState(): GauntletState {
       return value;
     };
 
-    const localFighter = localLegacySide === "player" ? player : enemy;
-    const remoteFighter = remoteLegacySide === "player" ? player : enemy;
+    const localFighter =
+      localLegacySide === "player" ? playerRef.current : enemyRef.current;
+    const remoteFighter =
+      remoteLegacySide === "player" ? playerRef.current : enemyRef.current;
 
     const localReserve = computeReserveSum(localFighter.hand);
     let remoteReserve: number;


### PR DESCRIPTION
## Summary
- ensure reserve totals use the most up-to-date fighter hands when resolving rounds

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce95fc32d083328e8b2ff5d89545a4