### PR TITLE
Add multi-lane combo evaluation and UI cues

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,6 +68,69 @@ type MPIntent =
   | { type: "rematch"; side: LegacySide }
   | { type: "reserve"; side: LegacySide; reserve: number; round: number };
 
+type ComboLaneResult = {
+  laneBonus: number[];
+  laneNotes: string[][];
+};
+
+function evaluateCombos(assignments: { player: (Card | null)[]; enemy: (Card | null)[] }):
+  Record<LegacySide, ComboLaneResult> {
+  const base: Record<LegacySide, ComboLaneResult> = {
+    player: { laneBonus: Array(assignments.player.length).fill(0), laneNotes: Array.from({ length: assignments.player.length }, () => [] as string[]) },
+    enemy: { laneBonus: Array(assignments.enemy.length).fill(0), laneNotes: Array.from({ length: assignments.enemy.length }, () => [] as string[]) },
+  };
+
+  (Object.keys(base) as LegacySide[]).forEach((side) => {
+    const slots = assignments[side];
+    const laneBonus = base[side].laneBonus;
+    const laneNotes = base[side].laneNotes;
+
+    const byCard = new Map<string, { card: Card; lanes: number[] }>();
+    const byNumber = new Map<number, { cards: Card[]; lanes: number[] }>();
+
+    slots.forEach((card, laneIdx) => {
+      if (!card) return;
+      if (!byCard.has(card.id)) byCard.set(card.id, { card, lanes: [] });
+      byCard.get(card.id)!.lanes.push(laneIdx);
+
+      if (isNormal(card)) {
+        if (!byNumber.has(card.number)) byNumber.set(card.number, { cards: [], lanes: [] });
+        const entry = byNumber.get(card.number)!;
+        entry.cards.push(card);
+        entry.lanes.push(laneIdx);
+      }
+    });
+
+    byCard.forEach(({ card, lanes }) => {
+      if (!card.multiLane || lanes.length <= 1) return;
+      const descriptor = card.linkDescriptors?.find((d) => d.kind === "lane");
+      const bonus = descriptor?.bonusSteps ?? 2;
+      const label = descriptor?.label ?? "Lane link";
+      lanes.forEach((laneIdx) => {
+        if (laneIdx >= laneBonus.length) return;
+        laneBonus[laneIdx] += bonus;
+        laneNotes[laneIdx].push(`${label} +${bonus}`);
+      });
+    });
+
+    byNumber.forEach(({ cards, lanes }, number) => {
+      if (lanes.length <= 1) return;
+      const descriptor = cards
+        .map((c) => c.linkDescriptors?.find((d) => d.kind === "numberMatch"))
+        .find((d): d is NonNullable<typeof d> => !!d);
+      const bonus = descriptor?.bonusSteps ?? 1;
+      const label = descriptor?.label ?? `Match ${fmtNum(number)}`;
+      lanes.forEach((laneIdx) => {
+        if (laneIdx >= laneBonus.length) return;
+        laneBonus[laneIdx] += bonus;
+        laneNotes[laneIdx].push(`${label} +${bonus}`);
+      });
+    });
+  });
+
+  return base;
+}
+
 // ---------------- Constants ----------------
 const MIN_WHEEL = 160;
 const MAX_WHEEL = 200;
