### PR TITLE
Refactor spells and mana system

### DIFF
--- a/src/ProfilePage.tsx
+++ b/src/ProfilePage.tsx
@@ -139,15 +139,15 @@ const PERK_INFO: Record<SorcererPerk, { title: string; description: string }> = 
   },
   spellEcho: {
     title: "Spell Echo",
-    description: "Predictive casts grant +3 reserve instead of +2.",
+    description: "Fireball reduces an extra point without extra mana.",
   },
   planarSwap: {
     title: "Planar Swap",
-    description: "VC swaps cost 1 less mana (minimum 1).",
+    description: "Arcane Shift moves two slices instead of one.",
   },
   recallMastery: {
     title: "Recall Mastery",
-    description: "Reserve recalls are free and pull up to two cards when possible.",
+    description: "Hex reduces reserves by 3 instead of 2.",
   },
 };
 


### PR DESCRIPTION
## Summary
- replace the old mana planning flow with spell planning, implementing Fireball, Ice Shard, Mirror Image, Arcane Shift, Hex, and Time Twist along with the updated spell UI and perk interactions
- adjust round resolution to award 1 mana for every wheel victory, apply spell effects during value calculation, and respect hex penalties when comparing reserves
- refresh perk descriptions so Spell Echo, Planar Swap, and Recall Mastery describe their new spell-driven benefits

## Testing
- npm run build
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d1711ad34083328556e0220a6a4d9f