### PR TITLE
Fix gauntlet purchase deck insertion

### DIFF
--- a/src/game/match/useMatchController.ts
+++ b/src/game/match/useMatchController.ts
@@ -2273,14 +2273,6 @@ function cloneCardForGauntlet(card: Card): Card {
   };
 }
 
-function addPurchasedCardToFighter(fighter: Fighter, card: Card): Fighter {
-  const purchased = cloneCardForGauntlet(card);
-  return {
-    ...fighter,
-    discard: [purchased, ...fighter.discard],
-  };
-}
-
 function cardsEqual(a: Card, b: Card): boolean {
   if (a.id !== b.id) return false;
   if (a.name !== b.name) return false;


### PR DESCRIPTION
## Summary
- remove the local gauntlet purchase helper that put new cards into the discard pile
- rely on the profile-store helper so purchased cards are stacked onto the top of the deck for the next draw

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce9ccf8f68833286dfbbd767d0b7bf