### PR TITLE
Remove swap/double victories and add spells popover

### DIFF
--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -127,9 +127,7 @@ export type VC =
   | "Weakest"
   | "ReserveSum"
   | "ClosestToTarget"
-  | "Initiative"
-  | "DoubleWin"
-  | "SwapWins";
+  | "Initiative";
 
 export type WheelArchetype = "bandit" | "sorcerer" | "beast" | "guardian" | "chaos";
 

--- a/src/game/wheel.ts
+++ b/src/game/wheel.ts
@@ -37,20 +37,6 @@ export const VC_META: Record<
     short: "INIT",
     explain: "Initiative holder wins.",
   },
-  DoubleWin: {
-    icon: "✨",
-    color: "#fb7185",
-    short: "DBL",
-    explain: "Higher value wins and awards 2 round wins.",
-    effect: "Winner gains two wins instead of one.",
-  },
-  SwapWins: {
-    icon: "🔄",
-    color: "#22d3ee",
-    short: "SWAP",
-    explain: "Lower value wins; after scoring, round tallies swap sides.",
-    effect: "Round win tallies trade places before the round is scored.",
-  },
 };
 
 export function genWheelSections(
@@ -80,8 +66,6 @@ export function genWheelSections(
     "ReserveSum",
     "ClosestToTarget",
     "Initiative",
-    "DoubleWin",
-    "SwapWins",
   ];
   const kinds: VC[] = shuffle(availableKinds, rng).slice(0, lens.length);
 


### PR DESCRIPTION
## Summary
- remove the Double Win and Swap Wins victory conditions from wheel metadata, types, and reference copy
- simplify round resolution logic now that only the core victory conditions remain
- replace the always-visible mana bar with a spell popover that opens from a new Spells button beside Reference

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d16bc732a88332b6f66f269b5eb5f4