### PR TITLE
Fix ability card hand tooltip

### DIFF
--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -85,7 +85,10 @@ export default memo(function StSCard({
   /** Optional: show a condensed reserve/ability hint when in minimal mode */
   showAbilityHint = false,
   adjustment,
-  
+  title,
+  ariaLabel,
+  ariaPressed,
+
 }: {
   card: Card;
   disabled?: boolean;
@@ -104,6 +107,9 @@ export default memo(function StSCard({
   ariaDescribedBy?: string;
   showAbilityHint?: boolean;
   adjustment?: CardAdjustmentDescriptor;
+  title?: string;
+  ariaLabel?: string;
+  ariaPressed?: boolean;
 
 }) {
   // ---------- Dimensions ----------
@@ -231,6 +237,14 @@ const statusTone: CardAdjustmentStatusTone = adjustment?.status?.tone ?? "info";
   const shouldShowAbilityHint =
     variant === "minimal" && showAbilityHint && abilityHintText.length > 0;
 
+  const computedAriaLabel =
+    typeof ariaLabel === "string"
+      ? ariaLabel
+      : `Card ${card?.name ?? ""}${(() => {
+          const summary = getCardEffectSummary(card);
+          return summary ? `, ${summary}` : "";
+        })()}`;
+
   return (
     <button
       onClick={(e) => {
@@ -245,10 +259,7 @@ const statusTone: CardAdjustmentStatusTone = adjustment?.status?.tone ?? "info";
         ${cardBackground}
       `}
       style={{ width: dims.w, height: dims.h }}
-      aria-label={`Card ${card?.name ?? ""}${(() => {
-        const summary = getCardEffectSummary(card);
-        return summary ? `, ${summary}` : "";
-      })()}`}
+      aria-label={computedAriaLabel}
       aria-describedby={ariaDescribedBy}
       draggable={draggable}
       onDragStart={onDragStart}
@@ -257,6 +268,8 @@ const statusTone: CardAdjustmentStatusTone = adjustment?.status?.tone ?? "info";
       data-card-kind={cardKind}
       data-play-val={playVal}
       data-card-id={id}
+      title={title}
+      aria-pressed={ariaPressed}
     >
       {/* Border-only frame; bg is transparent so it never masks the button background */}
       <div

--- a/src/components/match/HandDock.tsx
+++ b/src/components/match/HandDock.tsx
@@ -72,6 +72,7 @@ export default function HandDock({
           const abilitySummary = card.behavior
             ? getCardEffectSummary(card) ?? undefined
             : undefined;
+
           const handlePick = () => {
             if (!selectedCardId) {
               onSelectCard(card.id);
@@ -83,7 +84,8 @@ export default function HandDock({
               return;
             }
 
-            const lane = localLegacySide === "player" ? assign.player : assign.enemy;
+            const lane =
+              localLegacySide === "player" ? assign.player : assign.enemy;
             const slotIdx = lane.findIndex((c) => c?.id === selectedCardId);
             if (slotIdx !== -1) {
               onAssignToWheel(slotIdx, card);
@@ -92,14 +94,17 @@ export default function HandDock({
 
             onSelectCard(card.id);
           };
-          const ariaLabel = `Select ${card.name}${abilitySummary ? `, ${abilitySummary}` : ""}`;
 
-          const abilityTooltip = card.behavior
-            ? getCardEffectSummary(card) ?? undefined
-            : undefined;
+          const ariaLabel = `Select ${card.name}${
+            abilitySummary ? `, ${abilitySummary}` : ""
+          }`;
 
           return (
-            <div key={card.id} className="group relative pointer-events-auto" style={{ zIndex: 10 + idx }}>
+            <div
+              key={card.id}
+              className="group relative pointer-events-auto"
+              style={{ zIndex: 10 + idx }}
+            >
               <motion.div
                 data-hand-card
                 initial={false}
@@ -114,7 +119,9 @@ export default function HandDock({
                   scale: 1.04,
                 }}
                 transition={{ type: "spring", stiffness: 320, damping: 22 }}
-                className={`drop-shadow-xl ${isSelected ? "ring-2 ring-amber-300" : ""}`}
+                className={`drop-shadow-xl ${
+                  isSelected ? "ring-2 ring-amber-300" : ""
+                }`}
               >
                 <StSCard
                   card={card}
@@ -131,29 +138,14 @@ export default function HandDock({
                     event.dataTransfer.effectAllowed = "move";
                   }}
                   onDragEnd={() => onDragCardChange(null)}
-                  
-                  onPointerDown={(event: PointerEvent<HTMLButtonElement>) =>
-                    startPointerDrag(card, event)
-                  }
+                  onPointerDown={(
+                    event: PointerEvent<HTMLButtonElement>,
+                  ) => startPointerDrag(card, event)}
                   ariaLabel={ariaLabel}
                   title={abilitySummary}
                   ariaPressed={isSelected}
                   selected={isSelected}
                 />
-
-                  onPointerDown={(event: PointerEvent<HTMLButtonElement>) => startPointerDrag(card, event)}
-                  aria-pressed={isSelected}
-                  aria-label={`Select ${card.name}${abilityTooltip ? `, ${abilityTooltip}` : ""}`}
-                  title={abilityTooltip}
-                >
-                  <StSCard
-                    card={card}
-                    showReserve={false}
-                    variant="minimal"
-                    showAbilityHint
-                  />
-                </button>
-
               </motion.div>
             </div>
           );
@@ -166,13 +158,20 @@ export default function HandDock({
             position: "fixed",
             left: 0,
             top: 0,
-            transform: `translate(${pointerPosition.current.x - 48}px, ${pointerPosition.current.y - 64}px)`,
+            transform: `translate(${pointerPosition.current.x - 48}px, ${
+              pointerPosition.current.y - 64
+            }px)`,
             pointerEvents: "none",
             zIndex: 9999,
           }}
           aria-hidden
         >
-          <div style={{ transform: "scale(0.9)", filter: "drop-shadow(0 6px 8px rgba(0,0,0,.35))" }}>
+          <div
+            style={{
+              transform: "scale(0.9)",
+              filter: "drop-shadow(0 6px 8px rgba(0,0,0,.35))",
+            }}
+          >
             <StSCard
               card={pointerDragCard}
               showReserve={false}

--- a/src/components/match/HandDock.tsx
+++ b/src/components/match/HandDock.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { PointerEvent, DragEvent, MutableRefObject } from "react";
 import { motion } from "framer-motion";
-import StSCard from "../StSCard";
+import StSCard, { getCardEffectSummary } from "../StSCard";
 import type { Card, Fighter } from "../../game/types";
 import type { LegacySide } from "./MatchBoard";
 
@@ -68,6 +68,30 @@ export default function HandDock({
       <div className="mx-auto max-w-[1400px] flex justify-center gap-1.5 py-0.5">
         {localFighter.hand.map((card, idx) => {
           const isSelected = selectedCardId === card.id;
+          const abilitySummary = card.behavior
+            ? getCardEffectSummary(card) ?? undefined
+            : undefined;
+          const handlePick = () => {
+            if (!selectedCardId) {
+              onSelectCard(card.id);
+              return;
+            }
+
+            if (selectedCardId === card.id) {
+              onSelectCard(null);
+              return;
+            }
+
+            const lane = localLegacySide === "player" ? assign.player : assign.enemy;
+            const slotIdx = lane.findIndex((c) => c?.id === selectedCardId);
+            if (slotIdx !== -1) {
+              onAssignToWheel(slotIdx, card);
+              return;
+            }
+
+            onSelectCard(card.id);
+          };
+          const ariaLabel = `Select ${card.name}${abilitySummary ? `, ${abilitySummary}` : ""}`;
           return (
             <div key={card.id} className="group relative pointer-events-auto" style={{ zIndex: 10 + idx }}>
               <motion.div
@@ -86,31 +110,12 @@ export default function HandDock({
                 transition={{ type: "spring", stiffness: 320, damping: 22 }}
                 className={`drop-shadow-xl ${isSelected ? "ring-2 ring-amber-300" : ""}`}
               >
-                <button
-                  data-hand-card
-                  className="pointer-events-auto"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    if (!selectedCardId) {
-                      onSelectCard(card.id);
-                      return;
-                    }
-
-                    if (selectedCardId === card.id) {
-                      onSelectCard(null);
-                      return;
-                    }
-
-                    const lane =
-                      localLegacySide === "player" ? assign.player : assign.enemy;
-                    const slotIdx = lane.findIndex((c) => c?.id === selectedCardId);
-                    if (slotIdx !== -1) {
-                      onAssignToWheel(slotIdx, card);
-                      return;
-                    }
-
-                    onSelectCard(card.id);
-                  }}
+                <StSCard
+                  card={card}
+                  showReserve={false}
+                  variant="minimal"
+                  showAbilityHint
+                  onPick={handlePick}
                   draggable
                   onDragStart={(event: DragEvent<HTMLButtonElement>) => {
                     onDragCardChange(card.id);
@@ -120,17 +125,14 @@ export default function HandDock({
                     event.dataTransfer.effectAllowed = "move";
                   }}
                   onDragEnd={() => onDragCardChange(null)}
-                  onPointerDown={(event: PointerEvent<HTMLButtonElement>) => startPointerDrag(card, event)}
-                  aria-pressed={isSelected}
-                  aria-label={`Select ${card.name}`}
-                >
-                  <StSCard
-                    card={card}
-                    showReserve={false}
-                    variant="minimal"
-                    showAbilityHint
-                  />
-                </button>
+                  onPointerDown={(event: PointerEvent<HTMLButtonElement>) =>
+                    startPointerDrag(card, event)
+                  }
+                  ariaLabel={ariaLabel}
+                  title={abilitySummary}
+                  ariaPressed={isSelected}
+                  selected={isSelected}
+                />
               </motion.div>
             </div>
           );


### PR DESCRIPTION
## Summary
- expose optional title/aria overrides on `StSCard` so callers can surface tooltips on the button element itself
- render hand cards directly through `StSCard` and feed ability summaries into the tooltip/aria label for behavior cards
- keep selection/dragging logic intact by delegating through the card component instead of a wrapper button

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cf0de005f8833299da199d165b8c3e