### PR TITLE
Fix hand card frame rendering

### DIFF
--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -280,7 +280,6 @@ const statusTone: CardAdjustmentStatusTone = adjustment?.status?.tone ?? "info";
         ${buttonBackgroundClass}
       `}
       style={buttonStyle}
-      style={{ width: dims.w, height: dims.h }}
       aria-label={computedAriaLabel}
       aria-describedby={ariaDescribedBy}
       draggable={draggable}


### PR DESCRIPTION
## Summary
- ensure StSCard only sets its inline styles once so the hand frame background image is preserved

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf26f6dac883329a762ed6a397f9c6