### PR TITLE
Ensure round settlement discards hand before refilling

### DIFF
--- a/tests/matchController.test.ts
+++ b/tests/matchController.test.ts
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import type { Card, Fighter } from "../src/game/types.js";
+import { settleFighterAfterRound } from "../src/game/match/useMatchController.js";
+
+const makeCard = (id: string): Card => ({
+  id,
+  name: id,
+  type: "normal",
+  number: 0,
+  tags: [],
+});
+
+const makeFighter = (deck: Card[], hand: Card[], discard: Card[] = []): Fighter => ({
+  name: "Testy",
+  deck: [...deck],
+  hand: [...hand],
+  discard: [...discard],
+});
+
+test("settleFighterAfterRound discards the entire hand before refilling", () => {
+  const hand = ["h1", "h2", "h3", "h4", "h5"].map(makeCard);
+  const deck = ["d1", "d2", "d3", "d4", "d5", "d6"].map(makeCard);
+  const fighter = makeFighter(deck, hand);
+
+  const played = hand.slice(0, 2);
+  const result = settleFighterAfterRound(fighter, played);
+
+  assert.equal(result.hand.length, 5, "hand should be refilled to five cards");
+  const handIds = new Set(result.hand.map((card) => card.id));
+  hand.forEach((card) => {
+    assert.equal(
+      handIds.has(card.id),
+      false,
+      `card ${card.id} should not persist in hand after the round ends`,
+    );
+  });
+
+  const expectedNewHand = deck.slice(0, 5).map((card) => card.id);
+  assert.deepEqual(
+    result.hand.map((card) => card.id),
+    expectedNewHand,
+    "hand should draw fresh cards from the top of the deck",
+  );
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -12,6 +12,7 @@
     "tests/**/*.d.ts",
     "src/game/types.ts",
     "src/game/values.ts",
+    "src/game/match/useMatchController.ts",
     "src/game/match/valueAdjustments.ts",
     "src/player/profileStore.tsx"
   ],


### PR DESCRIPTION
## Summary
- ensure settleFighterAfterRound discards the entire hand before refilling and re-export it for testing
- add a focused node:test covering that hands are cleared and refilled with fresh cards between rounds
- extend the test TypeScript config to compile the match controller for testing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce9e61909c8332b7dabcf40dab21e4