### PR TITLE
Defer gauntlet purchase recording to resumeAfterShop

### DIFF
--- a/src/game/match/useMatchController.ts
+++ b/src/game/match/useMatchController.ts
@@ -1104,18 +1104,6 @@ function createInitialGauntletState(): GauntletState {
         `${namesByLegacy[side]} purchases ${card.name} for ${resolvedCost} gold.`,
       );
 
-      if (side === localLegacySide) {
-        const sourceId = resolvedOffering?.id ?? resolvedOfferingId ?? getCardSourceId(card);
-        if (sourceId) {
-          try {
-            applyGauntletPurchase({ add: [{ cardId: sourceId, qty: 1 }], cost: resolvedCost });
-          } catch (error) {
-            console.error("Failed to record gauntlet purchase", error);
-          }
-        }
-      }
-
-
       return true;
     },
     [


### PR DESCRIPTION
## Summary
- stop applyShopPurchase from recording local gauntlet purchases immediately
- rely on resumeAfterShop to stack purchases, record them once, and clear local state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceb4c550948332929a3124d804f8c5