### PR TITLE
Fix resolve button not triggering resolve phase

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1743,9 +1743,25 @@ animateSpins();    // <-- CALL IT
 
     if (resolveVotes[localLegacySide]) return;
 
+    const remoteReady = resolveVotes[remoteLegacySide];
+
     markResolveVote(localLegacySide);
     sendIntent({ type: "reveal", side: localLegacySide });
-  }, [canReveal, isMultiplayer, localLegacySide, markResolveVote, onReveal, phase, resolveVotes, sendIntent]);
+
+    if (remoteReady) {
+      onReveal();
+    }
+  }, [
+    canReveal,
+    isMultiplayer,
+    localLegacySide,
+    markResolveVote,
+    onReveal,
+    phase,
+    remoteLegacySide,
+    resolveVotes,
+    sendIntent,
+  ]);
 
   const handleNextClick = useCallback(() => {
     if (phase !== "roundEnd") return;


### PR DESCRIPTION
## Summary
- trigger the reveal phase immediately when the second multiplayer player clicks resolve
- call onReveal as soon as both sides are ready while still broadcasting readiness to the room

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1773ecf608332945e3508e1f915c6