### PR TITLE
Initialize gauntlet run lifecycle in match

### DIFF
--- a/src/game/modes/gauntlet/GauntletMatch.tsx
+++ b/src/game/modes/gauntlet/GauntletMatch.tsx
@@ -13,6 +13,11 @@ import {
   type Phase,
   useMatchController,
 } from "../../match/useMatchController";
+import {
+  endGauntletRun,
+  getGauntletRun,
+  startGauntletRun,
+} from "../../../player/profileStore";
 
 const THEME = {
   panelBg: "#2c1c0e",
@@ -71,6 +76,17 @@ export default function GauntletMatch({
   useEffect(() => {
     remoteIntentRef.current = controller.handleRemoteIntent;
   }, [controller.handleRemoteIntent]);
+
+  useEffect(() => {
+    const activeRun = getGauntletRun();
+    if (!activeRun) {
+      startGauntletRun();
+    }
+
+    return () => {
+      endGauntletRun();
+    };
+  }, []);
 
   const {
     active,


### PR DESCRIPTION
## Summary
- ensure gauntlet matches seed an active gauntlet run when they mount so purchases can be recorded
- end the gauntlet run when the match unmounts to avoid leaving stale state behind

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cffdce5adc8332b2e89c879354d42d