### PR TITLE
Refine gauntlet shop transition to deliver purchases to hand

### DIFF
--- a/src/game/match/useMatchController.ts
+++ b/src/game/match/useMatchController.ts
@@ -1403,20 +1403,6 @@ const purchaseFromShop = useCallback(
       enemy: purchases.enemy.map((purchase) => ({ ...purchase })),
     };
 
-    const purchases = takeShopPurchases();
-    const localPending = nextRoundPurchases[localLegacySide];
-    for (const purchase of localPending) {
-      if (!purchase.sourceId) continue;
-      try {
-        applyGauntletPurchase({
-          add: [{ cardId: purchase.sourceId, qty: 1 }],
-          cost: purchase.cost,
-        });
-      } catch (error) {
-        console.error("Failed to record gauntlet purchase", error);
-      }
-    }
-
     nextRoundCore({ force: true, purchases: nextRoundPurchases });
 
   }, [


### PR DESCRIPTION
## Summary
- require the gauntlet shop to open from the Next button instead of auto-advancing at round end
- carry queued shop purchases into the next round flow so they enter the hand before refilling from the deck
- update regression coverage to confirm purchased cards appear in hand immediately after closing the shop

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cec8fbfc6c833295f1dbb4ab1563e6