### PR TITLE
Ensure gauntlet clones receive unique ids

### DIFF
--- a/src/player/profileStore.tsx
+++ b/src/player/profileStore.tsx
@@ -148,6 +148,7 @@ export function cloneCardForGauntlet(card: Card): Card {
   return setCardSourceId(
     {
       ...card,
+      id: nextCardId(),
       split: card.split ? cloneSplit(card.split) : undefined,
       activation: card.activation ? card.activation.map(cloneActivation) : undefined,
       reserve: card.reserve ? { ...card.reserve } : undefined,

--- a/tests/matchController.test.ts
+++ b/tests/matchController.test.ts
@@ -140,10 +140,16 @@ test("settleFighterAfterRound places shop purchases into hand before refilling",
   const purchases: Card[] = [purchasedCard];
 
   const afterNextRound = settleFighterAfterRound(fighter, [], purchases);
+  const drawnPurchase = afterNextRound.hand[0];
   assert.equal(
-    afterNextRound.hand[0]?.id,
-    purchasedCard.id,
+    drawnPurchase?.name,
+    purchasedCard.name,
     "shop purchases should be added to the front of the new hand",
+  );
+  assert.notEqual(
+    drawnPurchase?.id,
+    purchasedCard.id,
+    "purchased cards should receive new runtime ids when cloned",
   );
 
   const expectedFollowUps = startingDeck.slice(0, 4).map((card) => card.id);
@@ -195,10 +201,16 @@ test("shop purchases remain available for immediate resume processing", () => {
     [],
     queueRef.current.player.map((purchase) => purchase.card),
   );
+  const resumedCard = afterNextRound.hand.find((card) => card.name === purchase.card.name);
   assert.equal(
-    afterNextRound.hand.some((card) => card.id === purchase.card.id),
+    resumedCard !== undefined,
     true,
     "the purchased card should be present in hand when the round resumes",
+  );
+  assert.notEqual(
+    resumedCard?.id,
+    purchase.card.id,
+    "purchased cards should not reuse the shop offering id",
   );
 
   queueRef.current = { player: [], enemy: [] };
@@ -240,14 +252,20 @@ test("purchased cards are drawn even when the queue is cleared before state upda
 
   const purchasesForNextRound = drained.player.map((item) => item.card);
   const afterAdvance = settleFighterAfterRound(fighter, [], purchasesForNextRound);
+  const advancedCard = afterAdvance.hand[0];
   assert.equal(
-    afterAdvance.hand[0]?.id,
-    purchase.card.id,
+    advancedCard?.name,
+    purchase.card.name,
     "nextRoundCore should draw the purchased card into hand even when the queue cleared early",
+  );
+  assert.notEqual(
+    advancedCard?.id,
+    purchase.card.id,
+    "purchased cards drawn into hand should be assigned a new runtime id",
   );
 
   assert.equal(
-    afterAdvance.deck.some((card) => card.id === purchase.card.id),
+    afterAdvance.deck.some((card) => card.name === purchase.card.name),
     false,
     "purchased cards should not remain in the deck after being added to hand",
   );

--- a/tests/profileStore.test.ts
+++ b/tests/profileStore.test.ts
@@ -38,10 +38,16 @@ test("addPurchasedCardToFighter places a cloned card on top of the deck", () => 
   const withPurchase = addPurchasedCardToFighter(fighter, purchased);
 
   assert.equal(withPurchase.deck.length, 2, "purchased card should extend the deck");
+  const clonedPurchase = withPurchase.deck[0];
   assert.equal(
-    withPurchase.deck[0]?.id,
-    purchased.id,
+    clonedPurchase?.name,
+    purchased.name,
     "purchased card should be the next card drawn",
+  );
+  assert.notEqual(
+    clonedPurchase?.id,
+    purchased.id,
+    "purchased cards should be assigned new runtime ids",
   );
   assert.notEqual(
     withPurchase.deck[0],
@@ -51,7 +57,16 @@ test("addPurchasedCardToFighter places a cloned card on top of the deck", () => 
 
   const afterDraw = drawOne(withPurchase);
   const lastDrawn = afterDraw.hand.at(-1);
-  assert.equal(lastDrawn?.id, purchased.id, "purchased card should enter the hand on the next draw");
+  assert.equal(
+    lastDrawn?.name,
+    purchased.name,
+    "purchased card should enter the hand on the next draw",
+  );
+  assert.notEqual(
+    lastDrawn?.id,
+    purchased.id,
+    "drawn cards should not reuse the shop offering id",
+  );
 });
 
 test("drawOne pulls from the discard pile when the deck is empty", () => {


### PR DESCRIPTION
## Summary
- assign new runtime card ids when cloning gauntlet shop purchases
- update gauntlet-related tests to expect cloned cards with distinct runtime ids

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d01e47a1c08332b175c690b993bcca