### PR TITLE
Add match modes and timer-aware match flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,12 +28,14 @@ import { motion } from "framer-motion";
 import {
   SLICES,
   TARGET_WINS,
+  resolveMatchMode,
   type Side as TwoSide,
   type Card,
   type Section,
   type Fighter,
   type SplitChoiceMap,
   type Players,
+  type MatchModeId,
   LEGACY_FROM_SIDE,
 } from "./game/types";
 import { easeInOutCubic, inSection, createSeededRng } from "./game/math";
@@ -90,6 +92,8 @@ export default function ThreeWheel_WinsOnly({
   roomCode,
   hostId,
   targetWins,
+  modeId,
+  timerSeconds: timerSecondsProp,
   onExit,
 }: {
   localSide: TwoSide;
@@ -99,6 +103,8 @@ export default function ThreeWheel_WinsOnly({
   roomCode?: string;
   hostId?: string;
   targetWins?: number;
+  modeId?: MatchModeId;
+  timerSeconds?: number | null;
   onExit?: () => void;
 }) {
   const mountedRef = useRef(true);
@@ -119,10 +125,33 @@ export default function ThreeWheel_WinsOnly({
     enemy: players.right.name,
   };
 
-  const winGoal =
+  const sanitizedTargetWins =
     typeof targetWins === "number" && Number.isFinite(targetWins)
-      ? Math.max(1, Math.min(15, Math.round(targetWins)))
-      : TARGET_WINS;
+      ? Math.max(1, Math.min(25, Math.round(targetWins)))
+      : null;
+
+  const sanitizedTimerSeconds =
+    typeof timerSecondsProp === "number" && Number.isFinite(timerSecondsProp) && timerSecondsProp > 0
+      ? Math.max(1, Math.round(timerSecondsProp))
+      : null;
+
+  const matchMode = useMemo(() => {
+    const base = resolveMatchMode(modeId ?? null);
+    const wins = sanitizedTargetWins ?? base.targetWins ?? TARGET_WINS;
+    const timer =
+      sanitizedTimerSeconds !== null
+        ? sanitizedTimerSeconds
+        : typeof base.timerSeconds === "number" && base.timerSeconds > 0
+        ? Math.round(base.timerSeconds)
+        : null;
+    return { ...base, targetWins: wins, timerSeconds: timer };
+  }, [modeId, sanitizedTargetWins, sanitizedTimerSeconds]);
+
+  const winGoal = matchMode.targetWins;
+  const initialTimerSeconds =
+    typeof matchMode.timerSeconds === "number" && matchMode.timerSeconds > 0
+      ? matchMode.timerSeconds
+      : null;
 
 
   const hostLegacySide: LegacySide = (() => {
@@ -144,6 +173,9 @@ export default function ThreeWheel_WinsOnly({
   );
   const [wins, setWins] = useState<{ player: number; enemy: number }>({ player: 0, enemy: 0 });
   const [round, setRound] = useState(1);
+  const [remainingTimer, setRemainingTimer] = useState<number | null>(initialTimerSeconds);
+  const timerRemainingRef = useRef<number | null>(initialTimerSeconds);
+  const [finalWinMethod, setFinalWinMethod] = useState<"goal" | "timer" | null>(null);
 
   // Freeze layout during resolution
   const [freezeLayout, setFreezeLayout] = useState(false);
@@ -214,23 +246,83 @@ export default function ThreeWheel_WinsOnly({
   const [levelUpFlash, setLevelUpFlash] = useState(false);
   const hasRecordedResultRef = useRef(false);
 
+  const timerExpired =
+    initialTimerSeconds !== null && (remainingTimer ?? initialTimerSeconds) <= 0;
+
   const matchWinner: LegacySide | null =
-    wins.player >= winGoal ? "player" : wins.enemy >= winGoal ? "enemy" : null;
+    wins.player >= winGoal
+      ? "player"
+      : wins.enemy >= winGoal
+      ? "enemy"
+      : timerExpired && wins.player !== wins.enemy
+      ? wins.player > wins.enemy
+        ? "player"
+        : "enemy"
+      : null;
   const localWinsCount = localLegacySide === "player" ? wins.player : wins.enemy;
   const remoteWinsCount = localLegacySide === "player" ? wins.enemy : wins.player;
   const localWon = matchWinner ? matchWinner === localLegacySide : false;
   const winnerName = matchWinner ? namesByLegacy[matchWinner] : null;
   const localName = namesByLegacy[localLegacySide];
   const remoteName = namesByLegacy[remoteLegacySide];
+  const finalOutcomeMessage =
+    finalWinMethod === "timer"
+      ? localWon
+        ? "You led when the clock expired."
+        : `${winnerName ?? remoteName} led when the clock expired.`
+      : localWon
+      ? `You reached ${winGoal} wins.`
+      : `${winnerName ?? remoteName} reached ${winGoal} wins.`;
 
   useEffect(() => {
     setInitiative(hostId ? hostLegacySide : localLegacySide);
   }, [hostId, hostLegacySide, localLegacySide]);
 
   useEffect(() => {
+    setRemainingTimer(initialTimerSeconds);
+    timerRemainingRef.current = initialTimerSeconds;
+  }, [initialTimerSeconds, seed]);
+
+  useEffect(() => {
+    timerRemainingRef.current = remainingTimer;
+  }, [remainingTimer]);
+
+  useEffect(() => {
+    if (initialTimerSeconds === null) return;
+    const currentRemaining = timerRemainingRef.current ?? initialTimerSeconds;
+    if (currentRemaining === null || currentRemaining <= 0) return;
+    if (phase === "ended") return;
+
+    let prev = Date.now();
+    const id = window.setInterval(() => {
+      setRemainingTimer((prevSecs) => {
+        if (prevSecs === null) return prevSecs;
+        if (prevSecs <= 0) return 0;
+        const now = Date.now();
+        const diff = Math.max(1, Math.floor((now - prev) / 1000));
+        prev = now;
+        const next = Math.max(0, prevSecs - diff);
+        timerRemainingRef.current = next;
+        return next;
+      });
+    }, 1000);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [initialTimerSeconds, phase]);
+
+  useEffect(() => {
     if (phase === "ended") {
       if (!hasRecordedResultRef.current) {
-        const summary = recordMatchResult({ didWin: localWon });
+        const summary = recordMatchResult({
+          didWin: localWon,
+          modeId: matchMode.id,
+          modeLabel: matchMode.name,
+          targetWins: winGoal,
+          timerSeconds: initialTimerSeconds,
+          winMethod: finalWinMethod ?? (matchWinner ? "goal" : undefined),
+        });
         hasRecordedResultRef.current = true;
         setMatchSummary(summary);
 
@@ -267,7 +359,18 @@ export default function ThreeWheel_WinsOnly({
         setLevelUpFlash(false);
       }
     }
-  }, [phase, localWon, wins.player, wins.enemy]);
+  }, [
+    phase,
+    localWon,
+    wins.player,
+    wins.enemy,
+    matchMode.id,
+    matchMode.name,
+    winGoal,
+    initialTimerSeconds,
+    finalWinMethod,
+    matchWinner,
+  ]);
 
   const [handClearance, setHandClearance] = useState<number>(0);
 
@@ -838,16 +941,38 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
       setWins({ player: pWins, enemy: eWins });
       setReserveSums({ player: pReserve, enemy: eReserve });
       clearAdvanceVotes();
-      setPhase("roundEnd");
+      let winner: LegacySide | null = null;
+      let method: "goal" | "timer" | null = null;
       if (pWins >= winGoal || eWins >= winGoal) {
+        winner = pWins >= winGoal ? "player" : "enemy";
+        method = "goal";
+      } else {
+        const timerNow = timerRemainingRef.current ?? remainingTimer ?? initialTimerSeconds;
+        if (initialTimerSeconds !== null && (timerNow ?? 0) <= 0 && pWins !== eWins) {
+          winner = pWins > eWins ? "player" : "enemy";
+          method = "timer";
+        }
+      }
+
+      if (winner && method) {
         clearRematchVotes();
+        setFinalWinMethod(method);
         setPhase("ended");
-        const localWins = localLegacySide === "player" ? pWins : eWins;
-        appendLog(
-          localWins >= winGoal
-            ? "You win the match!"
-            : `${namesByLegacy[remoteLegacySide]} wins the match!`
-        );
+        if (method === "timer") {
+          const leadLog =
+            winner === localLegacySide
+              ? `Time expired — you led ${pWins}-${eWins}.`
+              : `Time expired — ${namesByLegacy[winner]} led ${pWins}-${eWins}.`;
+          appendLog(leadLog);
+        } else {
+          appendLog(
+            winner === localLegacySide
+              ? "You win the match!"
+              : `${namesByLegacy[remoteLegacySide]} wins the match!`
+          );
+        }
+      } else {
+        setPhase("roundEnd");
       }
     };
 
@@ -1053,6 +1178,10 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
 
     reserveReportsRef.current = { player: null, enemy: null };
 
+    setFinalWinMethod(null);
+    setRemainingTimer(initialTimerSeconds);
+    timerRemainingRef.current = initialTimerSeconds;
+
     wheelRefs.forEach((ref) => ref.current?.setVisualToken(0));
 
     setFreezeLayout(false);
@@ -1091,6 +1220,7 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
     clearAdvanceVotes,
     clearRematchVotes,
     clearResolveVotes,
+    initialTimerSeconds,
     generateWheelSet,
     hostId,
     hostLegacySide,
@@ -1112,6 +1242,8 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
     setWheelHUD,
     setWheelSections,
     setWins,
+    setFinalWinMethod,
+    setRemainingTimer,
     _setDragOverWheel,
     wheelRefs
   ]);
@@ -1504,6 +1636,20 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
 const HUDPanels = () => {
   const rsP = reserveSums ? reserveSums.player : null;
   const rsE = reserveSums ? reserveSums.enemy : null;
+  const timerSecondsRemaining = remainingTimer ?? initialTimerSeconds ?? 0;
+  const timerCritical =
+    initialTimerSeconds !== null && timerSecondsRemaining > 0
+      ? timerSecondsRemaining <= Math.max(15, Math.floor(initialTimerSeconds * 0.1))
+      : false;
+  const timerClass = timerExpired
+    ? "border-rose-500/80 bg-rose-600/20 text-rose-100"
+    : timerCritical
+    ? "border-amber-400/80 bg-amber-500/20 text-amber-100"
+    : "border-white/20 bg-black/40 text-slate-100";
+  const timerDisplay =
+    initialTimerSeconds !== null
+      ? formatTimerForDisplay(timerSecondsRemaining)
+      : "Off";
 
   const Panel = ({ side }: { side: LegacySide }) => {
     const isPlayer = side === 'player';
@@ -1594,6 +1740,18 @@ const HUDPanels = () => {
 
   return (
     <div className="w-full flex flex-col items-center">
+      <div className="mb-3 flex flex-wrap items-center justify-center gap-2 text-xs sm:text-sm">
+        <span className="rounded-full border border-white/20 bg-black/40 px-3 py-1 text-slate-100">
+          Mode: <span className="font-semibold">{matchMode.name}</span>
+        </span>
+        <span className="rounded-full border border-white/20 bg-black/40 px-3 py-1 text-slate-100">
+          Target: <span className="tabular-nums font-semibold">{winGoal}</span> wins
+        </span>
+        <span className={`rounded-full border px-3 py-1 font-mono text-sm sm:text-base ${timerClass}`}>
+          Timer: {timerDisplay}
+        </span>
+      </div>
+
       <div className="grid w-full max-w-[900px] grid-cols-2 items-stretch gap-2 overflow-x-hidden">
         <div className="min-w-0 w-full max-w-[420px] mx-auto h-full">
           <Panel side="player" />
@@ -1786,11 +1944,7 @@ const HUDPanels = () => {
             {localWon ? "Victory" : "Defeat"}
           </div>
 
-          <div className="text-sm text-slate-200">
-            {localWon
-              ? `You reached ${winGoal} wins.`
-              : `${winnerName ?? remoteName} reached ${winGoal} wins.`}
-          </div>
+          <div className="text-sm text-slate-200">{finalOutcomeMessage}</div>
 
           <div className="rounded-md border border-slate-700 bg-slate-800/80 px-4 py-3 text-sm text-slate-100">
             <div className="font-semibold tracking-wide uppercase text-xs text-slate-400">Final Score</div>
@@ -1800,6 +1954,23 @@ const HUDPanels = () => {
               <span className="text-slate-500">—</span>
               <span className="px-2 py-0.5 rounded bg-slate-900/60 text-slate-200 tabular-nums">{remoteWinsCount}</span>
               <span className="text-rose-300">{remoteName}</span>
+            </div>
+          </div>
+
+          <div className="rounded-md border border-slate-700 bg-slate-800/70 px-4 py-3 text-sm text-slate-200">
+            <div className="font-semibold uppercase tracking-wide text-xs text-slate-400">Match Settings</div>
+            <div className="mt-2 space-y-1">
+              <div>
+                {matchMode.name} · first to {winGoal} wins
+                {initialTimerSeconds
+                  ? ` · ${formatTimerForDisplay(initialTimerSeconds)} timer`
+                  : " · No timer"}
+              </div>
+              <div className="text-xs text-slate-300/80">
+                {finalWinMethod === "timer"
+                  ? "Decided by highest score when the clock expired."
+                  : "Decided by reaching the win target."}
+              </div>
             </div>
           </div>
 
@@ -1859,7 +2030,30 @@ const HUDPanels = () => {
   
       </div>
     );
+}
+
+function formatTimerForDisplay(seconds: number | null | undefined): string {
+  if (typeof seconds !== "number" || !Number.isFinite(seconds)) {
+    return "No timer";
   }
+  const total = Math.floor(seconds);
+  if (total <= 0) {
+    return "0:00";
+  }
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const secs = total % 60;
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, "0")}:${secs
+      .toString()
+      .padStart(2, "0")}`;
+  }
+  const mins = Math.floor(total / 60);
+  if (mins > 0) {
+    return `${mins}:${secs.toString().padStart(2, "0")}`;
+  }
+  return `${secs}s`;
+}
 
 // ---------------- Dev Self-Tests (lightweight) ----------------
 if (typeof window !== 'undefined') {

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -4,7 +4,7 @@ import type { Realtime } from "ably";
 import App from "./App";
 import HubRoute from "./HubRoute";
 import MultiplayerRoute from "./MultiplayerRoute";
-import type { Players, Side } from "./game/types";
+import type { MatchModeId, Players, Side } from "./game/types";
 import ProfilePage from "./ProfilePage";
 
 type MPStartPayload = Parameters<
@@ -63,7 +63,13 @@ export default function AppShell() {
   let players: Players;
   let localSide: Side;
   let localPlayerId: string;
-  let extraProps: { roomCode?: string; hostId?: string; targetWins?: number } = {};
+  let extraProps: {
+    roomCode?: string;
+    hostId?: string;
+    targetWins?: number;
+    modeId?: MatchModeId;
+    timerSeconds?: number | null;
+  } = {};
 
   if (view.mode === "mp" && (view.mpPayload ?? mpPayload)) {
     const mp = (view.mpPayload ?? mpPayload)!;
@@ -71,7 +77,13 @@ export default function AppShell() {
     players = mp.players;
     localSide = mp.localSide;
     localPlayerId = mp.players[localSide].id;
-    extraProps = { roomCode: mp.roomCode, hostId: mp.hostId, targetWins: mp.targetWins };
+    extraProps = {
+      roomCode: mp.roomCode,
+      hostId: mp.hostId,
+      targetWins: mp.targetWins,
+      modeId: mp.modeId,
+      timerSeconds: mp.timerSeconds,
+    };
   } else {
     seed = Math.floor(Math.random() * 2 ** 31);
     players = {

--- a/src/MultiplayerRoute.tsx
+++ b/src/MultiplayerRoute.tsx
@@ -1,9 +1,16 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Realtime } from "ably";
 import type { PresenceMessage } from "ably";
-import { TARGET_WINS, type Players, type Side } from "./game/types";
+import {
+  MATCH_MODE_PRESETS,
+  DEFAULT_MATCH_MODE_ID,
+  resolveMatchMode,
+  type MatchModeId,
+  type Players,
+  type Side,
+} from "./game/types";
 
-// ----- Start payload now includes targetWins (wins goal) -----
+// ----- Start payload now includes match settings -----
 type StartMessagePayload = {
   roomCode: string;
   seed: number;
@@ -11,6 +18,8 @@ type StartMessagePayload = {
   players: Players;          // { left: {id,name,color}, right: {…} }
   playersArr?: { clientId: string; name: string }[]; // optional: raw list for debugging
   targetWins: number;        // 👈 merged feature: game wins goal
+  modeId: MatchModeId;
+  timerSeconds: number | null;
 };
 
 type StartPayload = StartMessagePayload & {
@@ -39,9 +48,15 @@ export default function MultiplayerRoute({
   const [name, setName] = useState<string>(() => defaultName());
   const [status, setStatus] = useState<string>("");
 
-  // Rounds to win (host controls)
-  const [targetWins, setTargetWins] = useState<number>(TARGET_WINS);
-  const [targetWinsInput, setTargetWinsInput] = useState<string>(String(TARGET_WINS));
+  // Match mode (host controls)
+  const [selectedModeId, setSelectedModeId] = useState<MatchModeId>(DEFAULT_MATCH_MODE_ID);
+  const selectedMode = MATCH_MODE_PRESETS[selectedModeId] ?? MATCH_MODE_PRESETS[DEFAULT_MATCH_MODE_ID];
+  const modeOptions = useMemo(() => Object.values(MATCH_MODE_PRESETS), []);
+  const selectedTargetWins = selectedMode.targetWins;
+  const selectedTimerSeconds =
+    typeof selectedMode.timerSeconds === "number" && selectedMode.timerSeconds > 0
+      ? Math.round(selectedMode.timerSeconds)
+      : null;
 
   // ---- Ably core refs ----
   const ablyRef = useRef<Realtime | null>(null);
@@ -49,7 +64,7 @@ export default function MultiplayerRoute({
 
   // members list (UI) and authoritative presence map
   const [members, setMembers] = useState<
-    { clientId: string; name: string; targetWins?: number }[]
+    { clientId: string; name: string; modeId?: MatchModeId }[]
   >([]);
   const clientId = useMemo(() => uid4(), []);
 
@@ -57,11 +72,11 @@ export default function MultiplayerRoute({
     clientId: string;
     name: string;
     ts: number;
-    targetWins?: number;
+    modeId?: MatchModeId;
   };
   const memberMapRef = useRef<Map<string, MemberEntry>>(new Map());
 
-  // Commit member map -> UI array; also sync host's targetWins to all clients
+  // Commit member map -> UI array; also sync host's match mode to all clients
   const commitMembers = useCallback((map: Map<string, MemberEntry>) => {
     const ordered = Array.from(map.values()).sort((a, b) => {
       if (a.ts !== b.ts) return a.ts - b.ts;
@@ -69,16 +84,17 @@ export default function MultiplayerRoute({
     });
 
     setMembers(
-      ordered.map(({ clientId, name, targetWins }) => ({ clientId, name, targetWins }))
+      ordered.map(({ clientId, name, modeId }) => ({ clientId, name, modeId }))
     );
 
-    // host is first; mirror host's wins goal locally
+    // host is first; mirror host's mode locally
     const host = ordered[0];
-    const hostTargetWins = host?.targetWins;
-    if (typeof hostTargetWins === "number" && Number.isFinite(hostTargetWins)) {
-      setTargetWins(clampTargetWins(hostTargetWins));
+    const hostModeId = host?.modeId;
+    if (hostModeId) {
+      const resolved = resolveMatchMode(hostModeId).id;
+      setSelectedModeId(resolved);
     }
-  }, []);
+  }, [setSelectedModeId]);
 
   const applySnapshot = useCallback(
   (list: PresenceMessage[] | undefined | null) => {
@@ -89,7 +105,7 @@ export default function MultiplayerRoute({
       for (const msg of list) {
         if (!msg?.clientId) continue;
         const data = (msg.data ?? {}) as any;
-        const rawTargetWins = data?.targetWins;
+        const rawModeId = typeof data?.modeId === "string" ? data.modeId : undefined;
         const prev = prevMap.get(msg.clientId);
         const serverTs = typeof msg.timestamp === "number" ? msg.timestamp : undefined;
         const ts =
@@ -103,10 +119,10 @@ export default function MultiplayerRoute({
           clientId: msg.clientId,
           name: data?.name ?? "Player",
           ts,
-          targetWins:
-            typeof rawTargetWins === "number" && Number.isFinite(rawTargetWins)
-              ? clampTargetWins(rawTargetWins)
-              : prev?.targetWins,
+          modeId:
+            rawModeId !== undefined
+              ? resolveMatchMode(rawModeId).id
+              : prev?.modeId ?? DEFAULT_MATCH_MODE_ID,
         });
       }
     }
@@ -148,16 +164,16 @@ export default function MultiplayerRoute({
       })();
 
       const name = data?.name ?? existing?.name ?? "Player";
-      const rawTargetWins = data?.targetWins;
-      const memberTargetWins =
-        typeof rawTargetWins === "number" && Number.isFinite(rawTargetWins)
-          ? clampTargetWins(rawTargetWins)
-          : existing?.targetWins;
+      const rawModeId = typeof data?.modeId === "string" ? data.modeId : undefined;
+      const memberModeId =
+        rawModeId !== undefined
+          ? resolveMatchMode(rawModeId).id
+          : existing?.modeId ?? DEFAULT_MATCH_MODE_ID;
 
       if (action === "leave" || action === "absent") {
         map.delete(msg.clientId);
       } else if (action === "enter" || action === "present" || action === "update") {
-        map.set(msg.clientId, { clientId: msg.clientId, name, ts, targetWins: memberTargetWins });
+        map.set(msg.clientId, { clientId: msg.clientId, name, ts, modeId: memberModeId });
       }
 
       memberMapRef.current = map;
@@ -257,8 +273,8 @@ export default function MultiplayerRoute({
       presenceListenerRef.current = onPresence;
       chan.presence.subscribe(onPresence);
 
-// 3) Enter presence with the current name and targetWins
-await chan.presence.enter({ name, targetWins });
+// 3) Enter presence with the current name and match mode
+await chan.presence.enter({ name, modeId: selectedModeId });
 
 // Seed self immediately so the UI shows the host right away
 {
@@ -266,7 +282,7 @@ await chan.presence.enter({ name, targetWins });
     clientId,
     name,
     ts: Date.now(),
-    targetWins,
+    modeId: selectedModeId,
   };
   const map = new Map<string, MemberEntry>([[clientId, self]]);
   memberMapRef.current = map;
@@ -361,24 +377,19 @@ await refreshMembers(chan);
     return false;
   }
 
-  // Keep the input string mirrored to state if host changes wins elsewhere
-  useEffect(() => {
-    setTargetWinsInput(targetWins.toString());
-  }, [targetWins]);
-
-  // If name/targetWins change while in-room, update presence & local cache
+  // If name/mode change while in-room, update presence & local cache
   useEffect(() => {
     (async () => {
       if (mode === "in-room" && channelRef.current) {
         try {
-          await channelRef.current.presence.update({ name, targetWins });
+          await channelRef.current.presence.update({ name, modeId: selectedModeId });
 
           const current = memberMapRef.current.get(clientId);
           const map = new Map(memberMapRef.current);
           map.set(clientId, {
             clientId,
             name,
-            targetWins,
+            modeId: selectedModeId,
             ts: current?.ts ?? Date.now(),
           });
           memberMapRef.current = map;
@@ -386,7 +397,7 @@ await refreshMembers(chan);
         } catch { /* no-op */ }
       }
     })();
-  }, [clientId, commitMembers, mode, name, targetWins]);
+  }, [clientId, commitMembers, mode, name, selectedModeId]);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -465,8 +476,7 @@ await refreshMembers(chan);
     setMode("idle");
     setRoomCode("");
     setJoinCode("");
-    setTargetWins(TARGET_WINS);
-    setTargetWinsInput(TARGET_WINS.toString());
+    setSelectedModeId(DEFAULT_MATCH_MODE_ID);
   }
 
   async function onStartGame() {
@@ -479,7 +489,8 @@ await refreshMembers(chan);
     // --- Assign sides deterministically: host=left, first joiner=right
     const players = assignSides(members);
 
-    const winsGoal = clampTargetWins(targetWins);
+    const winsGoal = selectedTargetWins;
+    const timerSeconds = selectedTimerSeconds;
     const seed = Math.floor(Math.random() * 2 ** 31);
     const payload: StartMessagePayload = {
       roomCode,
@@ -488,38 +499,13 @@ await refreshMembers(chan);
       hostId: members[0].clientId, // first in presence is host
       playersArr: members,         // optional, for debugging/analytics
       targetWins: winsGoal,        // 👈 pass wins goal into the game
+      modeId: selectedMode.id,
+      timerSeconds,
     };
 
     await channelRef.current?.publish("start", payload);
     // Host will also receive the 'start' event and flow through subscribe handler
   }
-
-  // --- host-only input handlers for “Rounds to win” ---
-  const handleTargetWinsChange = useCallback((value: string) => {
-    // only digits (allow empty while typing)
-    if (!/^\d*$/.test(value)) return;
-    setTargetWinsInput(value);
-    if (value === "") return;
-
-    const parsed = Number.parseInt(value, 10);
-    if (Number.isFinite(parsed)) {
-      setTargetWins(clampTargetWins(parsed));
-    }
-  }, []);
-
-  const handleTargetWinsBlur = useCallback(() => {
-    if (targetWinsInput === "") {
-      setTargetWins(TARGET_WINS);
-      setTargetWinsInput(TARGET_WINS.toString());
-      return;
-    }
-    const parsed = Number.parseInt(targetWinsInput, 10);
-    if (Number.isFinite(parsed)) {
-      const clamped = clampTargetWins(parsed);
-      setTargetWins(clamped);
-      setTargetWinsInput(clamped.toString());
-    }
-  }, [targetWinsInput]);
 
   return (
     <div className="min-h-screen grid place-items-center bg-slate-950 text-slate-100 p-4">
@@ -588,26 +574,50 @@ await refreshMembers(chan);
             </div>
 
             <div className="rounded-lg bg-black/30 px-3 py-2 ring-1 ring-white/10">
-              <div className="text-sm opacity-80 mb-1">Rounds to win</div>
-              <div className="flex items-center gap-2">
-                <input
-                  type="number"
-                  inputMode="numeric"
-                  pattern="[0-9]*"
-                  min={1}
-                  max={25}
-                  disabled={!isHost}
-                  className="w-24 rounded-lg bg-black/40 px-3 py-2 text-center ring-1 ring-white/10 disabled:opacity-60"
-                  value={targetWinsInput}
-                  onChange={(e) => handleTargetWinsChange(e.target.value)}
-                  onBlur={handleTargetWinsBlur}
-                />
+              <div className="mb-1 flex items-center justify-between text-sm opacity-80">
+                <span>Match mode</span>
                 {!isHost && (
                   <span className="rounded bg-white/10 px-2 py-0.5 text-xs">Host controls this</span>
                 )}
               </div>
+              <div className="grid gap-2">
+                {modeOptions.map((mode) => {
+                  const isSelected = selectedModeId === mode.id;
+                  const timerLabel = formatModeTimer(mode.timerSeconds);
+                  return (
+                    <label
+                      key={mode.id}
+                      className={`flex cursor-pointer items-start gap-2 rounded-lg border px-3 py-2 text-left transition ${
+                        isSelected ? "border-amber-400/80 bg-amber-400/10" : "border-white/10 bg-black/30 hover:border-white/20"
+                      } ${!isHost ? "cursor-default opacity-90" : ""}`}
+                    >
+                      <input
+                        type="radio"
+                        name="match-mode"
+                        className="mt-1"
+                        checked={isSelected}
+                        onChange={() => {
+                          if (!isHost) return;
+                          setSelectedModeId(mode.id);
+                        }}
+                        disabled={!isHost}
+                      />
+                      <div className="flex flex-col gap-0.5">
+                        <div className="text-sm font-semibold text-white">
+                          {mode.name}
+                        </div>
+                        <div className="text-xs text-white/80">
+                          {mode.targetWins} wins · {timerLabel}
+                        </div>
+                        <div className="text-[11px] text-white/60">{mode.description}</div>
+                      </div>
+                    </label>
+                  );
+                })}
+              </div>
               <div className="mt-1 text-xs opacity-70">
-                First player to reach {targetWins} round wins takes the match.
+                Selected: {selectedMode.name} — first to {selectedTargetWins} wins
+                {selectedTimerSeconds ? ` with a ${formatModeTimer(selectedTimerSeconds)} timer.` : " with no timer."}
               </div>
             </div>
 
@@ -680,11 +690,17 @@ function defaultName() {
   return `Player ${animals[Math.floor(Math.random() * animals.length)]}`;
 }
 
-function clampTargetWins(value: number) {
-  if (!Number.isFinite(value)) return TARGET_WINS;
-  const rounded = Math.round(value);
-  const clamped = Math.max(1, Math.min(25, rounded));
-  return clamped;
+function formatModeTimer(seconds: number | null | undefined): string {
+  if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds <= 0) {
+    return "No timer";
+  }
+  const total = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(total / 60);
+  const secs = total % 60;
+  if (minutes > 0) {
+    return `${minutes}:${secs.toString().padStart(2, "0")}`;
+  }
+  return `${secs}s`;
 }
 
 // Assign sides from presence order (host=left, first joiner=right)

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -2,6 +2,50 @@
 export const SLICES = 16 as const;
 export const TARGET_WINS = 7 as const;
 
+export type MatchModeId = "short" | "standard" | "marathon";
+
+export type MatchModeConfig = {
+  id: MatchModeId;
+  name: string;
+  description: string;
+  targetWins: number;
+  timerSeconds?: number | null;
+};
+
+export const DEFAULT_MATCH_MODE_ID: MatchModeId = "standard";
+
+export const MATCH_MODE_PRESETS: Record<MatchModeId, MatchModeConfig> = {
+  short: {
+    id: "short",
+    name: "Short",
+    description: "Quick race to three wins with a brisk timer.",
+    targetWins: 3,
+    timerSeconds: 180,
+  },
+  standard: {
+    id: "standard",
+    name: "Standard",
+    description: "Classic target of seven wins and no clock.",
+    targetWins: TARGET_WINS,
+    timerSeconds: null,
+  },
+  marathon: {
+    id: "marathon",
+    name: "Marathon",
+    description: "Extended match to eleven wins with a long clock.",
+    targetWins: 11,
+    timerSeconds: 1200,
+  },
+};
+
+export function resolveMatchMode(id: string | null | undefined): MatchModeConfig {
+  if (!id) return MATCH_MODE_PRESETS[DEFAULT_MATCH_MODE_ID];
+  if (id in MATCH_MODE_PRESETS) {
+    return MATCH_MODE_PRESETS[id as MatchModeId];
+  }
+  return MATCH_MODE_PRESETS[DEFAULT_MATCH_MODE_ID];
+}
+
 /** New canonical sides for 2P */
 export type Side = "left" | "right";
 

--- a/src/player/profileStore.tsx
+++ b/src/player/profileStore.tsx
@@ -2,7 +2,7 @@
 // to match your existing game types/functions.
 
 import { shuffle } from "../game/math";
-import type { Card, Fighter } from "../game/types";
+import type { Card, Fighter, MatchModeId } from "../game/types";
 
 // ===== Local persistence types (module-scoped) =====
 type CardId = string;
@@ -172,9 +172,24 @@ export type MatchResultSummary = {
   after: LevelProgress;
   segments: LevelProgressSegment[];
   levelUps: number;
+  modeId?: MatchModeId;
+  modeLabel?: string;
+  targetWins?: number;
+  timerSeconds?: number | null;
+  winMethod?: "goal" | "timer";
 };
 
-export function recordMatchResult({ didWin }: { didWin: boolean }): MatchResultSummary {
+type RecordMatchOptions = {
+  didWin: boolean;
+  modeId?: MatchModeId;
+  modeLabel?: string;
+  targetWins?: number;
+  timerSeconds?: number | null;
+  winMethod?: "goal" | "timer";
+};
+
+export function recordMatchResult(options: RecordMatchOptions): MatchResultSummary {
+  const { didWin, modeId, modeLabel, targetWins, timerSeconds, winMethod } = options;
   const state = loadStateRaw();
   const profile = state.profile;
   const before = toLevelProgress(profile);
@@ -229,6 +244,11 @@ export function recordMatchResult({ didWin }: { didWin: boolean }): MatchResultS
     after,
     segments,
     levelUps,
+    modeId,
+    modeLabel,
+    targetWins,
+    timerSeconds: timerSeconds ?? null,
+    winMethod,
   };
 }
 


### PR DESCRIPTION
## Summary
- add reusable match mode presets to the shared game types and progression summary data
- replace the multiplayer lobby win target input with named presets that sync countdown timer settings to all clients
- teach the core app to track optional countdown timers, honor score-based wins on expiration, and surface mode/timer info in the HUD and results

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d13879e4d083329e0daa27c9675cb6