### PR TITLE
Refactor match controller into modular hooks

### DIFF
--- a/src/game/match/useGauntletShop.ts
+++ b/src/game/match/useGauntletShop.ts
@@ -1,0 +1,372 @@
+import { useCallback, useRef, useState } from "react";
+
+import type { Card } from "../types";
+import { cloneCardForGauntlet } from "../../player/profileStore";
+import type { StoreOffering } from "../../player/profileStore";
+
+export type LegacySide = "player" | "enemy";
+
+export type GauntletShopPurchase = { cardId: string; round: number };
+
+export type GauntletShopState = {
+  inventory: StoreOffering[];
+  roll: number;
+  round: number;
+  purchases: GauntletShopPurchase[];
+};
+
+export type GauntletActivationState = {
+  selection: string | null;
+  passed: boolean;
+};
+
+export type GauntletSideState = {
+  shop: GauntletShopState;
+  gold: number;
+  goldDelta: number | null;
+  activation: GauntletActivationState;
+};
+
+export type GauntletState = Record<LegacySide, GauntletSideState>;
+
+export type GauntletShopRollPayload = {
+  inventory: StoreOffering[];
+  round: number;
+  roll: number;
+};
+
+export type GauntletGoldPayload = {
+  gold: number;
+  delta?: number;
+};
+
+export type GauntletShopIntent =
+  | ({ type: "shopRoll"; side: LegacySide } & GauntletShopRollPayload)
+  | ({ type: "shopPurchase"; side: LegacySide } & GauntletShopPurchase)
+  | ({ type: "gold"; side: LegacySide } & GauntletGoldPayload);
+
+export type GauntletActivationIntent =
+  | { type: "activationSelect"; side: LegacySide; activationId: string }
+  | { type: "activationPass"; side: LegacySide };
+
+export type UseGauntletShopOptions = {
+  localLegacySide: LegacySide;
+  emitIntent?: (intent: GauntletShopIntent | GauntletActivationIntent) => void;
+};
+
+export function useGauntletShop({
+  localLegacySide,
+  emitIntent,
+}: UseGauntletShopOptions) {
+  const gauntletStateRef = useRef<GauntletState>(createInitialGauntletState());
+  const [gauntletState, setGauntletState] = useState<GauntletState>(
+    () => gauntletStateRef.current,
+  );
+
+  const updateGauntletState = useCallback(
+    (updater: (prev: GauntletState) => GauntletState) => {
+      setGauntletState((prev) => {
+        const next = updater(prev);
+        gauntletStateRef.current = next;
+        return next;
+      });
+    },
+    [],
+  );
+
+  const resetGauntletState = useCallback(() => {
+    const reset = createInitialGauntletState();
+    gauntletStateRef.current = reset;
+    setGauntletState(reset);
+  }, []);
+
+  const resetGauntletShops = useCallback(() => {
+    updateGauntletState((prev) => ({
+      player: {
+        ...prev.player,
+        shop: { inventory: [], roll: 0, round: 0, purchases: [] },
+      },
+      enemy: {
+        ...prev.enemy,
+        shop: { inventory: [], roll: 0, round: 0, purchases: [] },
+      },
+    }));
+  }, [updateGauntletState]);
+
+  const applyGauntletShopRollFor = useCallback(
+    (side: LegacySide, payload: GauntletShopRollPayload) => {
+      updateGauntletState((prev) => {
+        const base = prev[side];
+        const nextInventory = payload.inventory.map(cloneStoreOffering);
+        const sameInventory = offeringsEqual(base.shop.inventory, nextInventory);
+        const sameRoll = base.shop.roll === payload.roll;
+        const sameRound = base.shop.round === payload.round;
+        if (sameInventory && sameRoll && sameRound && base.shop.purchases.length === 0) {
+          return prev;
+        }
+        const nextSide: GauntletSideState = {
+          ...base,
+          shop: {
+            inventory: nextInventory,
+            roll: payload.roll,
+            round: payload.round,
+            purchases: [],
+          },
+        };
+        return { ...prev, [side]: nextSide };
+      });
+    },
+    [updateGauntletState],
+  );
+
+  const applyGauntletPurchaseFor = useCallback(
+    (side: LegacySide, purchase: GauntletShopPurchase) => {
+      updateGauntletState((prev) => {
+        const base = prev[side];
+        const alreadyRecorded = base.shop.purchases.some(
+          (p) => p.cardId === purchase.cardId && p.round === purchase.round,
+        );
+        if (alreadyRecorded) {
+          return prev;
+        }
+        const nextSide: GauntletSideState = {
+          ...base,
+          shop: {
+            inventory: base.shop.inventory,
+            roll: base.shop.roll,
+            round: base.shop.round,
+            purchases: [...base.shop.purchases, { ...purchase }],
+          },
+        };
+        return { ...prev, [side]: nextSide };
+      });
+    },
+    [updateGauntletState],
+  );
+
+  const applyGauntletGoldFor = useCallback(
+    (side: LegacySide, payload: GauntletGoldPayload) => {
+      updateGauntletState((prev) => {
+        const base = prev[side];
+        const nextDelta =
+          typeof payload.delta === "number" && Number.isFinite(payload.delta)
+            ? payload.delta
+            : payload.gold - base.gold;
+        if (base.gold === payload.gold && base.goldDelta === nextDelta) {
+          return prev;
+        }
+        const nextSide: GauntletSideState = {
+          ...base,
+          gold: payload.gold,
+          goldDelta: nextDelta,
+        };
+        return { ...prev, [side]: nextSide };
+      });
+    },
+    [updateGauntletState],
+  );
+
+  const applyGauntletActivationSelectFor = useCallback(
+    (side: LegacySide, activationId: string) => {
+      updateGauntletState((prev) => {
+        const base = prev[side];
+        if (base.activation.selection === activationId && !base.activation.passed) {
+          return prev;
+        }
+        const nextSide: GauntletSideState = {
+          ...base,
+          activation: { selection: activationId, passed: false },
+        };
+        return { ...prev, [side]: nextSide };
+      });
+    },
+    [updateGauntletState],
+  );
+
+  const applyGauntletActivationPassFor = useCallback(
+    (side: LegacySide) => {
+      updateGauntletState((prev) => {
+        const base = prev[side];
+        if (base.activation.passed && base.activation.selection === null) {
+          return prev;
+        }
+        const nextSide: GauntletSideState = {
+          ...base,
+          activation: { selection: null, passed: true },
+        };
+        return { ...prev, [side]: nextSide };
+      });
+    },
+    [updateGauntletState],
+  );
+
+  const gauntletRollShop = useCallback(
+    (inventory: StoreOffering[], round: number, roll?: number) => {
+      const sanitizedInventory = inventory.map(cloneStoreOffering);
+      const current = gauntletStateRef.current[localLegacySide];
+      const resolvedRoll =
+        typeof roll === "number" && Number.isFinite(roll) ? roll : current.shop.roll + 1;
+      if (
+        offeringsEqual(current.shop.inventory, sanitizedInventory) &&
+        current.shop.round === round &&
+        current.shop.roll === resolvedRoll &&
+        current.shop.purchases.length === 0
+      ) {
+        return;
+      }
+      applyGauntletShopRollFor(localLegacySide, {
+        inventory: sanitizedInventory,
+        round,
+        roll: resolvedRoll,
+      });
+      emitIntent?.({
+        type: "shopRoll",
+        side: localLegacySide,
+        inventory: sanitizedInventory,
+        round,
+        roll: resolvedRoll,
+      });
+    },
+    [
+      applyGauntletShopRollFor,
+      emitIntent,
+      localLegacySide,
+    ],
+  );
+
+  const gauntletConfirmPurchase = useCallback(
+    (cardId: string, round: number) => {
+      const current = gauntletStateRef.current[localLegacySide];
+      const alreadyRecorded = current.shop.purchases.some(
+        (p) => p.cardId === cardId && p.round === round,
+      );
+      const hasCard = current.shop.inventory.some((offering) => offering.id === cardId);
+      if (!hasCard && alreadyRecorded) {
+        return;
+      }
+      applyGauntletPurchaseFor(localLegacySide, { cardId, round });
+      emitIntent?.({ type: "shopPurchase", side: localLegacySide, cardId, round });
+    },
+    [applyGauntletPurchaseFor, emitIntent, localLegacySide],
+  );
+
+  const gauntletUpdateGold = useCallback(
+    (gold: number, delta?: number) => {
+      const current = gauntletStateRef.current[localLegacySide];
+      const resolvedDelta =
+        typeof delta === "number" && Number.isFinite(delta) ? delta : gold - current.gold;
+      if (current.gold === gold && current.goldDelta === resolvedDelta) {
+        return;
+      }
+      applyGauntletGoldFor(localLegacySide, { gold, delta: resolvedDelta });
+      emitIntent?.({ type: "gold", side: localLegacySide, gold, delta: resolvedDelta });
+    },
+    [applyGauntletGoldFor, emitIntent, localLegacySide],
+  );
+
+  const gauntletSelectActivation = useCallback(
+    (activationId: string) => {
+      const current = gauntletStateRef.current[localLegacySide];
+      if (current.activation.selection === activationId && !current.activation.passed) {
+        return;
+      }
+      applyGauntletActivationSelectFor(localLegacySide, activationId);
+      emitIntent?.({ type: "activationSelect", side: localLegacySide, activationId });
+    },
+    [applyGauntletActivationSelectFor, emitIntent, localLegacySide],
+  );
+
+  const gauntletPassActivation = useCallback(() => {
+    const current = gauntletStateRef.current[localLegacySide];
+    if (current.activation.passed && current.activation.selection === null) {
+      return;
+    }
+    applyGauntletActivationPassFor(localLegacySide);
+    emitIntent?.({ type: "activationPass", side: localLegacySide });
+  }, [
+    applyGauntletActivationPassFor,
+    emitIntent,
+    localLegacySide,
+  ]);
+
+  return {
+    gauntletState,
+    gauntletStateRef,
+    resetGauntletState,
+    resetGauntletShops,
+    applyGauntletShopRollFor,
+    applyGauntletPurchaseFor,
+    applyGauntletGoldFor,
+    applyGauntletActivationSelectFor,
+    applyGauntletActivationPassFor,
+    gauntletRollShop,
+    gauntletConfirmPurchase,
+    gauntletUpdateGold,
+    gauntletSelectActivation,
+    gauntletPassActivation,
+  };
+}
+
+export function cloneStoreOffering(offering: StoreOffering): StoreOffering {
+  return {
+    ...offering,
+    card: cloneCardForGauntlet(offering.card),
+  };
+}
+
+export function offeringsEqual(a: StoreOffering[], b: StoreOffering[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    const offerA = a[i];
+    const offerB = b[i];
+    if (!offerA || !offerB) return false;
+    if (offerA.id !== offerB.id) return false;
+    if (offerA.cost !== offerB.cost) return false;
+    if (offerA.rarity !== offerB.rarity) return false;
+    if (offerA.summary !== offerB.summary) return false;
+    if (!cardsEqual(offerA.card, offerB.card)) return false;
+  }
+  return true;
+}
+
+function createInitialGauntletState(): GauntletState {
+  return {
+    player: createInitialGauntletSideState(),
+    enemy: createInitialGauntletSideState(),
+  };
+}
+
+function createInitialGauntletSideState(): GauntletSideState {
+  return {
+    shop: { inventory: [], roll: 0, round: 0, purchases: [] },
+    gold: 0,
+    goldDelta: null,
+    activation: { selection: null, passed: false },
+  };
+}
+
+function cardsEqual(a: Card, b: Card): boolean {
+  const legacyA = a as Card & {
+    leftValue?: number | null;
+    rightValue?: number | null;
+  };
+  const legacyB = b as Card & {
+    leftValue?: number | null;
+    rightValue?: number | null;
+  };
+  if (a.id !== b.id) return false;
+  if (a.name !== b.name) return false;
+  if ((a.type ?? "normal") !== (b.type ?? "normal")) return false;
+  if ((a.number ?? null) !== (b.number ?? null)) return false;
+  if ((legacyA.leftValue ?? null) !== (legacyB.leftValue ?? null)) return false;
+  if ((legacyA.rightValue ?? null) !== (legacyB.rightValue ?? null)) return false;
+  if ((a.behavior ?? null) !== (b.behavior ?? null)) return false;
+  if ((a.cost ?? null) !== (b.cost ?? null)) return false;
+  if ((a.rarity ?? null) !== (b.rarity ?? null)) return false;
+  if ((a.effectSummary ?? null) !== (b.effectSummary ?? null)) return false;
+  if (a.tags.length !== b.tags.length) return false;
+  for (let i = 0; i < a.tags.length; i += 1) {
+    if (a.tags[i] !== b.tags[i]) return false;
+  }
+  return true;
+}

