### PR TITLE
Fix purchase hand insertion to use source IDs

### DIFF
--- a/src/game/match/useMatchController.ts
+++ b/src/game/match/useMatchController.ts
@@ -2263,15 +2263,16 @@ export function settleFighterAfterRound(
 
   const ensurePurchasesInHand = (value: Fighter): Fighter => {
     if (purchasedCards.length === 0) return value;
-    const purchaseIds = new Set(purchasedCards.map((card) => card.id));
+    const getCardKey = (card: Card) => getCardSourceId(card) ?? card.id;
+    const purchaseIds = new Set(purchasedCards.map((card) => getCardKey(card)));
     return {
       ...value,
       hand: [
         ...purchasedCards,
-        ...value.hand.filter((card) => !purchaseIds.has(card.id)),
+        ...value.hand.filter((card) => !purchaseIds.has(getCardKey(card))),
       ],
-      deck: value.deck.filter((card) => !purchaseIds.has(card.id)),
-      discard: value.discard.filter((card) => !purchaseIds.has(card.id)),
+      deck: value.deck.filter((card) => !purchaseIds.has(getCardKey(card))),
+      discard: value.discard.filter((card) => !purchaseIds.has(getCardKey(card))),
     };
   };
 


### PR DESCRIPTION
## Summary
- ensure settleFighterAfterRound removes existing purchased copies using source-aware keys
- always rebuild hand, deck, and discard filters using the same source-aware comparison

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d022d44cac83329f89b885eddff5aa