### PR TITLE
Fix gauntlet shop purchases

### DIFF
--- a/src/game/modes/gauntlet/GauntletPhasePanel.tsx
+++ b/src/game/modes/gauntlet/GauntletPhasePanel.tsx
@@ -17,15 +17,22 @@ export type GauntletPhasePanelProps = {
   remoteLegacySide: LegacySide;
   namesByLegacy: Record<LegacySide, string>;
   gold: Record<LegacySide, number>;
-  shopInventory: Record<LegacySide, Card[]>;
-  shopPurchases: Record<LegacySide, Card[]>;
+  shopInventory: Record<LegacySide, StoreOffering[]>;
+  shopPurchases: Record<LegacySide, PendingShopPurchase[]>;
   shopReady: { player: boolean; enemy: boolean };
   gauntletState: GauntletState;
   gauntletRollShop: (inventory: StoreOffering[], round: number, roll?: number) => void;
   configureShopInventory: (
     inventory: Partial<Record<LegacySide, StoreOffering[]>>,
   ) => void;
-  purchaseFromShop: (side: LegacySide, offering: StoreOffering | string) => boolean;
+  purchaseFromShop: (
+    side: LegacySide,
+    offering:
+      | StoreOffering
+      | { offeringId: string; cost?: number }
+      | string
+      | { card: Card; cost: number; sourceId?: string | null },
+  ) => boolean;
   markShopComplete: (side: LegacySide) => boolean;
 };
 


### PR DESCRIPTION
## Summary
- ensure the gauntlet shop purchase helper accepts source identifiers and reuses the resolved offering data
- prevent duplicate purchases by checking the purchased card ids and persist the resolved cost on the pending purchase list
- align gauntlet shop panel props with the controller types so purchases can be executed via any payload shape

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cea8e094c4833291714822721bb037