--- a/src/game/match/useLatestRef.ts
+++ b/src/game/match/useLatestRef.ts
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from "react";
+
+export function useLatestRef<T>(value: T) {
+  const ref = useRef(value);
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref;
+}

--- a/src/game/match/useMatchActivationPhase.ts
+++ b/src/game/match/useMatchActivationPhase.ts
@@ -1,0 +1,385 @@
+import { useCallback, useEffect, useRef, useState, startTransition } from "react";
+import type { MutableRefObject } from "react";
+
+import type { Card } from "../types";
+import { getCardPlayValue } from "../values";
+import { useLatestRef } from "./useLatestRef";
+import type { ActivationAdjustmentsMap, ActivationSwapPairs } from "./valueAdjustments";
+import type { LegacySide } from "./useGauntletShop";
+
+export type Phase =
+  | "choose"
+  | "showEnemy"
+  | "anim"
+  | "roundEnd"
+  | "shop"
+  | "activation"
+  | "activationComplete"
+  | "ended";
+
+export type ActivationActionParams = {
+  side: LegacySide;
+  action: "activate" | "pass";
+  cardId?: string;
+};
+
+export type ActivationIntent = ActivationActionParams & { type: "activation" };
+
+export type ActivationLogEntry = ActivationActionParams;
+
+export type UseMatchActivationPhaseOptions = {
+  phase: Phase;
+  setPhase: (next: Phase) => void;
+  assignRef: MutableRefObject<{ player: (Card | null)[]; enemy: (Card | null)[] }>;
+  initiative: LegacySide;
+  appendLog: (message: string) => void;
+  activationCompleteRef: MutableRefObject<(enemyPicks: (Card | null)[]) => void>;
+  emitIntent?: (intent: ActivationIntent) => void;
+  isMultiplayer: boolean;
+  remoteLegacySide: LegacySide;
+};
+
+const isActivatableCard = (card: Card | null | undefined): card is Card => {
+  if (!card) return false;
+  return !!card.behavior;
+};
+
+const oppositeSide = (side: LegacySide): LegacySide => (side === "player" ? "enemy" : "player");
+
+export function useMatchActivationPhase({
+  phase,
+  setPhase,
+  assignRef,
+  initiative,
+  appendLog,
+  activationCompleteRef,
+  emitIntent,
+  isMultiplayer,
+  remoteLegacySide,
+}: UseMatchActivationPhaseOptions) {
+  const [activationTurn, setActivationTurn] = useState<LegacySide | null>(null);
+  const [activationPasses, setActivationPasses] = useState<{ player: boolean; enemy: boolean }>(
+    () => ({ player: false, enemy: false }),
+  );
+  const [activationLog, setActivationLog] = useState<ActivationLogEntry[]>([]);
+  const [activationAvailable, setActivationAvailable] = useState<Record<LegacySide, string[]>>({
+    player: [],
+    enemy: [],
+  });
+  const [activationInitial, setActivationInitial] = useState<Record<LegacySide, string[]>>({
+    player: [],
+    enemy: [],
+  });
+  const [pendingSwapCardId, setPendingSwapCardId] = useState<string | null>(null);
+  const [activationSwapPairs, setActivationSwapPairs] = useState<ActivationSwapPairs>([]);
+  const [activationAdjustments, setActivationAdjustments] =
+    useState<ActivationAdjustmentsMap>({});
+
+  const activationAvailableRef = useLatestRef(activationAvailable);
+  const activationAdjustmentsRef = useLatestRef<ActivationAdjustmentsMap>(activationAdjustments);
+  const activationSwapPairsRef = useLatestRef<ActivationSwapPairs>(activationSwapPairs);
+  const pendingSwapRef = useLatestRef<string | null>(pendingSwapCardId);
+  const activationEnemyPicksRef = useRef<(Card | null)[] | null>(null);
+
+  const resetActivationPhase = useCallback(() => {
+    setActivationTurn(null);
+    setActivationPasses({ player: false, enemy: false });
+    setActivationLog([]);
+    setActivationAvailable({ player: [], enemy: [] });
+    setActivationInitial({ player: [], enemy: [] });
+    setActivationSwapPairs([]);
+    setActivationAdjustments({});
+    setPendingSwapCardId(null);
+    activationEnemyPicksRef.current = null;
+  }, []);
+
+  const startActivationPhase = useCallback(
+    (enemyPicks: (Card | null)[]) => {
+      const playerCards = assignRef.current.player.filter((c): c is Card => !!c);
+      const enemyCards = enemyPicks.filter((c): c is Card => !!c);
+
+      const playerActivatable = playerCards.filter((card) => isActivatableCard(card));
+      const enemyActivatable = enemyCards.filter((card) => isActivatableCard(card));
+
+      const playerIds = playerActivatable.map((card) => card.id);
+      const enemyIds = enemyActivatable.map((card) => card.id);
+
+      activationEnemyPicksRef.current = enemyPicks;
+
+      setActivationInitial({ player: playerIds, enemy: enemyIds });
+      setActivationAvailable({ player: playerIds, enemy: enemyIds });
+      setActivationPasses({ player: false, enemy: false });
+      setActivationLog([]);
+      setActivationAdjustments({});
+      setActivationSwapPairs([]);
+      setPendingSwapCardId(null);
+
+      const hasPlayerCards = playerIds.length > 0;
+      const hasEnemyCards = enemyIds.length > 0;
+
+      const starter: LegacySide | null = (() => {
+        if (!hasPlayerCards && !hasEnemyCards) return null;
+        if (initiative === "player") {
+          if (hasPlayerCards) return "player";
+          if (hasEnemyCards) return "enemy";
+        } else {
+          if (hasEnemyCards) return "enemy";
+          if (hasPlayerCards) return "player";
+        }
+        if (hasPlayerCards) return "player";
+        if (hasEnemyCards) return "enemy";
+        return null;
+      })();
+
+      setActivationTurn(starter);
+
+      if (!hasPlayerCards && !hasEnemyCards) {
+        setPhase("anim");
+        activationCompleteRef.current(enemyPicks);
+        return;
+      }
+
+      appendLog("Activation phase begins.");
+      setPhase("activation");
+    },
+    [appendLog, assignRef, initiative, setPhase, activationCompleteRef],
+  );
+
+  const finishActivationPhase = useCallback(() => {
+    if (phase !== "activation") return false;
+    const enemyPicks = activationEnemyPicksRef.current ?? assignRef.current.enemy;
+    setActivationTurn(null);
+    setActivationPasses({ player: false, enemy: false });
+    setPendingSwapCardId(null);
+    activationEnemyPicksRef.current = null;
+    setPhase("anim");
+    activationCompleteRef.current(enemyPicks);
+    return true;
+  }, [
+    activationCompleteRef,
+    assignRef,
+    phase,
+    setPhase,
+  ]);
+
+  const applyActivationAction = useCallback(
+    (params: ActivationActionParams, opts?: { emit?: boolean }) => {
+      if (phase !== "activation") return false;
+
+      const availableForSide = activationAvailableRef.current[params.side];
+
+      if (activationTurn && activationTurn !== params.side) {
+        const canForcePass = params.action === "pass" && availableForSide.length === 0;
+        if (!canForcePass) {
+          return false;
+        }
+      }
+
+      if (params.action === "activate") {
+        const cardId = params.cardId;
+        if (!cardId) return false;
+
+        if (!availableForSide.includes(cardId)) {
+          return false;
+        }
+
+        const card =
+          assignRef.current.player.find((c) => c?.id === cardId) ??
+          assignRef.current.enemy.find((c) => c?.id === cardId) ??
+          null;
+        if (!card) return false;
+
+        const swapSource = pendingSwapRef.current;
+        if (swapSource && swapSource !== cardId) {
+          setActivationSwapPairs((prev) => [...prev, [swapSource, cardId]]);
+          setPendingSwapCardId(null);
+        } else if (swapSource && swapSource === cardId) {
+          setPendingSwapCardId(null);
+        }
+
+        const behavior = card.behavior ?? null;
+        if (behavior === "split") {
+          setActivationAdjustments((prev) => ({ ...prev, [cardId]: { type: "split" } }));
+        } else if (behavior === "boost") {
+          setActivationAdjustments((prev) => ({ ...prev, [cardId]: { type: "boost" } }));
+        } else if (behavior === "swap") {
+          setPendingSwapCardId(cardId);
+        }
+
+        const nextAvailableForSide = availableForSide.filter((id) => id !== cardId);
+        setActivationAvailable((prev) => ({
+          ...prev,
+          [params.side]: nextAvailableForSide,
+        }));
+        setActivationLog((prev) => [...prev, { ...params }]);
+        setActivationPasses({ player: false, enemy: false });
+
+        if (opts?.emit && isMultiplayer) {
+          emitIntent?.({ type: "activation", ...params });
+        }
+
+        const otherSide = oppositeSide(params.side);
+        const otherHasCards = activationAvailableRef.current[otherSide].length > 0;
+        const selfHasCardsAfter = nextAvailableForSide.length > 0;
+
+        if (!otherHasCards && !selfHasCardsAfter) {
+          setActivationTurn(null);
+          finishActivationPhase();
+          return true;
+        }
+
+        const nextTurn = otherHasCards ? otherSide : params.side;
+        setActivationTurn(nextTurn);
+        return true;
+      }
+
+      let shouldFinish = false;
+      setActivationPasses((prev) => {
+        if (prev[params.side]) return prev;
+        const updated = { ...prev, [params.side]: true };
+        if (updated.player && updated.enemy) {
+          shouldFinish = true;
+        }
+        return updated;
+      });
+      setActivationLog((prev) => [...prev, { ...params }]);
+
+      if (opts?.emit && isMultiplayer) {
+        emitIntent?.({ type: "activation", ...params });
+      }
+
+      const otherSide = oppositeSide(params.side);
+      const otherHasCards = activationAvailableRef.current[otherSide].length > 0;
+      const selfHasCards = availableForSide.length > 0;
+
+      if (shouldFinish || (!otherHasCards && !selfHasCards)) {
+        setActivationTurn(null);
+        finishActivationPhase();
+        return true;
+      }
+
+      const nextTurn = otherHasCards ? otherSide : params.side;
+      setActivationTurn(nextTurn);
+      return true;
+    },
+    [
+      activationAvailableRef,
+      activationTurn,
+      emitIntent,
+      finishActivationPhase,
+      isMultiplayer,
+      pendingSwapRef,
+      phase,
+      assignRef,
+    ],
+  );
+
+  const activateCurrent = useCallback(
+    (side: LegacySide, cardId?: string) =>
+      applyActivationAction({ side, action: "activate", cardId }, { emit: true }),
+    [applyActivationAction],
+  );
+
+  const passActivation = useCallback(
+    (side: LegacySide) => applyActivationAction({ side, action: "pass" }, { emit: true }),
+    [applyActivationAction],
+  );
+
+  const applyActivationActionRef = useLatestRef(applyActivationAction);
+
+  useEffect(() => {
+    if (phase !== "activation") return;
+
+    const activationAction = applyActivationActionRef.current;
+    if (!activationAction) return;
+
+    (Object.keys(activationAvailable) as LegacySide[]).forEach((side) => {
+      if (activationAvailable[side].length > 0) return;
+      if (activationPasses[side]) return;
+
+      activationAction({ side, action: "pass" }, { emit: true });
+    });
+  }, [activationAvailable, activationPasses, phase, applyActivationActionRef]);
+
+  useEffect(() => {
+    if (isMultiplayer) return;
+    if (phase !== "activation") return;
+    if (activationTurn !== remoteLegacySide) return;
+    if (activationPasses[remoteLegacySide]) return;
+
+    const activationAction = applyActivationActionRef.current;
+    if (!activationAction) return;
+
+    const availableIds = activationAvailable[remoteLegacySide];
+
+    const findCard = (cardId: string): Card | null => {
+      const fromAssign =
+        assignRef.current.player.find((card) => card?.id === cardId) ??
+        assignRef.current.enemy.find((card) => card?.id === cardId) ??
+        null;
+      if (fromAssign) return fromAssign;
+
+      const enemyPicks = activationEnemyPicksRef.current;
+      if (!enemyPicks) return null;
+      return enemyPicks.find((card) => card?.id === cardId) ?? null;
+    };
+
+    let bestCardId: string | undefined;
+    let bestValue = Number.NEGATIVE_INFINITY;
+
+    for (const cardId of availableIds) {
+      const card = findCard(cardId);
+      if (!card) continue;
+      const value = getCardPlayValue(card);
+      if (value > bestValue) {
+        bestValue = value;
+        bestCardId = cardId;
+      }
+    }
+
+    if (!bestCardId && availableIds.length > 0) {
+      bestCardId = availableIds[0];
+    }
+
+    const params: ActivationActionParams =
+      bestCardId
+        ? { side: remoteLegacySide, action: "activate", cardId: bestCardId }
+        : { side: remoteLegacySide, action: "pass" };
+
+    startTransition(() => {
+      const success = activationAction(params);
+      if (!success && params.action === "activate") {
+        activationAction({ side: remoteLegacySide, action: "pass" });
+      }
+    });
+  }, [
+    activationAvailable,
+    activationPasses,
+    activationTurn,
+    assignRef,
+    isMultiplayer,
+    phase,
+    remoteLegacySide,
+  ]);
+
+  return {
+    activationTurn,
+    activationPasses,
+    activationLog,
+    activationAvailable,
+    activationInitial,
+    activationSwapPairs,
+    activationAdjustments,
+    pendingSwapCardId,
+    startActivationPhase,
+    finishActivationPhase,
+    applyActivationAction,
+    activateCurrent,
+    passActivation,
+    resetActivationPhase,
+    activationAdjustmentsRef,
+    activationSwapPairsRef,
+    activationEnemyPicksRef,
+    applyActivationActionRef,
+  };
+}


### PR DESCRIPTION
## Summary
- extract gauntlet shop state and intents into useGauntletShop
- move activation phase logic into useMatchActivationPhase hook with multiplayer helpers
- simplify match controller by delegating to the new hooks and shared useLatestRef utility

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceb94142e08332a360a86ce9e06f75