### PR TITLE
Add progression systems, challenges, and multiplayer stats

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -398,9 +398,6 @@ export default function ThreeWheel_WinsOnly({
   const winnerName = matchWinner ? namesByLegacy[matchWinner] : null;
   const localName = namesByLegacy[localLegacySide];
   const remoteName = namesByLegacy[remoteLegacySide];
-
-  const matchMode: "solo" | "coop" | "versus" = isMultiplayer ? "versus" : "solo";
-
   const finalOutcomeMessage =
     finalWinMethod === "timer"
       ? localWon

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,7 @@ import {
   refillTo,
   freshFive,
   recordMatchResult,
-  getUnlockedWheelArchetypes,
+  getWheelLoadout,
   applySharedStatsFromNetwork,
   applyCoopObjectivesSnapshot,
   applyLeaderboardSnapshot,
@@ -89,20 +89,6 @@ const THEME = {
   slotBorder:'#7a5a33',
   brass:     '#b68a4e',
   textWarm:  '#ead9b9',
-};
-
-const WHEEL_COUNT = 3;
-const normalizeWheelLoadout = (list: WheelArchetype[]): WheelArchetype[] => {
-  const source = list.length ? [...list] : ["bandit"];
-  const out: WheelArchetype[] = [];
-  for (const arch of source) {
-    if (out.length >= WHEEL_COUNT) break;
-    out.push(arch);
-  }
-  while (out.length < WHEEL_COUNT) {
-    out.push(out[out.length - 1] ?? "bandit");
-  }
-  return out.slice(0, WHEEL_COUNT);
 };
 
 // ---------------- Main Component ----------------
@@ -151,7 +137,7 @@ export default function ThreeWheel_WinsOnly({
 
   const [sharedStatsState, setSharedStatsState] = useState<SharedStats>(() => getSharedStats());
   const [coopObjectivesState, setCoopObjectivesState] = useState<CoopObjective[]>(() => getCoopObjectives());
-  const [wheelLoadout, setWheelLoadout] = useState<WheelArchetype[]>(() => normalizeWheelLoadout(getUnlockedWheelArchetypes()));
+  const [wheelLoadout, setWheelLoadout] = useState<WheelArchetype[]>(() => getWheelLoadout());
 
   useEffect(() => {
     if (sharedStatsSnapshot) {
@@ -300,7 +286,7 @@ export default function ThreeWheel_WinsOnly({
         setMatchSummary(summary);
 
         if (summary.unlockedArchetypes?.length) {
-          setWheelLoadout(normalizeWheelLoadout(getUnlockedWheelArchetypes()));
+          setWheelLoadout(getWheelLoadout());
         }
         setSharedStatsState(getSharedStats());
         setCoopObjectivesState(getCoopObjectives());

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -6,6 +6,7 @@ import HubRoute from "./HubRoute";
 import MultiplayerRoute from "./MultiplayerRoute";
 import type { Players, Side } from "./game/types";
 import ProfilePage from "./ProfilePage";
+import type { SharedStats, CoopObjective, LeaderboardEntry } from "./player/profileStore";
 
 type MPStartPayload = Parameters<
   NonNullable<React.ComponentProps<typeof MultiplayerRoute>["onStart"]>
@@ -63,7 +64,14 @@ export default function AppShell() {
   let players: Players;
   let localSide: Side;
   let localPlayerId: string;
-  let extraProps: { roomCode?: string; hostId?: string; targetWins?: number } = {};
+  let extraProps: {
+    roomCode?: string;
+    hostId?: string;
+    targetWins?: number;
+    sharedStatsSnapshot?: SharedStats;
+    cooperativeObjectives?: CoopObjective[];
+    leaderboardSnapshot?: LeaderboardEntry[];
+  } = {};
 
   if (view.mode === "mp" && (view.mpPayload ?? mpPayload)) {
     const mp = (view.mpPayload ?? mpPayload)!;
@@ -71,7 +79,14 @@ export default function AppShell() {
     players = mp.players;
     localSide = mp.localSide;
     localPlayerId = mp.players[localSide].id;
-    extraProps = { roomCode: mp.roomCode, hostId: mp.hostId, targetWins: mp.targetWins };
+    extraProps = {
+      roomCode: mp.roomCode,
+      hostId: mp.hostId,
+      targetWins: mp.targetWins,
+      sharedStatsSnapshot: mp.sharedStats,
+      cooperativeObjectives: mp.cooperativeObjectives,
+      leaderboardSnapshot: mp.leaderboard,
+    };
   } else {
     seed = Math.floor(Math.random() * 2 ** 31);
     players = {

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -6,7 +6,6 @@ import HubRoute from "./HubRoute";
 import MultiplayerRoute from "./MultiplayerRoute";
 import type { Players, Side } from "./game/types";
 import ProfilePage from "./ProfilePage";
-import type { SharedStats, CoopObjective, LeaderboardEntry } from "./player/profileStore";
 
 type MPStartPayload = Parameters<
   NonNullable<React.ComponentProps<typeof MultiplayerRoute>["onStart"]>
@@ -64,14 +63,7 @@ export default function AppShell() {
   let players: Players;
   let localSide: Side;
   let localPlayerId: string;
-  let extraProps: {
-    roomCode?: string;
-    hostId?: string;
-    targetWins?: number;
-    sharedStatsSnapshot?: SharedStats;
-    cooperativeObjectives?: CoopObjective[];
-    leaderboardSnapshot?: LeaderboardEntry[];
-  } = {};
+  let extraProps: { roomCode?: string; hostId?: string; targetWins?: number } = {};
 
   if (view.mode === "mp" && (view.mpPayload ?? mpPayload)) {
     const mp = (view.mpPayload ?? mpPayload)!;
@@ -79,14 +71,7 @@ export default function AppShell() {
     players = mp.players;
     localSide = mp.localSide;
     localPlayerId = mp.players[localSide].id;
-    extraProps = {
-      roomCode: mp.roomCode,
-      hostId: mp.hostId,
-      targetWins: mp.targetWins,
-      sharedStatsSnapshot: mp.sharedStats,
-      cooperativeObjectives: mp.cooperativeObjectives,
-      leaderboardSnapshot: mp.leaderboard,
-    };
+    extraProps = { roomCode: mp.roomCode, hostId: mp.hostId, targetWins: mp.targetWins };
   } else {
     seed = Math.floor(Math.random() * 2 ** 31);
     players = {

--- a/src/MultiplayerRoute.tsx
+++ b/src/MultiplayerRoute.tsx
@@ -2,6 +2,14 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Realtime } from "ably";
 import type { PresenceMessage } from "ably";
 import { TARGET_WINS, type Players, type Side } from "./game/types";
+import {
+  getSharedStats,
+  getCoopObjectives,
+  getLeaderboard,
+  type SharedStats,
+  type CoopObjective,
+  type LeaderboardEntry,
+} from "./player/profileStore";
 
 // ----- Start payload now includes targetWins (wins goal) -----
 type StartMessagePayload = {
@@ -11,6 +19,9 @@ type StartMessagePayload = {
   players: Players;          // { left: {id,name,color}, right: {…} }
   playersArr?: { clientId: string; name: string }[]; // optional: raw list for debugging
   targetWins: number;        // 👈 merged feature: game wins goal
+  sharedStats: SharedStats;
+  leaderboard: LeaderboardEntry[];
+  cooperativeObjectives: CoopObjective[];
 };
 
 type StartPayload = StartMessagePayload & {
@@ -488,6 +499,9 @@ await refreshMembers(chan);
       hostId: members[0].clientId, // first in presence is host
       playersArr: members,         // optional, for debugging/analytics
       targetWins: winsGoal,        // 👈 pass wins goal into the game
+      sharedStats: getSharedStats(),
+      leaderboard: getLeaderboard(),
+      cooperativeObjectives: getCoopObjectives(),
     };
 
     await channelRef.current?.publish("start", payload);

--- a/src/ProfilePage.tsx
+++ b/src/ProfilePage.tsx
@@ -12,14 +12,67 @@ import {
   type ProfileBundle,
   type Challenge,
   type ChallengeReward,
-  cardNumberFromId,
+  type CoopObjective,
+  type LeaderboardEntry,
+  type UnlockState,
+  type CurrencyId,
 } from "./player/profileStore";
 import type { Card } from "./game/types";
 
 /** Map our string cardId → runtime Card for StSCard preview. */
 function cardFromId(cardId: string): Card {
-  const num = cardNumberFromId(cardId);
+  const mBasic = /^basic_(\d+)$/.exec(cardId);
+  const mNeg = /^neg_(-?\d+)$/.exec(cardId);
+  const mNum = /^num_(-?\d+)$/.exec(cardId);
+  const num = mBasic ? +mBasic[1] : mNeg ? +mNeg[1] : mNum ? +mNum[1] : 0;
   return { id: `preview_${cardId}`, name: `${num}`, type: "normal", number: num, tags: [] };
+}
+
+const CURRENCY_LABELS: Record<CurrencyId, string> = {
+  gold: "Gold",
+  sigils: "Sigils",
+};
+
+function rewardSummary(reward: ChallengeReward): string {
+  switch (reward.type) {
+    case "currency":
+      return `${reward.amount} ${CURRENCY_LABELS[reward.currency]}`;
+    case "inventory":
+      return reward.items.map((item) => `${item.qty}× ${item.cardId}`).join(", ");
+    case "cosmetic":
+      return reward.name ?? reward.cosmeticId;
+    default:
+      return "Reward";
+  }
+}
+
+function challengeProgress(challenge: Challenge): number {
+  if (challenge.target <= 0) return 0;
+  return Math.min(1, challenge.progress / challenge.target);
+}
+
+function challengeExpiresLabel(expiresAt: number): string {
+  const now = Date.now();
+  const diff = Math.max(0, expiresAt - now);
+  const hours = Math.floor(diff / (60 * 60 * 1000));
+  if (hours < 1) {
+    const minutes = Math.max(1, Math.floor(diff / (60 * 1000)));
+    return `${minutes}m left`;
+  }
+  if (hours < 24) {
+    return `${hours}h left`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${days}d left`;
+}
+
+function isChallengeClaimable(challenge: Challenge): boolean {
+  return !!challenge.completedAt && !challenge.claimedAt;
+}
+
+function formatObjectiveProgress(objective: CoopObjective): number {
+  if (objective.target <= 0) return 0;
+  return Math.min(1, objective.progress / objective.target);
 }
 
 /** Scales its child to fit the available width while preserving aspect. */
@@ -55,28 +108,37 @@ function FitCard({
   );
 }
 
-function rewardLabel(reward: ChallengeReward): string {
-  if (reward.type === "currency") return `${reward.amount} ${reward.currency}`;
-  if (reward.type === "inventory") {
-    return reward.items.map((item) => `${item.qty}× ${item.cardId}`).join(", ");
-  }
-  return reward.name ?? reward.cosmeticId;
-}
-
-const challengePercent = (challenge: Challenge) =>
-  challenge.target > 0 ? Math.min(1, challenge.progress / challenge.target) : 0;
-
 export default function ProfilePage() {
   // Initialize immediately so we can render without waiting for an effect
   const [bundle, setBundle] = useState<ProfileBundle | null>(() => {
     try { return getProfileBundle(); } catch { return null; }
   });
+  const [claimingId, setClaimingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const refresh = () => {
     try {
       setBundle(getProfileBundle());
     } catch (e) {
       console.error("getProfileBundle failed:", e);
+    }
+  };
+
+  const handleClaim = (id: string) => {
+    try {
+      setClaimingId(id);
+      const claimed = claimChallengeReward(id);
+      if (!claimed) {
+        setError("Challenge not ready to claim.");
+      } else {
+        setError(null);
+      }
+    } catch (e) {
+      console.error("claimChallengeReward failed:", e);
+      setError("Failed to claim reward.");
+    } finally {
+      setClaimingId(null);
+      refresh();
     }
   };
 
@@ -108,19 +170,6 @@ export default function ProfilePage() {
 
   const expToNext = expRequiredForLevel(profile.level);
   const expPercent = expToNext > 0 ? Math.min(1, profile.exp / expToNext) : 0;
-
-  const currencyEntries = useMemo(
-    () => Object.entries(profile.currencies ?? {} as Record<string, number>),
-    [profile.currencies]
-  );
-  const unlockedWheels = useMemo(
-    () =>
-      Object.entries(profile.unlocks?.wheels ?? {})
-        .filter(([, unlocked]) => Boolean(unlocked))
-        .map(([id]) => id),
-    [profile.unlocks]
-  );
-  const cosmetics = profile.cosmetics ?? [];
 
   // Expand active deck into 10 visible slots (duplicates expanded)
   const deckSlots: (string | null)[] = useMemo(() => {
@@ -161,14 +210,77 @@ export default function ProfilePage() {
     catch (err: any) { alert(err?.message ?? "Could not remove from deck"); }
   };
 
-  const handleClaim = (id: string) => {
-    try {
-      const result = claimChallengeReward(id);
-      if (!result) return;
-      refresh();
-    } catch (err: any) {
-      alert(err?.message ?? "Unable to claim reward");
-    }
+  const renderChallenge = (challenge: Challenge) => {
+    const percent = Math.round(challengeProgress(challenge) * 100);
+    const claimable = isChallengeClaimable(challenge);
+    return (
+      <div key={challenge.id} className="rounded-lg bg-white/5 p-3 ring-1 ring-white/10">
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <div className="text-sm font-semibold text-white/90">{challenge.title}</div>
+            <div className="text-xs text-white/70">{challenge.description}</div>
+          </div>
+          <div className="text-xs text-white/50">{challengeExpiresLabel(challenge.expiresAt)}</div>
+        </div>
+        <div className="mt-2 h-2 w-full rounded-full bg-white/10">
+          <div
+            className={`h-2 rounded-full ${claimable ? "bg-emerald-400" : "bg-amber-300"}`}
+            style={{ width: `${percent}%` }}
+          />
+        </div>
+        <div className="mt-2 flex items-center justify-between text-xs text-white/70">
+          <span>
+            {challenge.progress} / {challenge.target}
+          </span>
+          <span>Reward: {rewardSummary(challenge.reward)}</span>
+        </div>
+        <button
+          className={`mt-2 w-full rounded-md px-2 py-1 text-sm font-medium transition-colors ${
+            claimable
+              ? "bg-emerald-500 text-slate-900 hover:bg-emerald-400"
+              : challenge.claimedAt
+              ? "bg-white/10 text-white/50"
+              : "bg-white/10 text-white/60"
+          }`}
+          disabled={!claimable || claimingId === challenge.id}
+          onClick={() => handleClaim(challenge.id)}
+        >
+          {challenge.claimedAt
+            ? "Claimed"
+            : claimable
+            ? claimingId === challenge.id
+              ? "Claiming..."
+              : "Claim Reward"
+            : "In Progress"}
+        </button>
+      </div>
+    );
+  };
+
+  const renderObjective = (objective: CoopObjective) => {
+    const percent = Math.round(formatObjectiveProgress(objective) * 100);
+    return (
+      <div key={objective.id} className="rounded-lg bg-white/5 p-3 ring-1 ring-white/10">
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-sm font-semibold text-white/90">{objective.description}</div>
+          <div className="text-xs text-white/50">{challengeExpiresLabel(objective.expiresAt)}</div>
+        </div>
+        <div className="mt-2 h-2 w-full rounded-full bg-white/10">
+          <div className="h-2 rounded-full bg-sky-300" style={{ width: `${percent}%` }} />
+        </div>
+        <div className="mt-2 flex items-center justify-between text-xs text-white/70">
+          <span>
+            {objective.progress} / {objective.target}
+          </span>
+          {objective.reward && <span>Reward: {rewardSummary(objective.reward)}</span>}
+        </div>
+        {objective.completedAt && (
+          <div className="mt-2 text-xs font-semibold text-emerald-300">
+            {objective.claimedAt ? "Reward delivered" : "Completed"}
+          </div>
+        )}
+      </div>
+    );
   };
 
   return (
@@ -196,47 +308,54 @@ export default function ProfilePage() {
           <div className="mt-1 text-xs text-white/60">Current streak: {profile.winStreak}</div>
         </div>
 
-        <div className="mt-3 grid gap-3 sm:grid-cols-2">
-          <div className="rounded-lg bg-black/30 p-3 ring-1 ring-white/10">
-            <div className="text-xs font-semibold uppercase tracking-wide text-white/60">Currencies</div>
-            <ul className="mt-2 space-y-1 text-sm">
-              {currencyEntries.length ? (
-                currencyEntries.map(([id, amount]) => (
-                  <li key={id} className="flex items-center justify-between capitalize">
-                    <span>{id}</span>
-                    <span>{amount}</span>
-                  </li>
-                ))
-              ) : (
-                <li className="text-xs text-white/60">No currency yet.</li>
-              )}
-            </ul>
-          </div>
-          <div className="rounded-lg bg-black/30 p-3 ring-1 ring-white/10">
-            <div className="text-xs font-semibold uppercase tracking-wide text-white/60">Unlocked Wheels</div>
-            <div className="mt-2 flex flex-wrap gap-1 text-xs">
-              {unlockedWheels.length ? (
-                unlockedWheels.map((id) => (
-                  <span key={id} className="px-2 py-1 rounded-full bg-white/10 capitalize">
-                    {id}
+        <div className="mt-3 flex flex-wrap gap-2 text-xs">
+          {(Object.keys(profile.currencies) as CurrencyId[]).map((currency) => (
+            <span
+              key={currency}
+              className="rounded-full bg-white/10 px-3 py-1 font-semibold text-white/80"
+            >
+              {CURRENCY_LABELS[currency]}: {profile.currencies[currency]}
+            </span>
+          ))}
+        </div>
+
+        <div className="mt-3 grid gap-3 text-xs">
+          <div>
+            <div className="font-semibold uppercase tracking-wide text-white/70">Wheel Unlocks</div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {(Object.keys(profile.unlocks.wheels) as Array<keyof UnlockState["wheels"]>).map((arch) => {
+                const unlocked = profile.unlocks.wheels[arch];
+                return (
+                  <span
+                    key={arch}
+                    className={`rounded-full px-3 py-1 font-semibold ${
+                      unlocked ? "bg-emerald-500/20 text-emerald-200" : "bg-white/10 text-white/50"
+                    }`}
+                  >
+                    {unlocked ? "✓" : "✕"} {arch}
                   </span>
-                ))
-              ) : (
-                <span className="text-white/60">Bandit</span>
-              )}
+                );
+              })}
             </div>
-            {cosmetics.length > 0 && (
-              <div className="mt-3">
-                <div className="text-xs font-semibold uppercase tracking-wide text-white/60">Cosmetics</div>
-                <div className="mt-2 flex flex-wrap gap-1 text-xs">
-                  {cosmetics.map((id) => (
-                    <span key={id} className="px-2 py-1 rounded-full bg-indigo-500/20 text-indigo-100/90">
-                      {id}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
+          </div>
+          <div>
+            <div className="font-semibold uppercase tracking-wide text-white/70">Modes</div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {(Object.keys(profile.unlocks.modes) as Array<keyof UnlockState["modes"]>).map((mode) => {
+                const unlocked = profile.unlocks.modes[mode];
+                const label = mode === "coop" ? "Co-op" : "Leaderboard";
+                return (
+                  <span
+                    key={mode}
+                    className={`rounded-full px-3 py-1 font-semibold ${
+                      unlocked ? "bg-emerald-500/20 text-emerald-200" : "bg-white/10 text-white/50"
+                    }`}
+                  >
+                    {unlocked ? "✓" : "✕"} {label}
+                  </span>
+                );
+              })}
+            </div>
           </div>
         </div>
 
@@ -308,225 +427,143 @@ export default function ProfilePage() {
         </div>
       </section>
 
-      {/* RIGHT: Inventory */}
-      <section className="rounded-xl p-3 border border-white/20 bg-black/25">
-        <div className="flex items-center justify-between">
-          <h3 className="text-lg">Inventory</h3>
-          <div className="text-xs opacity-70">Drag to deck • Click to add</div>
-        </div>
+      <div className="grid gap-4">
+        <section className="rounded-xl p-3 border border-white/20 bg-black/25">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg">Inventory</h3>
+            <div className="text-xs opacity-70">Drag to deck • Click to add</div>
+          </div>
 
-        {/* Inventory grid = drop target for deck cards (to remove) */}
-        <div
-          className="mt-2 grid grid-cols-3 sm:grid-cols-4 gap-3"
-          onDragOver={(e) => e.preventDefault()}
-          onDrop={(e) => {
-            e.preventDefault();
-            const data = getDrag(e);
-            if (data?.from === "deck") removeFromDeck(data.cardId, 1);
-          }}
-        >
-          {inventory.map((i) => {
-            const avail = invAvailable(i.cardId);
-            return (
-              <div key={i.cardId} className="relative grid place-items-center">
-                <div className="aspect-[3/4] w-full max-w-[180px] p-1 rounded-lg ring-1 ring-white/10 bg-white/5 grid place-items-center">
-                  <FitCard>
-                    <StSCard
-                      card={cardFromId(i.cardId)}
-                      size="md"
-                      disabled={avail <= 0}
-                      draggable
-                      onDragStart={(e) => setDrag(e, { from: "inv", cardId: i.cardId })}
-                      onPick={() => avail > 0 && addToDeck(i.cardId, 1)}
-                    />
-                  </FitCard>
-                </div>
-                <span className="absolute top-1 left-1 text-[11px] px-1.5 py-0.5 rounded bg-black/60 ring-1 ring-white/20">
-                  x{avail}
-                </span>
-              </div>
-            );
-          })}
-        </div>
-      </section>
-
-      <section className="md:col-span-2 rounded-xl p-3 border border-white/20 bg-black/25">
-        <h3 className="text-lg">Challenges</h3>
-        <div className="mt-3 grid gap-4 md:grid-cols-2">
-          <div>
-            <h4 className="text-sm font-semibold text-white/80">Daily</h4>
-            <div className="mt-2 space-y-3">
-              {challenges.daily.length ? (
-                challenges.daily.map((challenge) => {
-                  const pct = challengePercent(challenge);
-                  return (
-                    <div key={challenge.id} className="rounded-lg bg-white/5 p-3 ring-1 ring-white/10">
-                      <div className="flex items-start justify-between gap-3">
-                        <div>
-                          <div className="font-semibold">{challenge.title}</div>
-                          <div className="text-xs text-white/70 mt-1">{challenge.description}</div>
-                        </div>
-                        <div className="text-xs text-white/60 whitespace-nowrap">
-                          {challenge.progress} / {challenge.target}
-                        </div>
-                      </div>
-                      <div className="mt-2 h-2 w-full rounded-full bg-white/10">
-                        <div
-                          className="h-2 rounded-full bg-emerald-400"
-                          style={{ width: `${Math.min(100, pct * 100)}%` }}
-                        />
-                      </div>
-                      <div className="mt-2 flex items-center justify-between text-xs text-white/70">
-                        <span>Reward: {rewardLabel(challenge.reward)}</span>
-                        <button
-                          className={`px-2 py-1 rounded border ${challenge.claimedAt
-                            ? "border-white/10 text-white/40"
-                            : challenge.completedAt
-                            ? "border-emerald-400 text-emerald-200 hover:bg-emerald-500/20"
-                            : "border-white/15 text-white/50"}`}
-                          onClick={() => handleClaim(challenge.id)}
-                          disabled={!challenge.completedAt || !!challenge.claimedAt}
-                        >
-                          {challenge.claimedAt ? "Claimed" : challenge.completedAt ? "Claim" : "In progress"}
-                        </button>
-                      </div>
-                    </div>
-                  );
-                })
-              ) : (
-                <p className="text-xs text-white/60">No daily challenges available.</p>
-              )}
-            </div>
-          </div>
-          <div>
-            <h4 className="text-sm font-semibold text-white/80">Weekly</h4>
-            <div className="mt-2 space-y-3">
-              {challenges.weekly.length ? (
-                challenges.weekly.map((challenge) => {
-                  const pct = challengePercent(challenge);
-                  return (
-                    <div key={challenge.id} className="rounded-lg bg-white/5 p-3 ring-1 ring-white/10">
-                      <div className="flex items-start justify-between gap-3">
-                        <div>
-                          <div className="font-semibold">{challenge.title}</div>
-                          <div className="text-xs text-white/70 mt-1">{challenge.description}</div>
-                        </div>
-                        <div className="text-xs text-white/60 whitespace-nowrap">
-                          {challenge.progress} / {challenge.target}
-                        </div>
-                      </div>
-                      <div className="mt-2 h-2 w-full rounded-full bg-white/10">
-                        <div
-                          className="h-2 rounded-full bg-sky-400"
-                          style={{ width: `${Math.min(100, pct * 100)}%` }}
-                        />
-                      </div>
-                      <div className="mt-2 flex items-center justify-between text-xs text-white/70">
-                        <span>Reward: {rewardLabel(challenge.reward)}</span>
-                        <button
-                          className={`px-2 py-1 rounded border ${challenge.claimedAt
-                            ? "border-white/10 text-white/40"
-                            : challenge.completedAt
-                            ? "border-sky-400 text-sky-100 hover:bg-sky-500/20"
-                            : "border-white/15 text-white/50"}`}
-                          onClick={() => handleClaim(challenge.id)}
-                          disabled={!challenge.completedAt || !!challenge.claimedAt}
-                        >
-                          {challenge.claimedAt ? "Claimed" : challenge.completedAt ? "Claim" : "In progress"}
-                        </button>
-                      </div>
-                    </div>
-                  );
-                })
-              ) : (
-                <p className="text-xs text-white/60">No weekly challenges available.</p>
-              )}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="md:col-span-2 rounded-xl p-3 border border-white/20 bg-black/25">
-        <h3 className="text-lg">Shared Progress</h3>
-        <div className="mt-3 grid gap-2 sm:grid-cols-2 md:grid-cols-4 text-sm">
-          <div className="rounded-lg bg-white/5 p-3 ring-1 ring-white/10">
-            <div className="text-xs uppercase text-white/60">Co-op Wins</div>
-            <div className="text-lg font-semibold">{sharedStats.coopWins}</div>
-          </div>
-          <div className="rounded-lg bg-white/5 p-3 ring-1 ring-white/10">
-            <div className="text-xs uppercase text-white/60">Co-op Losses</div>
-            <div className="text-lg font-semibold">{sharedStats.coopLosses}</div>
-          </div>
-          <div className="rounded-lg bg-white/5 p-3 ring-1 ring-white/10">
-            <div className="text-xs uppercase text-white/60">Objectives</div>
-            <div className="text-lg font-semibold">{sharedStats.objectivesCompleted}</div>
-          </div>
-          <div className="rounded-lg bg-white/5 p-3 ring-1 ring-white/10">
-            <div className="text-xs uppercase text-white/60">Rating</div>
-            <div className="text-lg font-semibold">{sharedStats.leaderboardRating}</div>
-          </div>
-        </div>
-
-        <div className="mt-4">
-          <h4 className="text-sm font-semibold text-white/80">Cooperative Objectives</h4>
-          <div className="mt-2 space-y-2">
-            {coopObjectives.length ? (
-              coopObjectives.map((objective) => {
-                const pct = objective.target > 0 ? Math.min(1, objective.progress / objective.target) : 0;
-                return (
-                  <div key={objective.id} className="rounded-lg bg-white/5 p-3 ring-1 ring-white/10">
-                    <div className="flex items-center justify-between text-sm">
-                      <div className="font-medium text-white/90">{objective.description}</div>
-                      <div className="text-xs text-white/60">
-                        {objective.progress} / {objective.target}
-                      </div>
-                    </div>
-                    <div className="mt-2 h-2 w-full rounded-full bg-white/10">
-                      <div
-                        className="h-2 rounded-full bg-fuchsia-400"
-                        style={{ width: `${Math.min(100, pct * 100)}%` }}
+          {/* Inventory grid = drop target for deck cards (to remove) */}
+          <div
+            className="mt-2 grid grid-cols-3 sm:grid-cols-4 gap-3"
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={(e) => {
+              e.preventDefault();
+              const data = getDrag(e);
+              if (data?.from === "deck") removeFromDeck(data.cardId, 1);
+            }}
+          >
+            {inventory.map((i) => {
+              const avail = invAvailable(i.cardId);
+              return (
+                <div key={i.cardId} className="relative grid place-items-center">
+                  <div className="aspect-[3/4] w-full max-w-[180px] p-1 rounded-lg ring-1 ring-white/10 bg-white/5 grid place-items-center">
+                    <FitCard>
+                      <StSCard
+                        card={cardFromId(i.cardId)}
+                        size="md"
+                        disabled={avail <= 0}
+                        draggable
+                        onDragStart={(e) => setDrag(e, { from: "inv", cardId: i.cardId })}
+                        onPick={() => avail > 0 && addToDeck(i.cardId, 1)}
                       />
-                    </div>
-                    {objective.reward && (
-                      <div className="mt-2 text-xs text-white/70">
-                        Reward: {rewardLabel(objective.reward)}
-                      </div>
-                    )}
+                    </FitCard>
                   </div>
-                );
-              })
+                  <span className="absolute top-1 left-1 text-[11px] px-1.5 py-0.5 rounded bg-black/60 ring-1 ring-white/20">
+                    x{avail}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="rounded-xl p-3 border border-white/20 bg-black/25">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg">Challenges</h3>
+            <span className="text-xs opacity-70">Daily & weekly goals</span>
+          </div>
+          {error && <div className="mt-2 text-xs text-rose-300">{error}</div>}
+          <div className="mt-3 grid gap-4">
+            <div>
+              <h4 className="text-sm font-semibold text-white/80">Daily</h4>
+              <div className="mt-2 grid gap-2">
+                {challenges.daily.length === 0 ? (
+                  <div className="text-xs text-white/60">No daily challenges available.</div>
+                ) : (
+                  challenges.daily.map(renderChallenge)
+                )}
+              </div>
+            </div>
+            <div>
+              <h4 className="text-sm font-semibold text-white/80">Weekly</h4>
+              <div className="mt-2 grid gap-2">
+                {challenges.weekly.length === 0 ? (
+                  <div className="text-xs text-white/60">No weekly challenges available.</div>
+                ) : (
+                  challenges.weekly.map(renderChallenge)
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-xl p-3 border border-white/20 bg-black/25">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg">Cooperative Objectives</h3>
+            <span className="text-xs opacity-70">Progress persists across sessions</span>
+          </div>
+          <div className="mt-2 grid gap-2">
+            {coopObjectives.length === 0 ? (
+              <div className="text-xs text-white/60">No active objectives.</div>
             ) : (
-              <p className="text-xs text-white/60">No cooperative objectives active.</p>
+              coopObjectives.map(renderObjective)
             )}
           </div>
-        </div>
-      </section>
+        </section>
 
-      <section className="md:col-span-2 rounded-xl p-3 border border-white/20 bg-black/25">
-        <h3 className="text-lg">Leaderboard Snapshot</h3>
-        <div className="mt-3 overflow-x-auto">
-          <table className="min-w-full text-sm">
-            <thead className="text-xs uppercase text-white/50">
-              <tr>
-                <th className="text-left py-1 pr-4">#</th>
-                <th className="text-left py-1 pr-4">Player</th>
-                <th className="text-left py-1 pr-4">Rating</th>
-                <th className="text-left py-1">Wins</th>
-              </tr>
-            </thead>
-            <tbody>
-              {leaderboard.slice(0, 5).map((entry, idx) => (
-                <tr key={entry.playerId} className="border-t border-white/10">
-                  <td className="py-1 pr-4">{idx + 1}</td>
-                  <td className="py-1 pr-4">{entry.name}</td>
-                  <td className="py-1 pr-4">{entry.rating}</td>
-                  <td className="py-1">{entry.victories}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
+        <section className="rounded-xl p-3 border border-white/20 bg-black/25">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg">Shared Progress</h3>
+            <span className="text-xs opacity-70">Multiplayer snapshot</span>
+          </div>
+          <div className="mt-3 grid gap-2 text-xs text-white/70">
+            <div className="grid grid-cols-2 gap-2">
+              <div className="rounded-lg bg-white/5 p-2">
+                <div className="text-sm font-semibold text-white/80">Co-op Wins</div>
+                <div className="mt-1 text-lg font-bold text-emerald-300">{sharedStats.coopWins}</div>
+              </div>
+              <div className="rounded-lg bg-white/5 p-2">
+                <div className="text-sm font-semibold text-white/80">Co-op Losses</div>
+                <div className="mt-1 text-lg font-bold text-rose-300">{sharedStats.coopLosses}</div>
+              </div>
+              <div className="rounded-lg bg-white/5 p-2">
+                <div className="text-sm font-semibold text-white/80">Objectives Completed</div>
+                <div className="mt-1 text-lg font-bold text-amber-200">{sharedStats.objectivesCompleted}</div>
+              </div>
+              <div className="rounded-lg bg-white/5 p-2">
+                <div className="text-sm font-semibold text-white/80">Leaderboard Rating</div>
+                <div className="mt-1 text-lg font-bold text-sky-200">{sharedStats.leaderboardRating}</div>
+              </div>
+            </div>
+
+            <div className="mt-3">
+              <h4 className="text-sm font-semibold text-white/80">Leaderboard</h4>
+              <div className="mt-2 overflow-hidden rounded-lg ring-1 ring-white/10">
+                <table className="min-w-full text-left text-xs text-white/80">
+                  <thead className="bg-white/10 text-[11px] uppercase tracking-wide">
+                    <tr>
+                      <th className="px-2 py-1">Player</th>
+                      <th className="px-2 py-1 text-right">Rating</th>
+                      <th className="px-2 py-1 text-right">Victories</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {leaderboard.slice(0, 5).map((entry) => (
+                      <tr key={entry.playerId} className="odd:bg-white/5">
+                        <td className="px-2 py-1">{entry.name}</td>
+                        <td className="px-2 py-1 text-right font-semibold">{entry.rating}</td>
+                        <td className="px-2 py-1 text-right">{entry.victories}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
     </div>
   );
 }

--- a/src/ProfilePage.tsx
+++ b/src/ProfilePage.tsx
@@ -12,15 +12,13 @@ import {
   type ProfileBundle,
   type Challenge,
   type ChallengeReward,
+  cardNumberFromId,
 } from "./player/profileStore";
 import type { Card } from "./game/types";
 
 /** Map our string cardId → runtime Card for StSCard preview. */
 function cardFromId(cardId: string): Card {
-  const mBasic = /^basic_(\d+)$/.exec(cardId);
-  const mNeg = /^neg_(-?\d+)$/.exec(cardId);
-  const mNum = /^num_(-?\d+)$/.exec(cardId);
-  const num = mBasic ? +mBasic[1] : mNeg ? +mNeg[1] : mNum ? +mNum[1] : 0;
+  const num = cardNumberFromId(cardId);
   return { id: `preview_${cardId}`, name: `${num}`, type: "normal", number: num, tags: [] };
 }
 

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -46,6 +46,13 @@ export type VC =
   | "ClosestToTarget"
   | "Initiative";
 
+export type WheelArchetype =
+  | "bandit"
+  | "sorcerer"
+  | "beast"
+  | "guardian"
+  | "chaos";
+
 export type Section = {
   id: VC;
   color: string;

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -46,12 +46,7 @@ export type VC =
   | "ClosestToTarget"
   | "Initiative";
 
-export type WheelArchetype =
-  | "bandit"
-  | "sorcerer"
-  | "beast"
-  | "guardian"
-  | "chaos";
+export type WheelArchetype = "bandit" | "sorcerer" | "beast" | "guardian" | "chaos";
 
 export type Section = {
   id: VC;

--- a/src/game/wheel.ts
+++ b/src/game/wheel.ts
@@ -1,5 +1,5 @@
 // src/game/wheel.ts
-import { SLICES, VC, Section } from "./types";
+import { SLICES, VC, Section, type WheelArchetype } from "./types";
 
 export const VC_META: Record<
   VC,
@@ -14,15 +14,20 @@ export const VC_META: Record<
 
 import { shuffle } from "./math";
 
+const ARCHETYPE_SEGMENTS: Record<WheelArchetype, number[]> = {
+  bandit: [5, 4, 3, 2, 1],
+  sorcerer: [5, 5, 2, 2, 1],
+  beast: [6, 3, 3, 2, 1],
+  guardian: [4, 4, 3, 3, 2],
+  chaos: [7, 3, 2, 2, 2],
+};
+
 export function genWheelSections(
-  archetype: "bandit" | "sorcerer" | "beast" = "bandit",
+  archetype: WheelArchetype = "bandit",
   rng: () => number = Math.random
 ): Section[] {
-  const lens = (() => {
-    if (archetype === "bandit") return shuffle([5, 4, 3, 2, 1], rng);
-    if (archetype === "sorcerer") return shuffle([5, 5, 2, 2, 1], rng);
-    return shuffle([6, 3, 3, 2, 1], rng);
-  })();
+  const baseLens = ARCHETYPE_SEGMENTS[archetype] ?? ARCHETYPE_SEGMENTS.bandit;
+  const lens = shuffle(baseLens, rng);
   const kinds: VC[] = shuffle([
     "Strongest",
     "Weakest",

--- a/src/game/wheel.ts
+++ b/src/game/wheel.ts
@@ -1,5 +1,6 @@
 // src/game/wheel.ts
 import { SLICES, VC, Section, type WheelArchetype } from "./types";
+import { shuffle } from "./math";
 
 export const VC_META: Record<
   VC,
@@ -21,7 +22,8 @@ export const VC_META: Record<
     icon: "🗃️",
     color: "#0ea5e9",
     short: "RES",
-    explain: "Compare sums of the two cards left in hand.",
+    // Adapted: reflect HUD-based reserve (cards left + bonuses like recall/predictive/echo)
+    explain: "Compare reserve totals (hand leftovers + bonuses).",
   },
   ClosestToTarget: {
     icon: "🎯",
@@ -51,8 +53,6 @@ export const VC_META: Record<
   },
 };
 
-import { shuffle } from "./math";
-
 export function genWheelSections(
   archetype: WheelArchetype = "bandit",
   rng: () => number = Math.random
@@ -73,6 +73,7 @@ export function genWheelSections(
         return shuffle([5, 4, 3, 2, 1], rng);
     }
   })();
+
   const availableKinds: VC[] = [
     "Strongest",
     "Weakest",
@@ -83,6 +84,7 @@ export function genWheelSections(
     "SwapWins",
   ];
   const kinds: VC[] = shuffle(availableKinds, rng).slice(0, lens.length);
+
   let start = 1;
   const sections: Section[] = [];
   for (let i = 0; i < kinds.length; i++) {

--- a/src/game/wheel.ts
+++ b/src/game/wheel.ts
@@ -14,20 +14,26 @@ export const VC_META: Record<
 
 import { shuffle } from "./math";
 
-const ARCHETYPE_SEGMENTS: Record<WheelArchetype, number[]> = {
-  bandit: [5, 4, 3, 2, 1],
-  sorcerer: [5, 5, 2, 2, 1],
-  beast: [6, 3, 3, 2, 1],
-  guardian: [4, 4, 3, 3, 2],
-  chaos: [7, 3, 2, 2, 2],
-};
-
 export function genWheelSections(
   archetype: WheelArchetype = "bandit",
   rng: () => number = Math.random
 ): Section[] {
-  const baseLens = ARCHETYPE_SEGMENTS[archetype] ?? ARCHETYPE_SEGMENTS.bandit;
-  const lens = shuffle(baseLens, rng);
+  const lens = (() => {
+    switch (archetype) {
+      case "bandit":
+        return shuffle([5, 4, 3, 2, 1], rng);
+      case "sorcerer":
+        return shuffle([5, 5, 2, 2, 1], rng);
+      case "beast":
+        return shuffle([6, 3, 3, 2, 1], rng);
+      case "guardian":
+        return shuffle([4, 4, 3, 3, 2], rng);
+      case "chaos":
+        return shuffle([6, 5, 3, 1, 1], rng);
+      default:
+        return shuffle([5, 4, 3, 2, 1], rng);
+    }
+  })();
   const kinds: VC[] = shuffle([
     "Strongest",
     "Weakest",

--- a/src/player/profileStore.tsx
+++ b/src/player/profileStore.tsx
@@ -882,7 +882,6 @@ export function recordMatchResult(opts: RecordMatchOptions): MatchResultSummary 
 
   // ...existing implementation that updates profile, XP, streak, etc.
   // Use mode/modeId/modeLabel as needed, and apply sharedStatsDelta if provided.
-}
 
   const state = loadStateRaw();
   const profile = state.profile;

--- a/src/player/profileStore.tsx
+++ b/src/player/profileStore.tsx
@@ -2,13 +2,20 @@
 // to match your existing game types/functions.
 
 import { shuffle } from "../game/math";
-import type { Card, Fighter } from "../game/types";
+import type { Card, Fighter, WheelArchetype } from "../game/types";
 
 // ===== Local persistence types (module-scoped) =====
 type CardId = string;
 export type InventoryItem = { cardId: CardId; qty: number };
 export type DeckCard = { cardId: CardId; qty: number };
 export type Deck = { id: string; name: string; isActive: boolean; cards: DeckCard[] };
+export type SwapItem = { cardId: string; qty: number };
+export type CurrencyId = "gold" | "sigils";
+export type CurrencyLedger = Record<CurrencyId, number>;
+export type UnlockState = {
+  wheels: Record<WheelArchetype, boolean>;
+  modes: { coop: boolean; leaderboard: boolean };
+};
 export type Profile = {
   id: string;
   displayName: string;
@@ -17,14 +24,102 @@ export type Profile = {
   level: number;
   exp: number;
   winStreak: number;
+  currencies: CurrencyLedger;
+  unlocks: UnlockState;
+  cosmetics: string[];
 };
-type LocalState = { version: number; profile: Profile; inventory: InventoryItem[]; decks: Deck[] };
+
+export type ChallengeFrequency = "daily" | "weekly";
+export type ChallengeKind = "win_matches" | "play_cards" | "coop_victories";
+export type ChallengeReward =
+  | { type: "currency"; currency: CurrencyId; amount: number }
+  | { type: "inventory"; items: SwapItem[] }
+  | { type: "cosmetic"; cosmeticId: string; name: string };
+export type Challenge = {
+  id: string;
+  frequency: ChallengeFrequency;
+  kind: ChallengeKind;
+  title: string;
+  description: string;
+  target: number;
+  progress: number;
+  reward: ChallengeReward;
+  expiresAt: number;
+  completedAt?: number;
+  claimedAt?: number;
+};
+export type ChallengeBoard = {
+  daily: Challenge[];
+  weekly: Challenge[];
+  generatedAt: { daily: number; weekly: number };
+};
+export type ChallengeProgressSnapshot = {
+  id: string;
+  kind: ChallengeKind;
+  progress: number;
+  target: number;
+  completed: boolean;
+  claimed: boolean;
+};
+
+export type SharedStats = {
+  coopWins: number;
+  coopLosses: number;
+  objectivesCompleted: number;
+  leaderboardRating: number;
+  lastUpdated: number;
+};
+export type CoopObjective = {
+  id: string;
+  description: string;
+  target: number;
+  progress: number;
+  reward?: ChallengeReward;
+  expiresAt: number;
+};
+export type LeaderboardEntry = {
+  playerId: string;
+  name: string;
+  rating: number;
+  victories: number;
+  updatedAt: number;
+};
+
+type LocalState = {
+  version: number;
+  profile: Profile;
+  inventory: InventoryItem[];
+  decks: Deck[];
+  challenges: ChallengeBoard;
+  sharedStats: SharedStats;
+  coopObjectives: CoopObjective[];
+  leaderboard: LeaderboardEntry[];
+};
 
 // ===== Storage/config =====
 const KEY = "rw:single:state";
-const VERSION = 2;
+const VERSION = 3;
 const MAX_DECK_SIZE = 10;
 const MAX_COPIES_PER_DECK = 2;
+const DAILY_SLOTS = 2;
+const WEEKLY_SLOTS = 2;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const WEEK_MS = DAY_MS * 7;
+
+const DEFAULT_CURRENCIES: CurrencyLedger = { gold: 0, sigils: 0 };
+const DEFAULT_UNLOCKS: UnlockState = {
+  wheels: { bandit: true, sorcerer: true, beast: true, guardian: false, chaos: false },
+  modes: { coop: false, leaderboard: false },
+};
+const DEFAULT_SHARED: SharedStats = {
+  coopWins: 0,
+  coopLosses: 0,
+  objectivesCompleted: 0,
+  leaderboardRating: 1000,
+  lastUpdated: Date.now(),
+};
+
+const COOP_OBJECTIVE_PERIOD_MS = WEEK_MS;
 
 type SafeStorage = Pick<Storage, "getItem" | "setItem"> | null;
 
@@ -50,6 +145,8 @@ function uid(prefix = "id") {
   return `${prefix}_${Math.random().toString(36).slice(2, 8)}${Date.now().toString(36).slice(-4)}`;
 }
 
+const DEFAULT_COSMETICS: string[] = [];
+
 // ===== Seed data (keep numbers only to match Card { type:'normal', number:n }) =====
 const SEED_INVENTORY: InventoryItem[] = [];
 
@@ -60,21 +157,377 @@ const SEED_DECK: Deck = {
   cards: Array.from({ length: 10 }, (_, n) => ({ cardId: `basic_${n}`, qty: 1 })),
 };
 
+// Challenge + objective templates
+
+type ChallengeTemplate = {
+  kind: ChallengeKind;
+  title: string;
+  description: string;
+  target: number;
+  reward: ChallengeReward;
+  minLevel?: number;
+};
+
+const CHALLENGE_TEMPLATES: Record<ChallengeFrequency, ChallengeTemplate[]> = {
+  daily: [
+    {
+      kind: "win_matches",
+      title: "Morning Warmup",
+      description: "Win two matches in any mode.",
+      target: 2,
+      reward: { type: "inventory", items: [{ cardId: "neg_-1", qty: 1 }] },
+    },
+    {
+      kind: "play_cards",
+      title: "Card Slinger",
+      description: "Play 12 cards across matches today.",
+      target: 12,
+      reward: { type: "cosmetic", cosmeticId: "banner_ember", name: "Ember Pennant" },
+    },
+    {
+      kind: "coop_victories",
+      title: "Team Spirit",
+      description: "Win a cooperative round with an ally.",
+      target: 1,
+      reward: { type: "currency", currency: "gold", amount: 150 },
+      minLevel: 3,
+    },
+  ],
+  weekly: [
+    {
+      kind: "win_matches",
+      title: "Wheel Champion",
+      description: "Win ten matches before the week ends.",
+      target: 10,
+      reward: { type: "inventory", items: [{ cardId: "neg_-2", qty: 1 }, { cardId: "neg_-3", qty: 1 }] },
+    },
+    {
+      kind: "coop_victories",
+      title: "Allied Triumphs",
+      description: "Earn five cooperative victories this week.",
+      target: 5,
+      reward: { type: "cosmetic", cosmeticId: "sigil_starlit", name: "Starlit Sigil" },
+    },
+  ],
+};
+
+type ObjectiveTemplate = {
+  description: string;
+  target: number;
+  reward?: ChallengeReward;
+};
+
+const COOP_OBJECTIVE_TEMPLATES: ObjectiveTemplate[] = [
+  {
+    description: "Win 3 cooperative matches with any ally.",
+    target: 3,
+    reward: { type: "currency", currency: "sigils", amount: 40 },
+  },
+  {
+    description: "Spin the guardian wheel 8 times in cooperative play.",
+    target: 8,
+    reward: { type: "inventory", items: [{ cardId: "basic_7", qty: 1 }] },
+  },
+  {
+    description: "Complete 4 cooperative objectives with perfect rounds.",
+    target: 4,
+    reward: { type: "cosmetic", cosmeticId: "trail_radiant", name: "Radiant Trail" },
+  },
+];
+
+function normalizeCurrencies(input?: Partial<CurrencyLedger> | null): CurrencyLedger {
+  const next: CurrencyLedger = { ...DEFAULT_CURRENCIES };
+  if (input) {
+    for (const key of Object.keys(DEFAULT_CURRENCIES) as CurrencyId[]) {
+      const raw = input[key];
+      next[key] = typeof raw === "number" && Number.isFinite(raw) ? Math.max(0, Math.floor(raw)) : DEFAULT_CURRENCIES[key];
+    }
+  }
+  return next;
+}
+
+function normalizeUnlocks(input?: Partial<UnlockState> | null): UnlockState {
+  const wheels: Record<WheelArchetype, boolean> = { ...DEFAULT_UNLOCKS.wheels };
+  const modes = { ...DEFAULT_UNLOCKS.modes };
+  if (input?.wheels) {
+    for (const key of Object.keys(wheels) as WheelArchetype[]) {
+      const raw = (input.wheels as Record<string, unknown>)[key];
+      wheels[key] = Boolean(raw);
+    }
+  }
+  if (input?.modes) {
+    modes.coop = Boolean((input.modes as any).coop);
+    modes.leaderboard = Boolean((input.modes as any).leaderboard);
+  }
+  return { wheels, modes };
+}
+
+function ensureCosmetics(list: unknown): string[] {
+  if (!Array.isArray(list)) return [...DEFAULT_COSMETICS];
+  const out = new Set<string>();
+  for (const entry of list) {
+    const str = typeof entry === "string" ? entry : null;
+    if (str) out.add(str);
+  }
+  return Array.from(out);
+}
+
+function ensureLeaderboard(entries: unknown, profile: Profile): LeaderboardEntry[] {
+  const list: LeaderboardEntry[] = Array.isArray(entries)
+    ? entries
+        .map((entry) => ({
+          playerId: typeof entry?.playerId === "string" ? entry.playerId : uid("lb"),
+          name: typeof entry?.name === "string" ? entry.name : "Player",
+          rating: typeof entry?.rating === "number" && Number.isFinite(entry.rating) ? entry.rating : 1000,
+          victories: typeof entry?.victories === "number" && Number.isFinite(entry.victories) ? Math.max(0, Math.floor(entry.victories)) : 0,
+          updatedAt: typeof entry?.updatedAt === "number" ? entry.updatedAt : Date.now(),
+        }))
+    : [];
+
+  const existing = list.find((e) => e.playerId === profile.id);
+  if (!existing) {
+    list.push({
+      playerId: profile.id,
+      name: profile.displayName,
+      rating: DEFAULT_SHARED.leaderboardRating,
+      victories: 0,
+      updatedAt: Date.now(),
+    });
+  }
+  return list.sort((a, b) => b.rating - a.rating);
+}
+
+function ensureSharedStats(stats: unknown): SharedStats {
+  const base = { ...DEFAULT_SHARED };
+  if (!stats || typeof stats !== "object") return base;
+  const obj = stats as Partial<SharedStats>;
+  base.coopWins = typeof obj.coopWins === "number" ? Math.max(0, Math.floor(obj.coopWins)) : base.coopWins;
+  base.coopLosses = typeof obj.coopLosses === "number" ? Math.max(0, Math.floor(obj.coopLosses)) : base.coopLosses;
+  base.objectivesCompleted =
+    typeof obj.objectivesCompleted === "number" ? Math.max(0, Math.floor(obj.objectivesCompleted)) : base.objectivesCompleted;
+  base.leaderboardRating =
+    typeof obj.leaderboardRating === "number" && Number.isFinite(obj.leaderboardRating)
+      ? Math.max(0, Math.floor(obj.leaderboardRating))
+      : base.leaderboardRating;
+  base.lastUpdated = typeof obj.lastUpdated === "number" ? obj.lastUpdated : Date.now();
+  return base;
+}
+
+function ensureObjectives(entries: unknown, now: number): CoopObjective[] {
+  if (!Array.isArray(entries)) {
+    return generateObjectives([], now);
+  }
+  const sanitized: CoopObjective[] = entries
+    .map((entry) => ({
+      id: typeof entry?.id === "string" ? entry.id : uid("coop"),
+      description: typeof entry?.description === "string" ? entry.description : "Cooperative goal",
+      target: typeof entry?.target === "number" && entry.target > 0 ? Math.floor(entry.target) : 1,
+      progress: typeof entry?.progress === "number" && entry.progress >= 0 ? Math.floor(entry.progress) : 0,
+      reward: entry?.reward as ChallengeReward | undefined,
+      expiresAt: typeof entry?.expiresAt === "number" ? entry.expiresAt : now + COOP_OBJECTIVE_PERIOD_MS,
+    }))
+    .filter(Boolean);
+  return generateObjectives(sanitized, now);
+}
+
+function generateObjectives(existing: CoopObjective[], now: number): CoopObjective[] {
+  const filtered = existing.filter((obj) => obj.expiresAt > now);
+  const needed = Math.max(0, 2 - filtered.length);
+  const out = [...filtered];
+  for (let i = 0; i < needed; i++) {
+    const template = COOP_OBJECTIVE_TEMPLATES[(filtered.length + i) % COOP_OBJECTIVE_TEMPLATES.length];
+    const expiresAt = computeExpiry("weekly", now, COOP_OBJECTIVE_PERIOD_MS);
+    out.push({
+      id: uid("coop"),
+      description: template.description,
+      target: template.target,
+      progress: 0,
+      reward: template.reward,
+      expiresAt,
+    });
+  }
+  return out;
+}
+
+function computeExpiry(frequency: ChallengeFrequency, now: number, periodOverride?: number) {
+  const period = periodOverride ?? (frequency === "daily" ? DAY_MS : WEEK_MS);
+  const bucket = Math.floor(now / period) * period;
+  return bucket + period;
+}
+
+function refreshChallengeBoard(state: LocalState, now = Date.now()) {
+  const board = state.challenges;
+  const trim = (list: Challenge[]) => list.filter((ch) => ch.expiresAt > now);
+  board.daily = trim(board.daily);
+  board.weekly = trim(board.weekly);
+
+  const ensure = (frequency: ChallengeFrequency, slots: number) => {
+    const templates = CHALLENGE_TEMPLATES[frequency];
+    const list = frequency === "daily" ? board.daily : board.weekly;
+    let i = 0;
+    while (list.length < slots && templates.length > 0) {
+      const template = templates[(Math.floor(now / (frequency === "daily" ? DAY_MS : WEEK_MS)) + list.length + i) % templates.length];
+      const minLevel = template.minLevel ?? 0;
+      if (state.profile.level >= minLevel) {
+        list.push({
+          id: uid(frequency === "daily" ? "day" : "week"),
+          frequency,
+          kind: template.kind,
+          title: template.title,
+          description: template.description,
+          target: template.target,
+          progress: 0,
+          reward: template.reward,
+          expiresAt: computeExpiry(frequency, now),
+        });
+      }
+      i++;
+      if (i > templates.length * 2) break;
+    }
+  };
+
+  ensure("daily", DAILY_SLOTS);
+  ensure("weekly", WEEKLY_SLOTS);
+  board.generatedAt.daily = now;
+  board.generatedAt.weekly = now;
+}
+
+function cloneChallenge(ch: Challenge): Challenge {
+  return { ...ch, reward: { ...ch.reward } };
+}
+
+function applyChallengeProgress(state: LocalState, kind: ChallengeKind, delta: number, now: number) {
+  if (delta <= 0) return;
+  const apply = (ch: Challenge) => {
+    if (ch.kind !== kind || ch.completedAt) return false;
+    const before = ch.progress;
+    ch.progress = Math.min(ch.target, ch.progress + delta);
+    if (ch.progress >= ch.target) {
+      ch.completedAt = now;
+    }
+    return ch.progress !== before;
+  };
+  let changed = false;
+  for (const ch of state.challenges.daily) changed = apply(ch) || changed;
+  for (const ch of state.challenges.weekly) changed = apply(ch) || changed;
+  if (changed) state.challenges.generatedAt.daily = now;
+}
+
+function objectiveProgress(state: LocalState, amount: number, now: number) {
+  if (amount <= 0) return;
+  let completed = 0;
+  for (const obj of state.coopObjectives) {
+    if (obj.progress >= obj.target) continue;
+    const before = obj.progress;
+    obj.progress = Math.min(obj.target, obj.progress + amount);
+    if (obj.progress >= obj.target) {
+      state.sharedStats.objectivesCompleted += 1;
+      if (obj.reward) {
+        applyReward(state, obj.reward, now, false);
+      }
+    }
+    if (obj.progress !== before && obj.progress >= obj.target) completed++;
+  }
+  if (completed > 0) {
+    state.sharedStats.lastUpdated = now;
+  }
+}
+
+function applyReward(state: LocalState, reward: ChallengeReward, now: number, markShared = true) {
+  if (reward.type === "currency") {
+    state.profile.currencies[reward.currency] =
+      (state.profile.currencies[reward.currency] ?? 0) + Math.max(0, Math.floor(reward.amount));
+  } else if (reward.type === "inventory") {
+    for (const item of reward.items) {
+      const existing = state.inventory.find((i) => i.cardId === item.cardId);
+      if (existing) existing.qty += item.qty;
+      else state.inventory.push({ cardId: item.cardId, qty: item.qty });
+    }
+  } else if (reward.type === "cosmetic") {
+    if (!state.profile.cosmetics.includes(reward.cosmeticId)) {
+      state.profile.cosmetics.push(reward.cosmeticId);
+    }
+  }
+  if (markShared) state.sharedStats.lastUpdated = now;
+}
+
+function migrateState(raw: any): LocalState {
+  const seedState = seed();
+  if (!raw || typeof raw !== "object") {
+    return seedState;
+  }
+
+  const profileRaw = raw.profile ?? {};
+  const profile: Profile = {
+    ...seedState.profile,
+    ...profileRaw,
+    level: typeof profileRaw.level === "number" ? profileRaw.level : seedState.profile.level,
+    exp: typeof profileRaw.exp === "number" ? profileRaw.exp : seedState.profile.exp,
+    winStreak: typeof profileRaw.winStreak === "number" ? profileRaw.winStreak : seedState.profile.winStreak,
+    currencies: normalizeCurrencies(profileRaw.currencies),
+    unlocks: normalizeUnlocks(profileRaw.unlocks),
+    cosmetics: ensureCosmetics(profileRaw.cosmetics),
+  };
+
+  const state: LocalState = {
+    version: VERSION,
+    profile,
+    inventory: Array.isArray(raw.inventory) ? raw.inventory.map((i: any) => ({ cardId: String(i.cardId), qty: Math.max(0, Number(i.qty) || 0) })) : seedState.inventory,
+    decks: Array.isArray(raw.decks)
+      ? raw.decks.map((d: any) => ({
+          id: typeof d.id === "string" ? d.id : uid("deck"),
+          name: typeof d.name === "string" ? d.name : "Deck",
+          isActive: Boolean(d.isActive),
+          cards: Array.isArray(d.cards)
+            ? d.cards.map((c: any) => ({ cardId: String(c.cardId), qty: Math.max(0, Number(c.qty) || 0) }))
+            : [],
+        }))
+      : seedState.decks,
+    challenges: {
+      daily: Array.isArray(raw.challenges?.daily) ? raw.challenges.daily.map(cloneChallenge) : seedState.challenges.daily,
+      weekly: Array.isArray(raw.challenges?.weekly) ? raw.challenges.weekly.map(cloneChallenge) : seedState.challenges.weekly,
+      generatedAt: {
+        daily: typeof raw.challenges?.generatedAt?.daily === "number" ? raw.challenges.generatedAt.daily : 0,
+        weekly: typeof raw.challenges?.generatedAt?.weekly === "number" ? raw.challenges.generatedAt.weekly : 0,
+      },
+    },
+    sharedStats: ensureSharedStats(raw.sharedStats),
+    coopObjectives: ensureObjectives(raw.coopObjectives, Date.now()),
+    leaderboard: ensureLeaderboard(raw.leaderboard, profile),
+  };
+
+  if (!state.decks.some((d) => d.isActive) && state.decks[0]) state.decks[0].isActive = true;
+  refreshChallengeBoard(state);
+  return state;
+}
+
 function seed(): LocalState {
-  return {
+  const now = Date.now();
+  const base: LocalState = {
     version: VERSION,
     profile: {
       id: uid("user"),
       displayName: "Local Player",
       mmr: 1000,
-      createdAt: Date.now(),
+      createdAt: now,
       level: 1,
       exp: 0,
       winStreak: 0,
+      currencies: { ...DEFAULT_CURRENCIES },
+      unlocks: { ...DEFAULT_UNLOCKS },
+      cosmetics: [...DEFAULT_COSMETICS],
     },
-    inventory: SEED_INVENTORY,
+    inventory: SEED_INVENTORY.map((i) => ({ ...i })),
     decks: [SEED_DECK],
+    challenges: { daily: [], weekly: [], generatedAt: { daily: 0, weekly: 0 } },
+    sharedStats: { ...DEFAULT_SHARED },
+    coopObjectives: [],
+    leaderboard: [],
   };
+  base.leaderboard = ensureLeaderboard(base.leaderboard, base.profile);
+  base.coopObjectives = generateObjectives(base.coopObjectives, now);
+  refreshChallengeBoard(base, now);
+  return base;
 }
 
 // ===== Load/save =====
@@ -101,20 +554,10 @@ function loadStateRaw(): LocalState {
     return s;
   }
   try {
-    const s = JSON.parse(raw) as LocalState;
-    if (!(s as any).version) (s as any).version = VERSION;
-    if (s.version < 2) {
-      s.version = 2;
-      if (!s.profile) {
-        s.profile = seed().profile;
-      } else {
-        if (typeof s.profile.level !== "number") s.profile.level = 1;
-        if (typeof s.profile.exp !== "number") s.profile.exp = 0;
-        if (typeof s.profile.winStreak !== "number") s.profile.winStreak = 0;
-      }
-      saveState(s);
-    }
-    return s;
+    const parsed = JSON.parse(raw);
+    const state = migrateState(parsed);
+    saveState(state);
+    return state;
   } catch {
     const s = seed();
     try {
@@ -126,6 +569,7 @@ function loadStateRaw(): LocalState {
   }
 }
 function saveState(state: LocalState) {
+  state.version = VERSION;
   if (!storage) {
     memoryState = state;
     return;
@@ -138,16 +582,19 @@ function saveState(state: LocalState) {
 }
 
 // ===== Helpers =====
-const findActive = (s: LocalState) => s.decks.find(d => d.isActive) ?? s.decks[0];
+const findActive = (s: LocalState) => s.decks.find((d) => d.isActive) ?? s.decks[0];
 const sum = (cards: DeckCard[]) => cards.reduce((a, c) => a + c.qty, 0);
-const qtyInDeck = (d: Deck, id: string) => d.cards.find(c => c.cardId === id)?.qty ?? 0;
+const qtyInDeck = (d: Deck, id: string) => d.cards.find((c) => c.cardId === id)?.qty ?? 0;
 const setQty = (d: Deck, id: string, q: number) => {
-  const i = d.cards.findIndex(c => c.cardId === id);
-  if (q <= 0) { if (i >= 0) d.cards.splice(i, 1); return; }
-  if (i >= 0) d.cards[i].qty = q; else d.cards.push({ cardId: id, qty: q });
+  const i = d.cards.findIndex((c) => c.cardId === id);
+  if (q <= 0) {
+    if (i >= 0) d.cards.splice(i, 1);
+    return;
+  }
+  if (i >= 0) d.cards[i].qty = q;
+  else d.cards.push({ cardId: id, qty: q });
 };
-const ownAtLeast = (inv: InventoryItem[], id: string, need: number) =>
-  (inv.find(i => i.cardId === id)?.qty ?? 0) >= need;
+const ownAtLeast = (inv: InventoryItem[], id: string, need: number) => (inv.find((i) => i.cardId === id)?.qty ?? 0) >= need;
 
 const EXP_BASE = 100;
 
@@ -164,6 +611,13 @@ const toLevelProgress = (profile: Profile): LevelProgress => {
   return { level: profile.level, exp: profile.exp, expToNext, percent };
 };
 
+export type MatchContext = {
+  didWin: boolean;
+  mode?: "solo" | "multiplayer" | "coop";
+  wheelArchetypes?: WheelArchetype[];
+  cooperativeObjectiveProgress?: number;
+};
+
 export type MatchResultSummary = {
   didWin: boolean;
   expGained: number;
@@ -172,12 +626,21 @@ export type MatchResultSummary = {
   after: LevelProgress;
   segments: LevelProgressSegment[];
   levelUps: number;
+  challengeProgress?: ChallengeProgressSnapshot[];
+  unlockedArchetypes?: WheelArchetype[];
+  currencies?: CurrencyLedger;
+  sharedStats?: SharedStats;
+  coopObjectives?: CoopObjective[];
+  leaderboard?: LeaderboardEntry[];
 };
 
-export function recordMatchResult({ didWin }: { didWin: boolean }): MatchResultSummary {
+export function recordMatchResult({ didWin, mode = "solo", wheelArchetypes = [], cooperativeObjectiveProgress = 0 }: MatchContext): MatchResultSummary {
   const state = loadStateRaw();
   const profile = state.profile;
   const before = toLevelProgress(profile);
+  const now = Date.now();
+
+  refreshChallengeBoard(state, now);
 
   let expGained = 0;
   let levelUps = 0;
@@ -214,11 +677,65 @@ export function recordMatchResult({ didWin }: { didWin: boolean }): MatchResultS
 
     profile.level = curLevel;
     profile.exp = curExp;
+
+    applyChallengeProgress(state, "win_matches", 1, now);
+    if (mode === "coop" || mode === "multiplayer") {
+      applyChallengeProgress(state, "coop_victories", 1, now);
+    }
   } else {
     profile.winStreak = 0;
   }
 
+  applyChallengeProgress(state, "play_cards", 3, now);
+  if (cooperativeObjectiveProgress > 0) {
+    objectiveProgress(state, cooperativeObjectiveProgress, now);
+  }
+
+  // Shared stats + leaderboard persistence
+  if (mode !== "solo") {
+    state.sharedStats.lastUpdated = now;
+    if (didWin) state.sharedStats.coopWins += 1;
+    else state.sharedStats.coopLosses += 1;
+
+    const localEntry = state.leaderboard.find((entry) => entry.playerId === profile.id);
+    if (localEntry) {
+      const delta = didWin ? 15 : -10;
+      localEntry.rating = Math.max(0, localEntry.rating + delta);
+      if (didWin) localEntry.victories += 1;
+      localEntry.updatedAt = now;
+      state.sharedStats.leaderboardRating = localEntry.rating;
+    }
+  }
+
+  if (mode === "coop" && cooperativeObjectiveProgress <= 0 && didWin) {
+    objectiveProgress(state, 1, now);
+  }
+
+  // Level-based unlocks
+  const unlocked: WheelArchetype[] = [];
+  if (!state.profile.unlocks.wheels.guardian && profile.level >= 5) {
+    state.profile.unlocks.wheels.guardian = true;
+    unlocked.push("guardian");
+  }
+  if (!state.profile.unlocks.wheels.chaos && profile.level >= 12) {
+    state.profile.unlocks.wheels.chaos = true;
+    unlocked.push("chaos");
+  }
+
   const after = toLevelProgress(profile);
+
+  const challengeProgress: ChallengeProgressSnapshot[] = [
+    ...state.challenges.daily,
+    ...state.challenges.weekly,
+  ].map((ch) => ({
+    id: ch.id,
+    kind: ch.kind,
+    progress: ch.progress,
+    target: ch.target,
+    completed: !!ch.completedAt,
+    claimed: !!ch.claimedAt,
+  }));
+
   saveState(state);
 
   return {
@@ -229,45 +746,72 @@ export function recordMatchResult({ didWin }: { didWin: boolean }): MatchResultS
     after,
     segments,
     levelUps,
+    challengeProgress,
+    unlockedArchetypes: unlocked.length ? unlocked : undefined,
+    currencies: { ...state.profile.currencies },
+    sharedStats: { ...state.sharedStats },
+    coopObjectives: state.coopObjectives.map((o) => ({ ...o })),
+    leaderboard: state.leaderboard.map((l) => ({ ...l })),
   };
 }
 
 // ===== Public profile/deck management API (used by UI) =====
-export type ProfileBundle = { profile: Profile; inventory: InventoryItem[]; decks: Deck[]; active: Deck | undefined };
+export type ProfileBundle = {
+  profile: Profile;
+  inventory: InventoryItem[];
+  decks: Deck[];
+  active: Deck | undefined;
+  challenges: ChallengeBoard;
+  sharedStats: SharedStats;
+  coopObjectives: CoopObjective[];
+  leaderboard: LeaderboardEntry[];
+};
 
 export function getProfileBundle(): ProfileBundle {
   const s = loadStateRaw();
-  return { profile: s.profile, inventory: s.inventory, decks: s.decks, active: findActive(s) };
+  refreshChallengeBoard(s);
+  saveState(s);
+  return {
+    profile: s.profile,
+    inventory: s.inventory,
+    decks: s.decks,
+    active: findActive(s),
+    challenges: s.challenges,
+    sharedStats: s.sharedStats,
+    coopObjectives: s.coopObjectives,
+    leaderboard: s.leaderboard,
+  };
 }
 export function createDeck(name = "New Deck") {
   const s = loadStateRaw();
   const d: Deck = { id: uid("deck"), name, isActive: false, cards: [] };
-  s.decks.push(d); saveState(s); return d;
+  s.decks.push(d);
+  saveState(s);
+  return d;
 }
 export function setActiveDeck(id: string) {
   const s = loadStateRaw();
-  s.decks = s.decks.map(d => ({ ...d, isActive: d.id === id }));
+  s.decks = s.decks.map((d) => ({ ...d, isActive: d.id === id }));
   saveState(s);
 }
 export function renameDeck(id: string, name: string) {
   const s = loadStateRaw();
-  const d = s.decks.find(x => x.id === id);
+  const d = s.decks.find((x) => x.id === id);
   if (d) d.name = name || "Deck";
   saveState(s);
 }
 export function deleteDeck(id: string) {
   const s = loadStateRaw();
-  s.decks = s.decks.filter(d => d.id !== id);
-  if (!s.decks.some(d => d.isActive) && s.decks[0]) s.decks[0].isActive = true;
+  s.decks = s.decks.filter((d) => d.id !== id);
+  if (!s.decks.some((d) => d.isActive) && s.decks[0]) s.decks[0].isActive = true;
   saveState(s);
 }
-export type SwapItem = { cardId: string; qty: number };
 export function swapDeckCards(deckId: string, remove: SwapItem[], add: SwapItem[]) {
   const s = loadStateRaw();
-  const deck = s.decks.find(d => d.id === deckId);
+  const deck = s.decks.find((d) => d.id === deckId);
   if (!deck) throw new Error("Deck not found");
 
-  const next: DeckCard[] = deck.cards.map(c => ({ ...c }));
+  const next: DeckCard[] = deck.cards.map((c) => ({ ...c }));
   const tmp: Deck = { ...deck, cards: next };
 
   for (const r of remove) setQty(tmp, r.cardId, Math.max(0, qtyInDeck(tmp, r.cardId) - r.qty));
@@ -277,8 +821,7 @@ export function swapDeckCards(deckId: string, remove: SwapItem[], add: SwapItem[
   for (const c of tmp.cards) {
     if (!c.cardId.startsWith("basic_") && c.qty > MAX_COPIES_PER_DECK)
       throw new Error(`Too many copies of ${c.cardId} (max ${MAX_COPIES_PER_DECK})`);
-    if (!ownAtLeast(s.inventory, c.cardId, 1))
-      throw new Error(`You don't own ${c.cardId}`);
+    if (!ownAtLeast(s.inventory, c.cardId, 1)) throw new Error(`You don't own ${c.cardId}`);
   }
 
   deck.cards = tmp.cards;
@@ -288,17 +831,119 @@ export function swapDeckCards(deckId: string, remove: SwapItem[], add: SwapItem[
 export function addToInventory(items: SwapItem[]) {
   const s = loadStateRaw();
   for (const it of items) {
-    const i = s.inventory.findIndex(x => x.cardId === it.cardId);
+    const i = s.inventory.findIndex((x) => x.cardId === it.cardId);
     if (i >= 0) s.inventory[i].qty += it.qty;
     else s.inventory.push({ cardId: it.cardId, qty: it.qty });
   }
   saveState(s);
 }
 
+export function adjustCurrency(currency: CurrencyId, delta: number): number {
+  const s = loadStateRaw();
+  const current = s.profile.currencies[currency] ?? 0;
+  const next = Math.max(0, current + Math.floor(delta));
+  s.profile.currencies[currency] = next;
+  saveState(s);
+  return next;
+}
+
+export function unlockWheel(archetype: WheelArchetype) {
+  const s = loadStateRaw();
+  if (!s.profile.unlocks.wheels[archetype]) {
+    s.profile.unlocks.wheels[archetype] = true;
+    saveState(s);
+  }
+}
+
+export function getUnlockedWheelArchetypes(): WheelArchetype[] {
+  const s = loadStateRaw();
+  return (Object.keys(s.profile.unlocks.wheels) as WheelArchetype[]).filter((key) => s.profile.unlocks.wheels[key]);
+}
+
+export function getChallengeBoard(): ChallengeBoard {
+  const s = loadStateRaw();
+  refreshChallengeBoard(s);
+  saveState(s);
+  return {
+    daily: s.challenges.daily.map(cloneChallenge),
+    weekly: s.challenges.weekly.map(cloneChallenge),
+    generatedAt: { ...s.challenges.generatedAt },
+  };
+}
+
+export function claimChallengeReward(id: string): Challenge | null {
+  const s = loadStateRaw();
+  refreshChallengeBoard(s);
+  const all = [...s.challenges.daily, ...s.challenges.weekly];
+  const target = all.find((ch) => ch.id === id);
+  if (!target || !target.completedAt || target.claimedAt) return null;
+  const now = Date.now();
+  target.claimedAt = now;
+  applyReward(s, target.reward, now);
+  saveState(s);
+  return cloneChallenge(target);
+}
+
+export function getSharedStats(): SharedStats {
+  const s = loadStateRaw();
+  return { ...s.sharedStats };
+}
+
+export function applySharedStatsFromNetwork(snapshot: SharedStats): SharedStats {
+  const s = loadStateRaw();
+  s.sharedStats = {
+    coopWins: Math.max(s.sharedStats.coopWins, snapshot.coopWins),
+    coopLosses: Math.max(s.sharedStats.coopLosses, snapshot.coopLosses),
+    objectivesCompleted: Math.max(s.sharedStats.objectivesCompleted, snapshot.objectivesCompleted),
+    leaderboardRating: Math.max(s.sharedStats.leaderboardRating, snapshot.leaderboardRating),
+    lastUpdated: Math.max(s.sharedStats.lastUpdated, snapshot.lastUpdated),
+  };
+  saveState(s);
+  return { ...s.sharedStats };
+}
+
+export function getCoopObjectives(): CoopObjective[] {
+  const s = loadStateRaw();
+  s.coopObjectives = generateObjectives(s.coopObjectives, Date.now());
+  saveState(s);
+  return s.coopObjectives.map((o) => ({ ...o }));
+}
+
+export function applyCoopObjectivesSnapshot(list: CoopObjective[]): CoopObjective[] {
+  const s = loadStateRaw();
+  const now = Date.now();
+  const merged = generateObjectives(list.map((o) => ({ ...o })), now);
+  s.coopObjectives = merged;
+  saveState(s);
+  return merged.map((o) => ({ ...o }));
+}
+
+export function getLeaderboard(): LeaderboardEntry[] {
+  const s = loadStateRaw();
+  return s.leaderboard.map((entry) => ({ ...entry }));
+}
+
+export function applyLeaderboardSnapshot(entries: LeaderboardEntry[]): LeaderboardEntry[] {
+  const s = loadStateRaw();
+  const map = new Map<string, LeaderboardEntry>();
+  for (const entry of [...s.leaderboard, ...entries]) {
+    const existing = map.get(entry.playerId);
+    if (!existing || existing.rating < entry.rating) {
+      map.set(entry.playerId, { ...entry });
+    }
+  }
+  s.leaderboard = Array.from(map.values()).sort((a, b) => b.rating - a.rating);
+  saveState(s);
+  return s.leaderboard.map((entry) => ({ ...entry }));
+}
+
 // ====== CARD FACTORY to map profile cardIds -> real game Card ======
 
 // sequential card ids for the runtime deck
-const nextCardId = (() => { let i = 1; return () => `C${i++}`; })();
+const nextCardId = (() => {
+  let i = 1;
+  return () => `C${i++}`;
+})();
 
 /**
  * Supported cardId formats:
@@ -310,8 +955,8 @@ const nextCardId = (() => { let i = 1; return () => `C${i++}`; })();
 function cardFromId(cardId: string): Card {
   let num = 0;
   const mBasic = /^basic_(\d+)$/.exec(cardId);
-  const mNeg   = /^neg_(-?\d+)$/.exec(cardId);
-  const mNum   = /^num_(-?\d+)$/.exec(cardId);
+  const mNeg = /^neg_(-?\d+)$/.exec(cardId);
+  const mNum = /^num_(-?\d+)$/.exec(cardId);
 
   if (mBasic) num = parseInt(mBasic[1], 10);
   else if (mNeg) num = parseInt(mNeg[1], 10);


### PR DESCRIPTION
## Summary
- expand the profile store with currencies, unlock flags, cosmetics, challenge generation, shared stats, cooperative objectives, and leaderboard support plus migration utilities
- allow multiplayer payloads to share progress snapshots and unlockable wheel archetypes that the client now respects when building wheels and recording match results
- surface the new progression data on the profile page with reward claiming, shared progress, and leaderboard snapshots

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d138844c208332ae670fee184b09b8