### PR TITLE
Remove wheel archetype labels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2404,9 +2404,6 @@ return (
   onClick={(e) => { e.stopPropagation(); tapAssignIfSelected(); }}
   aria-label={`Wheel ${i+1}`}
 >
-    <div className="pointer-events-none absolute top-2 left-1/2 -translate-x-1/2 text-[11px] font-semibold uppercase tracking-wide text-white/80">
-      {(wheelArchetypes[i] ?? `wheel-${i + 1}`).replace(/^(\w)/, (c) => c.toUpperCase())}
-    </div>
     <CanvasWheel ref={wheelRefs[i]} sections={wheelSections[i]} size={ws} />
     <div
       aria-hidden


### PR DESCRIPTION
## Summary
- remove the overlay text labels above each wheel so archetype names no longer display

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d17b40f17483328bc2d31a54ae5203