### PR TITLE
Add gamble mechanics with All-In flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1081,16 +1081,6 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
       const roundWins: Record<LegacySide, number> = { player: 0, enemy: 0 };
       let swapCount = 0;
       outcomes.forEach((o) => 
-        const wheelLabel = `Wheel ${o.wheel + 1}`;
-        if (o.tie) {
-          appendLog(`${wheelLabel} tie: ${o.detail} — no win.`);
-          if (o.section.id === "SwapWins") {
-            swapCount += 1;
-            appendLog(`🔄 ${wheelLabel}: Round tallies will swap before scoring.`);
-
-          }
-          return;
-        }
 
         if (!o.winner) return;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1081,11 +1081,6 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
       const roundWins: Record<LegacySide, number> = { player: 0, enemy: 0 };
       let swapCount = 0;
       outcomes.forEach((o) => 
-
-        if (!o.winner) return;
-
-        hudColors[o.wheel] = HUD_COLORS[o.winner];
-
         const stake = laneWagers[o.wheel];
         let bonus = 0;
         const bonusParts: string[] = [];

--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -1,6 +1,7 @@
 // src/components/StSCard.tsx
 import React, { memo } from "react";
 import { Card } from "../game/types";
+import { getGambleBadges } from "../game/gamble";
 import { fmtNum, isSplit } from "../game/values";
 
 export default memo(function StSCard({
@@ -25,6 +26,7 @@ export default memo(function StSCard({
   onPointerDown?: React.PointerEventHandler<HTMLButtonElement>;
 }) {
   const dims = size === "lg" ? { w: 120, h: 160 } : size === "md" ? { w: 92, h: 128 } : { w: 72, h: 96 };
+  const gambleBadges = getGambleBadges(card);
   return (
     <button
       onClick={(e) => { e.stopPropagation(); onPick?.(); }}
@@ -48,6 +50,19 @@ export default memo(function StSCard({
           <div className="text-3xl font-extrabold text-white/90">{fmtNum(card.number as number)}</div>
         )}
       </div>
+      {gambleBadges.length > 0 && (
+        <div className="absolute inset-x-1 bottom-1 flex flex-wrap items-center justify-center gap-1">
+          {gambleBadges.map((meta) => (
+            <span
+              key={meta.id}
+              className="rounded-full bg-amber-500/20 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-amber-100 shadow"
+              title={meta.description}
+            >
+              {meta.badge}
+            </span>
+          ))}
+        </div>
+      )}
     </button>
   );
 });

--- a/src/game/gamble.ts
+++ b/src/game/gamble.ts
@@ -1,0 +1,133 @@
+import { Card, LegacySide, TagId } from "./types";
+
+export type GambleTagKind = "wager" | "coinflip" | "reroll" | "jackpot" | "legacy";
+
+export type GambleTagMeta = {
+  id: TagId;
+  kind: GambleTagKind;
+  label: string;
+  badge: string;
+  description: string;
+  stake?: number;
+};
+
+const BASE_TAG_META: Record<TagId, GambleTagMeta> = {
+  oddshift: {
+    id: "oddshift",
+    kind: "legacy",
+    label: "Oddshift",
+    badge: "Oddshift",
+    description: "Legacy effect."
+  },
+  parityflip: {
+    id: "parityflip",
+    kind: "legacy",
+    label: "Parity Flip",
+    badge: "Parity",
+    description: "Legacy effect."
+  },
+  echoreserve: {
+    id: "echoreserve",
+    kind: "legacy",
+    label: "Echo Reserve",
+    badge: "Echo",
+    description: "Legacy effect."
+  },
+  wager1: {
+    id: "wager1",
+    kind: "wager",
+    label: "Wager +1",
+    badge: "+1",
+    description: "Stake +1 bonus win on this wheel.",
+    stake: 1
+  },
+  wager2: {
+    id: "wager2",
+    kind: "wager",
+    label: "Wager +2",
+    badge: "+2",
+    description: "Stake +2 bonus wins on this wheel.",
+    stake: 2
+  },
+  wager3: {
+    id: "wager3",
+    kind: "wager",
+    label: "Wager +3",
+    badge: "+3",
+    description: "Stake +3 bonus wins on this wheel.",
+    stake: 3
+  },
+  coinflip: {
+    id: "coinflip",
+    kind: "coinflip",
+    label: "Coin Flip",
+    badge: "Flip",
+    description: "50% to double this card; 50% to bust."
+  },
+  reroll: {
+    id: "reroll",
+    kind: "reroll",
+    label: "Reroll",
+    badge: "Reroll",
+    description: "Swap this card's value for a wild reroll before resolve."
+  },
+  jackpot: {
+    id: "jackpot",
+    kind: "jackpot",
+    label: "Jackpot",
+    badge: "Jackpot",
+    description: "Feed the shared jackpot pot. Winner with Jackpot claims it all."
+  },
+};
+
+export const getTagMeta = (tag: TagId): GambleTagMeta | undefined => BASE_TAG_META[tag];
+
+export const getGambleBadges = (card: Card): GambleTagMeta[] =>
+  (card.tags ?? [])
+    .map((tag) => getTagMeta(tag))
+    .filter((meta): meta is GambleTagMeta => !!meta && meta.kind !== "legacy");
+
+export const getWagerStake = (tags: TagId[]): number =>
+  tags.reduce((sum, tag) => {
+    const meta = getTagMeta(tag);
+    if (meta?.kind === "wager" && typeof meta.stake === "number") {
+      return sum + meta.stake;
+    }
+    return sum;
+  }, 0);
+
+export const hasCoinFlip = (tags: TagId[]) => tags.some((tag) => getTagMeta(tag)?.kind === "coinflip");
+export const hasReroll = (tags: TagId[]) => tags.some((tag) => getTagMeta(tag)?.kind === "reroll");
+export const hasJackpot = (tags: TagId[]) => tags.some((tag) => getTagMeta(tag)?.kind === "jackpot");
+
+export const describeTagStake = (meta: GambleTagMeta, lane: number, sideName: string) => {
+  switch (meta.kind) {
+    case "wager":
+      return `${sideName} antes +${meta.stake} on wheel ${lane + 1}.`;
+    case "coinflip":
+      return `${sideName} flips for double-or-bust on wheel ${lane + 1}.`;
+    case "reroll":
+      return `${sideName} rerolls their value on wheel ${lane + 1}.`;
+    case "jackpot":
+      return `${sideName} feeds the jackpot on wheel ${lane + 1}.`;
+    default:
+      return `${sideName} readies ${meta.label}.`;
+  }
+};
+
+export const makeAllInCard = (power: number): Card => ({
+  id:
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `allin-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  name: "Jackpot Wild",
+  type: "normal",
+  number: power,
+  tags: ["wager3", "jackpot"],
+});
+
+export const summarizeGambleEvent = (
+  lane: number,
+  side: LegacySide,
+  text: string
+) => `Wheel ${lane + 1} · ${side === "player" ? "Player" : "Enemy"}: ${text}`;

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -25,7 +25,16 @@ export type PlayerCore = {
 };
 export type Players = Record<Side, PlayerCore>;
 
-export type TagId = "oddshift" | "parityflip" | "echoreserve";
+export type TagId =
+  | "oddshift"
+  | "parityflip"
+  | "echoreserve"
+  | "wager1"
+  | "wager2"
+  | "wager3"
+  | "coinflip"
+  | "reroll"
+  | "jackpot";
 
 export type CardType = "normal" | "split";
 

--- a/src/player/profileStore.tsx
+++ b/src/player/profileStore.tsx
@@ -2,7 +2,7 @@
 // to match your existing game types/functions.
 
 import { shuffle } from "../game/math";
-import type { Card, Fighter } from "../game/types";
+import type { Card, Fighter, TagId } from "../game/types";
 
 // ===== Local persistence types (module-scoped) =====
 type CardId = string;
@@ -307,6 +307,18 @@ const nextCardId = (() => { let i = 1; return () => `C${i++}`; })();
  *  - "num_X" explicit number alias
  * Anything else falls back to number 0.
  */
+function deriveGambleTags(num: number): TagId[] {
+  const tags = new Set<TagId>();
+  if (num <= 1) tags.add("coinflip");
+  if (num < 0) tags.add("coinflip");
+  if (num === 5 || num === 7) tags.add("reroll");
+  if (num >= 4 && num < 7) tags.add("wager1");
+  if (num >= 7 && num < 9) tags.add("wager2");
+  if (num >= 9) tags.add("wager3");
+  if (num >= 8) tags.add("jackpot");
+  return Array.from(tags);
+}
+
 function cardFromId(cardId: string): Card {
   let num = 0;
   const mBasic = /^basic_(\d+)$/.exec(cardId);
@@ -317,12 +329,14 @@ function cardFromId(cardId: string): Card {
   else if (mNeg) num = parseInt(mNeg[1], 10);
   else if (mNum) num = parseInt(mNum[1], 10);
 
+  const tags = deriveGambleTags(num);
+
   return {
     id: nextCardId(),
     name: `${num}`,
     type: "normal",
     number: num,
-    tags: [],
+    tags,
   };
 }
 
@@ -345,7 +359,7 @@ export function starterDeck(): Card[] {
     name: `${n}`,
     type: "normal",
     number: n,
-    tags: [],
+    tags: deriveGambleTags(n),
   }));
   return shuffle(base);
 }


### PR DESCRIPTION
## Summary
- add gamble tag metadata, extend card type identifiers, and surface gamble badges on hand cards
- assign gamble tags when building decks and implement once-per-match All-In that forges a jackpot wild and updates fighter state
- expand round resolution to handle wagers, coin flips, rerolls, and jackpot payouts while broadcasting results to HUD and logs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d138809c188332845c3311b900049f