@@ -408,6 +471,7 @@ function startPointerDrag(card: Card, e: React.PointerEvent) {
   useEffect(() => {
     assignRef.current = assign;
   }, [assign]);
+  const comboSummary = useMemo(() => evaluateCombos(assign), [assign]);
 
 const reserveReportsRef = useRef<
   Record<LegacySide, { reserve: number; round: number } | null>
@@ -485,6 +549,15 @@ const storeReserveReport = useCallback(
       const lane = side === "player" ? assignRef.current.player : assignRef.current.enemy;
       const prevAtLane = lane[laneIndex];
       const fromIdx = lane.findIndex((c) => c?.id === card.id);
+      const allowsMulti = !!card.multiLane;
+      const prevElsewhere = prevAtLane
+        ? lane.some((c, idx) => idx !== laneIndex && c?.id === prevAtLane.id)
+        : false;
+      const shouldReturnPrev = !!(
+        prevAtLane &&
+        prevAtLane.id !== card.id &&
+        !prevElsewhere
+      );
 
 
       if (prevAtLane && prevAtLane.id === card.id && fromIdx === laneIndex) {
@@ -501,25 +574,39 @@ const storeReserveReport = useCallback(
           const laneArr = isPlayer ? prev.player : prev.enemy;
           const nextLane = [...laneArr];
           const existingIdx = nextLane.findIndex((c) => c?.id === card.id);
-          if (existingIdx !== -1) nextLane[existingIdx] = null;
+          if (existingIdx !== -1 && (!allowsMulti || existingIdx === laneIndex)) {
+            nextLane[existingIdx] = null;
+          }
           nextLane[laneIndex] = card;
           return isPlayer ? { ...prev, player: nextLane } : { ...prev, enemy: nextLane };
         });
 
         if (isPlayer) {
           setPlayer((p) => {
-            let hand = p.hand.filter((c) => c.id !== card.id);
-            if (prevAtLane && prevAtLane.id !== card.id && !hand.some((c) => c.id === prevAtLane.id)) {
-              hand = [...hand, prevAtLane];
+            let hand = p.hand;
+            if (hand.some((c) => c.id === card.id)) {
+              hand = hand.filter((c) => c.id !== card.id);
             }
+            if (shouldReturnPrev && prevAtLane) {
+              if (!hand.some((c) => c.id === prevAtLane.id)) {
+                hand = [...hand, prevAtLane];
+              }
+            }
+            if (hand === p.hand) return p;
             return { ...p, hand };
           });
         } else {
           setEnemy((e) => {
-            let hand = e.hand.filter((c) => c.id !== card.id);
-            if (prevAtLane && prevAtLane.id !== card.id && !hand.some((c) => c.id === prevAtLane.id)) {
-              hand = [...hand, prevAtLane];
+            let hand = e.hand;
+            if (hand.some((c) => c.id === card.id)) {
+              hand = hand.filter((c) => c.id !== card.id);
             }
+            if (shouldReturnPrev && prevAtLane) {
+              if (!hand.some((c) => c.id === prevAtLane.id)) {
+                hand = [...hand, prevAtLane];
+              }
+            }
+            if (hand === e.hand) return e;
             return { ...e, hand };
           });
         }
@@ -542,6 +629,7 @@ const storeReserveReport = useCallback(
       const lane = side === "player" ? assignRef.current.player : assignRef.current.enemy;
       const prev = lane[laneIndex];
       if (!prev) return false;
+      const stillAssigned = lane.some((c, idx) => idx !== laneIndex && c?.id === prev.id);
 
       const isPlayer = side === "player";
 
@@ -556,12 +644,12 @@ const storeReserveReport = useCallback(
 
         if (isPlayer) {
           setPlayer((p) => {
-            if (p.hand.some((c) => c.id === prev.id)) return p;
+            if (stillAssigned || p.hand.some((c) => c.id === prev.id)) return p;
             return { ...p, hand: [...p.hand, prev] };
           });
         } else {
           setEnemy((e) => {
-            if (e.hand.some((c) => c.id === prev.id)) return e;
+            if (stillAssigned || e.hand.some((c) => c.id === prev.id)) return e;
             return { ...e, hand: [...e.hand, prev] };
           });
         }
@@ -745,18 +833,30 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
     // 🔸 show these during showEnemy/anim immediately
     setReserveSums({ player: pReserve, enemy: eReserve });
 
-    type Outcome = { steps: number; targetSlice: number; section: Section; winner: LegacySide | null; tie: boolean; wheel: number; detail: string };
+    type Outcome = { steps: number; targetSlice: number; section: Section; winner: LegacySide | null; tie: boolean; wheel: number; detail: string; comboNotes: string[] };
     const outcomes: Outcome[] = [];
+    const combosForResolve = evaluateCombos({
+      player: played.map((pe) => pe.p ?? null),
+      enemy: played.map((pe) => pe.e ?? null),
+    });
 
     for (let w = 0; w < 3; w++) {
       const secList = wheelSections[w];
       const baseP = (played[w].p?.number ?? 0);
       const baseE = (played[w].e?.number ?? 0);
-      const steps = ((baseP % SLICES) + (baseE % SLICES)) % SLICES;
+      const bonusP = combosForResolve.player.laneBonus[w] ?? 0;
+      const bonusE = combosForResolve.enemy.laneBonus[w] ?? 0;
+      const pVal = baseP + bonusP;
+      const eVal = baseE + bonusE;
+      const steps = (((pVal % SLICES) + (eVal % SLICES)) % SLICES + SLICES) % SLICES;
       const targetSlice = (tokens[w] + steps) % SLICES;
       const section = secList.find((s) => targetSlice !== 0 && inSection(targetSlice, s)) || ({ id: "Strongest", color: "transparent", start: 0, end: 0 } as Section);
 
-      const pVal = baseP; const eVal = baseE;
+      const comboNotes = [
+        ...((combosForResolve.player.laneNotes[w] ?? []).map((note) => `${namesByLegacy.player}: ${note}`)),
+        ...((combosForResolve.enemy.laneNotes[w] ?? []).map((note) => `${namesByLegacy.enemy}: ${note}`)),
+      ];
+
       let winner: LegacySide | null = null; let tie = false; let detail = "";
       switch (section.id) {
         case "Strongest": if (pVal === eVal) tie = true; else winner = pVal > eVal ? "player" : "enemy"; detail = `Strongest ${pVal} vs ${eVal}`; break;
@@ -774,7 +874,10 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
         case "Initiative": winner = initiative; detail = `Initiative -> ${winner}`; break;
         default: tie = true; detail = `Slice 0: no section`; break;
       }
-      outcomes.push({ steps, targetSlice, section, winner, tie, wheel: w, detail });
+      if (comboNotes.length) {
+        detail = `${detail} | ${comboNotes.join("; ")}`;
+      }
+      outcomes.push({ steps, targetSlice, section, winner, tie, wheel: w, detail, comboNotes });
     }
 
     const animateSpins = async () => {
@@ -1154,132 +1257,175 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
   // ---------------- UI ----------------
 
   const renderWheelPanel = (i: number) => {
-  const pc = assign.player[i];
-  const ec = assign.enemy[i];
+    const pc = assign.player[i];
+    const ec = assign.enemy[i];
 
-  const leftSlot = { side: "player" as const, card: pc, name: namesByLegacy.player };
-  const rightSlot = { side: "enemy" as const, card: ec, name: namesByLegacy.enemy };
+    const localNotes = comboSummary[localLegacySide].laneNotes[i] ?? [];
+    const remoteNotes = comboSummary[remoteLegacySide].laneNotes[i] ?? [];
+    const combinedComboNotes = [
+      ...localNotes.map((note) => `${namesByLegacy[localLegacySide]}: ${note}`),
+      ...((phase !== "choose") ? remoteNotes.map((note) => `${namesByLegacy[remoteLegacySide]}: ${note}`) : []),
+    ];
 
-  const ws = Math.round(lockedWheelSize ?? wheelSize);
-
-  const isLeftSelected = !!leftSlot.card && selectedCardId === leftSlot.card.id;
-  const isRightSelected = !!rightSlot.card && selectedCardId === rightSlot.card.id;
-
-  const shouldShowLeftCard =
-    !!leftSlot.card && (leftSlot.side === localLegacySide || phase !== "choose");
-  const shouldShowRightCard =
-    !!rightSlot.card && (rightSlot.side === localLegacySide || phase !== "choose");
-
-  // --- layout numbers that must match the classes below ---
-  const slotW    = 80;   // w-[80px] on both slots
-  const gapX     = 16;   // gap-2 => 8px, two gaps between three items => 16
-  const paddingX = 16;   // p-2 => 8px left + 8px right
-  const borderX  = 4;    // border-2 => 2px left + 2px right
-  const EXTRA_H  = 16;   // extra breathing room inside the panel (change to tweak height)
-
-  // panel width (border-box) so wheel is visually centered
-  const panelW = ws + slotW * 2 + gapX + paddingX + borderX;
-
-  const renderSlotCard = (slot: typeof leftSlot, isSlotSelected: boolean) => {
-    if (!slot.card) return null;
-    const card = slot.card;
-    const interactable = slot.side === localLegacySide && phase === "choose";
-
-    const handlePick = () => {
-      if (!interactable) return;
-      if (selectedCardId) {
-        tapAssignIfSelected();
-      } else {
-        setSelectedCardId(card.id);
+    let previewNotes: string[] = [];
+    if (phase === "choose" && active[i]) {
+      const candidateId = dragCardId ?? selectedCardId;
+      if (candidateId) {
+        const simulated = {
+          player: [...assign.player],
+          enemy: [...assign.enemy],
+        };
+        const isLocalPlayer = localLegacySide === "player";
+        const handSource = isLocalPlayer ? player.hand : enemy.hand;
+        const slotSource = isLocalPlayer ? assign.player : assign.enemy;
+        const card =
+          handSource.find((c) => c.id === candidateId) ||
+          slotSource.find((c) => c?.id === candidateId) ||
+          null;
+        if (card) {
+          const laneArr = isLocalPlayer ? simulated.player : simulated.enemy;
+          if (!card.multiLane) {
+            const existing = laneArr.findIndex((c) => c?.id === card.id);
+            if (existing !== -1) laneArr[existing] = null;
+          }
+          laneArr[i] = card;
+          const simSummary = evaluateCombos(simulated);
+          previewNotes = simSummary[localLegacySide].laneNotes[i] ?? [];
+        }
       }
+    }
+    const lanePreviewActive = previewNotes.length > 0;
+    const laneComboActive = localNotes.length > 0 || (phase !== "choose" && remoteNotes.length > 0);
+
+    const leftSlot = { side: "player" as const, card: pc, name: namesByLegacy.player };
+    const rightSlot = { side: "enemy" as const, card: ec, name: namesByLegacy.enemy };
+
+    const ws = Math.round(lockedWheelSize ?? wheelSize);
+
+    const isLeftSelected = !!leftSlot.card && selectedCardId === leftSlot.card.id;
+    const isRightSelected = !!rightSlot.card && selectedCardId === rightSlot.card.id;
+
+    const shouldShowLeftCard =
+      !!leftSlot.card && (leftSlot.side === localLegacySide || phase !== "choose");
+    const shouldShowRightCard =
+      !!rightSlot.card && (rightSlot.side === localLegacySide || phase !== "choose");
+
+    // --- layout numbers that must match the classes below ---
+    const slotW    = 80;   // w-[80px] on both slots
+    const gapX     = 16;   // gap-2 => 8px, two gaps between three items => 16
+    const paddingX = 16;   // p-2 => 8px left + 8px right
+    const borderX  = 4;    // border-2 => 2px left + 2px right
+    const EXTRA_H  = 16;   // extra breathing room inside the panel (change to tweak height)
+
+    // panel width (border-box) so wheel is visually centered
+    const panelW = ws + slotW * 2 + gapX + paddingX + borderX;
+
+    const renderSlotCard = (slot: typeof leftSlot, isSlotSelected: boolean) => {
+      if (!slot.card) return null;
+      const card = slot.card;
+      const interactable = slot.side === localLegacySide && phase === "choose";
+
+      const handlePick = () => {
+        if (!interactable) return;
+        if (selectedCardId) {
+          tapAssignIfSelected();
+        } else {
+          setSelectedCardId(card.id);
+        }
+      };
+
+      const handleDragStart = (e: React.DragEvent<HTMLButtonElement>) => {
+        if (!interactable) return;
+        setSelectedCardId(card.id);
+        setDragCardId(card.id);
+        try { e.dataTransfer.setData("text/plain", card.id); } catch {}
+        e.dataTransfer.effectAllowed = "move";
+      };
+
+      const handleDragEnd = () => {
+        setDragCardId(null);
+        setDragOverWheel(null);
+      };
+
+      const handlePointerDown = (e: React.PointerEvent<HTMLButtonElement>) => {
+        if (!interactable) return;
+        e.stopPropagation();
+        startPointerDrag(card, e);
+      };
+
+      return (
+        <StSCard
+          card={card}
+          size="sm"
+          disabled={!interactable}
+          selected={isSlotSelected}
+          onPick={handlePick}
+          draggable={interactable}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onPointerDown={handlePointerDown}
+        />
+      );
     };
 
-    const handleDragStart = (e: React.DragEvent<HTMLButtonElement>) => {
-      if (!interactable) return;
-      setSelectedCardId(card.id);
-      setDragCardId(card.id);
-      try { e.dataTransfer.setData("text/plain", card.id); } catch {}
-      e.dataTransfer.effectAllowed = "move";
-    };
+    const onZoneDragOver = (e: React.DragEvent) => { e.preventDefault(); if (dragCardId && active[i]) setDragOverWheel(i); };
+    const onZoneLeave = () => { if (dragCardId) setDragOverWheel(null); };
+    const handleDropCommon = (id: string | null, targetSide?: LegacySide) => {
+      if (!id || !active[i]) return;
+      const intendedSide = targetSide ?? localLegacySide;
+      if (intendedSide !== localLegacySide) {
+        setDragOverWheel(null);
+        setDragCardId(null);
+        return;
+      }
 
-    const handleDragEnd = () => {
-      setDragCardId(null);
+      const isLocalPlayer = localLegacySide === "player";
+      const fromHand = (isLocalPlayer ? player.hand : enemy.hand).find((c) => c.id === id);
+      const fromSlots = (isLocalPlayer ? assign.player : assign.enemy).find((c) => c && c.id === id) as Card | undefined;
+      const card = fromHand || fromSlots || null;
+      if (card) assignToWheelLocal(i, card as Card);
       setDragOverWheel(null);
+      setDragCardId(null);
+    };
+    const onZoneDrop = (e: React.DragEvent, targetSide?: LegacySide) => {
+      e.preventDefault();
+      handleDropCommon(e.dataTransfer.getData("text/plain") || dragCardId, targetSide);
     };
 
-    const handlePointerDown = (e: React.PointerEvent<HTMLButtonElement>) => {
-      if (!interactable) return;
-      e.stopPropagation();
-      startPointerDrag(card, e);
+    const tapAssignIfSelected = () => {
+      if (!selectedCardId) return;
+      const isLocalPlayer = localLegacySide === "player";
+      const card =
+        (isLocalPlayer ? player.hand : enemy.hand).find(c => c.id === selectedCardId) ||
+        (isLocalPlayer ? assign.player : assign.enemy).find(c => c?.id === selectedCardId) ||
+        null;
+      if (card) assignToWheelLocal(i, card as Card);
     };
+
+    const panelShadow = '0 2px 8px rgba(0,0,0,.28), inset 0 1px 0 rgba(255,255,255,.04)';
+    const borderColor = lanePreviewActive ? '#facc15' : laneComboActive ? '#fb923c' : THEME.panelBorder;
+    const shadowWithCombo = lanePreviewActive
+      ? `${panelShadow}, 0 0 12px rgba(250,204,21,0.35)`
+      : laneComboActive
+        ? `${panelShadow}, 0 0 10px rgba(249,115,22,0.28)`
+        : panelShadow;
 
     return (
-      <StSCard
-        card={card}
-        size="sm"
-        disabled={!interactable}
-        selected={isSlotSelected}
-        onPick={handlePick}
-        draggable={interactable}
-        onDragStart={handleDragStart}
-        onDragEnd={handleDragEnd}
-        onPointerDown={handlePointerDown}
-      />
-    );
-  };
-
-  const onZoneDragOver = (e: React.DragEvent) => { e.preventDefault(); if (dragCardId && active[i]) setDragOverWheel(i); };
-  const onZoneLeave = () => { if (dragCardId) setDragOverWheel(null); };
-  const handleDropCommon = (id: string | null, targetSide?: LegacySide) => {
-    if (!id || !active[i]) return;
-    const intendedSide = targetSide ?? localLegacySide;
-    if (intendedSide !== localLegacySide) {
-      setDragOverWheel(null);
-      setDragCardId(null);
-      return;
-    }
-
-    const isLocalPlayer = localLegacySide === "player";
-    const fromHand = (isLocalPlayer ? player.hand : enemy.hand).find((c) => c.id === id);
-    const fromSlots = (isLocalPlayer ? assign.player : assign.enemy).find((c) => c && c.id === id) as Card | undefined;
-    const card = fromHand || fromSlots || null;
-    if (card) assignToWheelLocal(i, card as Card);
-    setDragOverWheel(null);
-    setDragCardId(null);
-  };
-  const onZoneDrop = (e: React.DragEvent, targetSide?: LegacySide) => {
-    e.preventDefault();
-    handleDropCommon(e.dataTransfer.getData("text/plain") || dragCardId, targetSide);
-  };
-
-  const tapAssignIfSelected = () => {
-    if (!selectedCardId) return;
-    const isLocalPlayer = localLegacySide === "player";
-    const card =
-      (isLocalPlayer ? player.hand : enemy.hand).find(c => c.id === selectedCardId) ||
-      (isLocalPlayer ? assign.player : assign.enemy).find(c => c?.id === selectedCardId) ||
-      null;
-    if (card) assignToWheelLocal(i, card as Card);
-  };
-
-  const panelShadow = '0 2px 8px rgba(0,0,0,.28), inset 0 1px 0 rgba(255,255,255,.04)';
-
-  return (
-    <div
-      className="relative rounded-xl border p-2 shadow flex-none"
-      style={{
-        width: panelW,
-        height: ws + EXTRA_H,
-        background: `linear-gradient(180deg, rgba(255,255,255,.04) 0%, rgba(0,0,0,.14) 100%), ${THEME.panelBg}`,
-        borderColor: THEME.panelBorder,
-        borderWidth: 2,
-        boxShadow: panelShadow,
-        contain: 'paint',
-        backfaceVisibility: 'hidden',
-        transform: 'translateZ(0)',
-        isolation: 'isolate'
-      }}
-    >
+      <div
+        className="relative rounded-xl border p-2 shadow flex-none"
+        style={{
+          width: panelW,
+          height: ws + EXTRA_H,
+          background: `linear-gradient(180deg, rgba(255,255,255,.04) 0%, rgba(0,0,0,.14) 100%), ${THEME.panelBg}`,
+          borderColor,
+          borderWidth: 2,
+          boxShadow: shadowWithCombo,
+          contain: 'paint',
+          backfaceVisibility: 'hidden',
+          transform: 'translateZ(0)',
+          isolation: 'isolate'
+        }}
+      >
   {/* ADD: winner dots (don’t affect layout) */}
   { (phase === "roundEnd" || phase === "ended") && (
     <>
@@ -1403,6 +1549,17 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
               </div>}
         </div>
       </div>
+
+      {(laneComboActive || lanePreviewActive) && (
+        <div className="absolute left-2 right-2 bottom-2 text-[10px] leading-tight text-amber-100 space-y-0.5">
+          {combinedComboNotes.map((note, idx) => (
+            <div key={`combo-${i}-${idx}`} className="font-semibold drop-shadow">{note}</div>
+          ))}
+          {lanePreviewActive && previewNotes.map((note, idx) => (
+            <div key={`preview-${i}-${idx}`} className="italic text-amber-200/80">Preview: {note}</div>
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -25,6 +25,8 @@ export default memo(function StSCard({
   onPointerDown?: React.PointerEventHandler<HTMLButtonElement>;
 }) {
   const dims = size === "lg" ? { w: 120, h: 160 } : size === "md" ? { w: 92, h: 128 } : { w: 72, h: 96 };
+  const laneDescriptor = card.linkDescriptors?.find((d) => d.kind === "lane");
+  const matchDescriptor = card.linkDescriptors?.find((d) => d.kind === "numberMatch");
   return (
     <button
       onClick={(e) => { e.stopPropagation(); onPick?.(); }}
@@ -39,6 +41,20 @@ export default memo(function StSCard({
     >
       <div className="absolute inset-0 rounded-xl border bg-gradient-to-br from-slate-600 to-slate-800 border-slate-400"></div>
       <div className="absolute inset-px rounded-[10px] bg-slate-900/85 backdrop-blur-[1px] border border-slate-700/70" />
+      {(card.multiLane || card.linkDescriptors?.length) && (
+        <div className="absolute top-1 left-1 right-1 flex flex-wrap gap-0.5 justify-start">
+          {card.multiLane && (
+            <span className="px-1 py-px rounded-sm bg-amber-500/80 text-[9px] font-semibold text-stone-900 shadow">
+              {(laneDescriptor?.label ?? "Link").slice(0, 8)}
+            </span>
+          )}
+          {card.linkDescriptors?.some((d) => d.kind === "numberMatch") && (
+            <span className="px-1 py-px rounded-sm bg-emerald-500/80 text-[9px] font-semibold text-stone-900 shadow">
+              {(matchDescriptor?.label ?? "Match").slice(0, 8)}
+            </span>
+          )}
+        </div>
+      )}
       <div className="absolute inset-0 flex items-center justify-center">
         {isSplit(card) ? (
           <div className="text-xl font-extrabold text-white/90 leading-none text-center">

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -27,6 +27,16 @@ export type Players = Record<Side, PlayerCore>;
 
 export type TagId = "oddshift" | "parityflip" | "echoreserve";
 
+export type LinkKind = "lane" | "numberMatch";
+
+export type CardLinkDescriptor = {
+  kind: LinkKind;
+  key: string;
+  label: string;
+  bonusSteps: number;
+  description?: string;
+};
+
 export type CardType = "normal" | "split";
 
 export type Card = {
@@ -37,6 +47,8 @@ export type Card = {
   leftValue?: number;   // when type === "split"
   rightValue?: number;  // when type === "split"
   tags: TagId[];
+  multiLane?: boolean;
+  linkDescriptors?: CardLinkDescriptor[];
 };
 
 export type VC =

--- a/src/player/profileStore.tsx
+++ b/src/player/profileStore.tsx
@@ -307,6 +307,33 @@ const nextCardId = (() => { let i = 1; return () => `C${i++}`; })();
  *  - "num_X" explicit number alias
  * Anything else falls back to number 0.
  */
+function buildDescriptorsForNumber(num: number) {
+  const pretty = num < 0 ? `−${Math.abs(num)}` : `${num}`;
+  const linkDescriptors: Card["linkDescriptors"] = [];
+  let multiLane = false;
+
+  if (num % 3 === 0) {
+    multiLane = true;
+    linkDescriptors.push({
+      kind: "lane",
+      key: `triad-${num}`,
+      label: "Tri-Link",
+      bonusSteps: 2,
+      description: "Copy this card across lanes to add +2 steps each.",
+    });
+  }
+
+  linkDescriptors.push({
+    kind: "numberMatch",
+    key: `match-${num}`,
+    label: `Match ${pretty}`,
+    bonusSteps: 1,
+    description: `Pair ${pretty} on another lane to add +1 step.`,
+  });
+
+  return { multiLane, linkDescriptors };
+}
+
 function cardFromId(cardId: string): Card {
   let num = 0;
   const mBasic = /^basic_(\d+)$/.exec(cardId);
@@ -317,12 +344,15 @@ function cardFromId(cardId: string): Card {
   else if (mNeg) num = parseInt(mNeg[1], 10);
   else if (mNum) num = parseInt(mNum[1], 10);
 
+  const descriptors = buildDescriptorsForNumber(num);
+
   return {
     id: nextCardId(),
     name: `${num}`,
     type: "normal",
     number: num,
     tags: [],
+    ...descriptors,
   };
 }
 
@@ -340,13 +370,7 @@ export function buildActiveDeckAsCards(): Card[] {
 
 // ====== Runtime helpers (folded from your src/game/decks.ts) ======
 export function starterDeck(): Card[] {
-  const base: Card[] = Array.from({ length: 10 }, (_, n) => ({
-    id: nextCardId(),
-    name: `${n}`,
-    type: "normal",
-    number: n,
-    tags: [],
-  }));
+  const base: Card[] = Array.from({ length: 10 }, (_, n) => cardFromId(`basic_${n}`));
   return shuffle(base);
 }
 


### PR DESCRIPTION
## Summary
- Extend the card model with link descriptors and multi-lane support, and emit that metadata when constructing decks.
- Allow cards to occupy multiple lanes while keeping hands consistent and propagate combo bonuses into round outcomes.
- Surface combo badges and lane-level previews so players can spot active or potential links.

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d13878c06c8332902b5d21f322be95