### PR TITLE
Add tactics solo mode with ability-only decks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ const ClassicMatch = lazy(() => import("./game/modes/classic/ClassicMatch"));
 const GauntletMatch = lazy(() => import("./game/modes/gauntlet/GauntletMatch"));
 
 export type AppProps =
-  | ({ mode: "classic" } & ClassicMatchProps)
+  | ({ mode: "classic" | "tactics" } & ClassicMatchProps)
   | ({ mode: "gauntlet" } & GauntletMatchProps);
 
 const MATCH_FALLBACK = <LoadingScreen />;
@@ -25,7 +25,7 @@ export default function App(props: AppProps) {
   const { mode: _mode, ...matchProps } = props;
   return (
     <Suspense fallback={MATCH_FALLBACK}>
-      <ClassicMatch {...matchProps} />
+      <ClassicMatch {...matchProps} mode={props.mode} />
     </Suspense>
   );
 }

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -19,7 +19,7 @@ type View =
   | { key: "soloMenu" }
   | { key: "mp" }
   | { key: "profile" }
-  | { key: "game"; mode: "classic" | "gauntlet" }
+  | { key: "game"; mode: "classic" | "gauntlet" | "tactics" }
   | { key: "game"; mode: "mp"; mpPayload?: MPStartPayload };
 
 export default function AppShell() {
@@ -32,6 +32,7 @@ export default function AppShell() {
   const goToProfile = useCallback(() => setView({ key: "profile" }), [setView]);
   const startClassic = useCallback(() => setView({ key: "game", mode: "classic" }), [setView]);
   const startGauntlet = useCallback(() => setView({ key: "game", mode: "gauntlet" }), [setView]);
+  const startTactics = useCallback(() => setView({ key: "game", mode: "tactics" }), [setView]);
 
   useEffect(() => {
     const handleNewRun = () => goToSoloMenu();
@@ -59,6 +60,7 @@ export default function AppShell() {
           onBack={goToHub}
           onSelectClassic={startClassic}
           onSelectGauntlet={startGauntlet}
+          onSelectTactics={startTactics}
         />
       </Suspense>
     );
@@ -126,10 +128,17 @@ export default function AppShell() {
     setMpPayload(null);
   };
 
+  const appMode =
+    view.mode === "gauntlet"
+      ? "gauntlet"
+      : view.mode === "tactics"
+        ? "tactics"
+        : "classic";
+
   return (
     <Suspense fallback={<LoadingScreen />}>
       <App
-        mode={view.mode === "gauntlet" ? "gauntlet" : "classic"}
+        mode={appMode}
         localSide={localSide}
         localPlayerId={localPlayerId}
         players={players}

--- a/src/SoloModeRoute.tsx
+++ b/src/SoloModeRoute.tsx
@@ -5,10 +5,11 @@ type SoloModeRouteProps = {
   onBack: () => void;
   onSelectClassic: () => void;
   onSelectGauntlet: () => void;
+  onSelectTactics: () => void;
 };
 
 type ModeOption = {
-  key: "classic" | "gauntlet";
+  key: "classic" | "gauntlet" | "tactics";
   title: string;
   subtitle: string;
   description: string;
@@ -19,6 +20,7 @@ export default function SoloModeRoute({
   onBack,
   onSelectClassic,
   onSelectGauntlet,
+  onSelectTactics,
 }: SoloModeRouteProps) {
   const options = useMemo<ModeOption[]>(
     () => [
@@ -38,8 +40,16 @@ export default function SoloModeRoute({
           "Tackle a run of consecutive encounters where every decision matters. Manage your roster between fights and see how far you can push your luck.",
         onSelect: onSelectGauntlet,
       },
+      {
+        key: "tactics",
+        title: "Tactics",
+        subtitle: "Command an ability-only arsenal in a duel of wits.",
+        description:
+          "Both sides begin with decks made entirely of ability cards. Master activations and outmaneuver Nemesis with precise tactical plays.",
+        onSelect: onSelectTactics,
+      },
     ],
-    [onSelectClassic, onSelectGauntlet]
+    [onSelectClassic, onSelectGauntlet, onSelectTactics]
   );
 
   const [selected, setSelected] = useState(0);

--- a/src/game/match/useMatchController.ts
+++ b/src/game/match/useMatchController.ts
@@ -24,6 +24,7 @@ import {
   recordMatchResult,
   rollStoreOfferings,
   buildGauntletDeckAsCards,
+  buildAbilityDeckAsCards,
   applyGauntletPurchase,
   type MatchResultSummary,
   type LevelProgress,
@@ -55,7 +56,7 @@ import {
 } from "./useMatchActivationPhase";
 import { useLatestRef } from "./useLatestRef";
 
-export type MatchMode = "classic" | "gauntlet";
+export type MatchMode = "classic" | "gauntlet" | "tactics";
 
 export type {
   LegacySide,
@@ -141,6 +142,7 @@ export function useMatchController({
 }: UseMatchControllerOptions) {
   const matchMode = mode;
   const isGauntletMode = matchMode === "gauntlet";
+  const isTacticsMode = matchMode === "tactics";
 
   const sendIntentRef = useRef(sendIntent);
   useEffect(() => {
@@ -210,10 +212,21 @@ export function useMatchController({
     return id;
   }, []);
 
-  const [player, setPlayer] = useState<Fighter>(() =>
-    isGauntletMode ? makeFighter("Wanderer", { deck: buildGauntletDeckAsCards() }) : makeFighter("Wanderer"),
-  );
-  const [enemy, setEnemy] = useState<Fighter>(() => makeFighter("Shade Bandit"));
+  const [player, setPlayer] = useState<Fighter>(() => {
+    if (isGauntletMode) {
+      return makeFighter("Wanderer", { deck: buildGauntletDeckAsCards() });
+    }
+    if (isTacticsMode) {
+      return makeFighter("Wanderer", { deck: buildAbilityDeckAsCards() });
+    }
+    return makeFighter("Wanderer");
+  });
+  const [enemy, setEnemy] = useState<Fighter>(() => {
+    if (isTacticsMode) {
+      return makeFighter("Shade Bandit", { deck: buildAbilityDeckAsCards() });
+    }
+    return makeFighter("Shade Bandit");
+  });
   const playerRef = useLatestRef(player);
   const enemyRef = useLatestRef(enemy);
 
@@ -1619,10 +1632,21 @@ const purchaseFromShop = useCallback(
     setFreezeLayout(false);
     setLockedWheelSize(null);
 
-    setPlayer(() =>
-      isGauntletMode ? makeFighter("Wanderer", { deck: buildGauntletDeckAsCards() }) : makeFighter("Wanderer"),
-    );
-    setEnemy(() => makeFighter("Shade Bandit"));
+    setPlayer(() => {
+      if (isGauntletMode) {
+        return makeFighter("Wanderer", { deck: buildGauntletDeckAsCards() });
+      }
+      if (isTacticsMode) {
+        return makeFighter("Wanderer", { deck: buildAbilityDeckAsCards() });
+      }
+      return makeFighter("Wanderer");
+    });
+    setEnemy(() => {
+      if (isTacticsMode) {
+        return makeFighter("Shade Bandit", { deck: buildAbilityDeckAsCards() });
+      }
+      return makeFighter("Shade Bandit");
+    });
 
     setInitiative(hostId ? hostLegacySide : localLegacySide);
 
@@ -1661,6 +1685,7 @@ const purchaseFromShop = useCallback(
     clearResolveVotes,
     generateWheelSet,
     isGauntletMode,
+    isTacticsMode,
     hostId,
     hostLegacySide,
     localLegacySide,

--- a/src/player/profileStore.tsx
+++ b/src/player/profileStore.tsx
@@ -435,6 +435,22 @@ const CARD_BLUEPRINT_MAP = new Map<string, CardBlueprint>(
 
 export const CARD_CATALOG: readonly CardBlueprint[] = CARD_BLUEPRINTS;
 
+export function buildAbilityDeckAsCards(deckSize = MAX_DECK_SIZE): Card[] {
+  const abilityPool = CARD_BLUEPRINTS.filter((entry) => entry.behavior);
+  if (!abilityPool.length) {
+    return starterDeck();
+  }
+
+  const cards: Card[] = [];
+  for (let i = 0; cards.length < deckSize; i += 1) {
+    const blueprint = abilityPool[i % abilityPool.length];
+    if (!blueprint) break;
+    cards.push(instantiateCard(blueprint));
+  }
+
+  return shuffle(cards);
+}
+
 const RARITY_WEIGHTS: Record<CardRarity, number> = {
   common: 8,
   uncommon: 4,


### PR DESCRIPTION
## Summary
- add a Tactics entry to the solo mode selection menu
- allow the app shell to launch Tactics games and forward the mode flag to ClassicMatch
- build ability-only decks for both fighters when playing the new Tactics mode

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d001d15f8c8332917fe1e82c5883b3