### PR TITLE
Improve ability tooltips and icons

### DIFF
--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -204,9 +204,19 @@ const framesByKind: Record<Kind, string> = {
 const cardBackground = backgroundsByKind[cardKind];
 const frameBorder = framesByKind[cardKind];
 
+const splitFaces = getSplitFaces(card);
+
 const behavior = getCardBehavior(card);
 const behaviorIcon =
   behavior === "split" ? "✂️" : behavior === "boost" ? "⚡" : behavior === "swap" ? "🔄" : null;
+
+const hasAbilityMetadata = Boolean(
+  (card.activation?.length ?? 0) > 0 ||
+    splitFaces.some((face) => (face.activation?.length ?? 0) > 0) ||
+    card.reserve?.summary,
+);
+
+const abilityBadgeIcon = behaviorIcon ?? (hasAbilityMetadata ? "✨" : null);
 
 const displayValue =
   typeof adjustment?.value === "number" ? adjustment.value : playVal;
@@ -223,7 +233,7 @@ const statusTone: CardAdjustmentStatusTone = adjustment?.status?.tone ?? "info";
   const reserveValue = getCardReserveValue(card);
   const activationSummaries = [
     ...(card.activation ?? []).map((ability) => ability.summary),
-    ...getSplitFaces(card).flatMap((face) =>
+    ...splitFaces.flatMap((face) =>
       (face.activation ?? []).map((ability) =>
         `${face.label ?? (face.id === "left" ? "Left" : "Right")}: ${ability.summary}`,
       ),
@@ -315,9 +325,9 @@ const statusTone: CardAdjustmentStatusTone = adjustment?.status?.tone ?? "info";
         </div>
       )}
 
-      {behaviorIcon && (
+      {abilityBadgeIcon && (
         <div className="pointer-events-none absolute left-1 top-1 text-lg leading-none drop-shadow-[0_1px_1px_rgba(0,0,0,0.65)]">
-          {behaviorIcon}
+          {abilityBadgeIcon}
         </div>
       )}
 
@@ -340,7 +350,7 @@ const statusTone: CardAdjustmentStatusTone = adjustment?.status?.tone ?? "info";
         <div className="flex-1 flex items-center justify-center text-center">
           {isSplit(card) ? (
             <div className="grid grid-cols-2 gap-x-2 text-center text-white/90">
-              {getSplitFaces(card).map((face) => (
+              {splitFaces.map((face) => (
                 <div key={face.id} className="leading-tight">
                   <div className="text-[10px] uppercase text-slate-300">
                     {face.label ?? (face.id === "left" ? "Left" : "Right")}

--- a/src/components/match/HandDock.tsx
+++ b/src/components/match/HandDock.tsx
@@ -3,6 +3,7 @@ import type { PointerEvent, DragEvent, MutableRefObject } from "react";
 import { motion } from "framer-motion";
 import StSCard, { getCardEffectSummary } from "../StSCard";
 import type { Card, Fighter } from "../../game/types";
+import { isSplit } from "../../game/values";
 import type { LegacySide } from "./MatchBoard";
 
 interface HandDockProps {
@@ -68,7 +69,13 @@ export default function HandDock({
       <div className="mx-auto max-w-[1400px] flex justify-center gap-1.5 py-0.5">
         {localFighter.hand.map((card, idx) => {
           const isSelected = selectedCardId === card.id;
-          const abilitySummary = card.behavior
+          const shouldDescribeAbility = Boolean(
+            card.behavior ||
+              (card.activation?.length ?? 0) > 0 ||
+              card.reserve?.summary ||
+              isSplit(card),
+          );
+          const abilitySummary = shouldDescribeAbility
             ? getCardEffectSummary(card) ?? undefined
             : undefined;
 


### PR DESCRIPTION
## Summary
- expand ability summaries in the hand to cover activations, reserve text, and split cards while feeding them into both the aria-label and tooltip
- add a fallback sparkle badge for cards with activation or reserve metadata so ability cards stay visually distinct

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf2b05e3ac83328ba25a50149e44e4