### PR TITLE
Extract spell buttons into dedicated component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,7 @@ import { fmtNum } from "./game/values";
 // components
 import CanvasWheel, { WheelHandle } from "./components/CanvasWheel";
 import StSCard from "./components/StSCard";
+import SpellButtons from "./components/SpellButtons";
 
 type AblyRealtime = InstanceType<typeof Realtime>;
 type AblyChannel = ReturnType<AblyRealtime["channels"]["get"]>;
@@ -2712,51 +2713,6 @@ const PreSpinControls = () => {
   const notes = plan.notes.length ? plan.notes.join(' · ') : 'None';
   const timeTwistDisabled = !canAct || mana < 1 || plan.initiativeSwapped;
 
-  const spells = [
-    {
-      key: 'fireball',
-      label: 'Fireball (spend X mana)',
-      onClick: handleFireballCast,
-      disabled: !canAct || mana < 1,
-      help: 'Spend mana to reduce an enemy lane by X (+1 with Spell Echo).',
-    },
-    {
-      key: 'ice-shard',
-      label: 'Ice Shard (-1 mana)',
-      onClick: handleIceShardCast,
-      disabled: !canAct || mana < 1,
-      help: 'Freeze an enemy lane; its value can no longer change this round.',
-    },
-    {
-      key: 'mirror-image',
-      label: 'Mirror Image (-1 mana)',
-      onClick: handleMirrorImageCast,
-      disabled: !canAct || mana < 1,
-      help: 'Copy the opposing card on a lane you committed to.',
-    },
-    {
-      key: 'arcane-shift',
-      label: 'Arcane Shift (-1 mana)',
-      onClick: handleArcaneShiftCast,
-      disabled: !canAct || mana < 1,
-      help: 'Move a wheel’s pointer by ±1 slice (±2 with Planar Swap).',
-    },
-    {
-      key: 'hex',
-      label: 'Hex (-1 mana)',
-      onClick: handleHexCast,
-      disabled: !canAct || mana < 1,
-      help: 'Reduce the opponent’s reserve sum by 2 (3 with Recall Mastery).',
-    },
-    {
-      key: 'time-twist',
-      label: plan.initiativeSwapped ? 'Time Twist (used)' : 'Time Twist (-1 mana)',
-      onClick: handleTimeTwistCast,
-      disabled: timeTwistDisabled,
-      help: 'Swap initiative for the rest of the round.',
-    },
-  ];
-
   return (
     <div className="space-y-3 text-[12px] text-slate-100">
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -2764,20 +2720,18 @@ const PreSpinControls = () => {
           Mana: <span className="tabular-nums">{mana}</span>
         </div>
       </div>
-      <div className="space-y-2">
-        {spells.map((spell) => (
-          <div key={spell.key} className="flex flex-col gap-0.5">
-            <button
-              onClick={spell.onClick}
-              disabled={spell.disabled}
-              className="rounded bg-amber-400/90 px-2 py-1 font-semibold text-slate-900 transition disabled:opacity-40"
-            >
-              {spell.label}
-            </button>
-            <span className="text-[11px] text-slate-300">{spell.help}</span>
-          </div>
-        ))}
-      </div>
+      <SpellButtons
+        mana={mana}
+        canAct={canAct}
+        timeTwistDisabled={timeTwistDisabled}
+        timeTwistUsed={plan.initiativeSwapped}
+        onFireball={handleFireballCast}
+        onIceShard={handleIceShardCast}
+        onMirrorImage={handleMirrorImageCast}
+        onArcaneShift={handleArcaneShiftCast}
+        onHex={handleHexCast}
+        onTimeTwist={handleTimeTwistCast}
+      />
       <div className="text-[11px] text-slate-300">Active effects: {notes}</div>
       {!canAct && isMultiplayer ? (
         <div className="text-[11px] text-slate-400 italic">

--- a/src/components/SpellButtons.tsx
+++ b/src/components/SpellButtons.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+
+type SpellButtonConfig = {
+  key: string;
+  label: string;
+  help: string;
+  disabled: boolean;
+  onClick: () => void;
+};
+
+type SpellButtonsProps = {
+  mana: number;
+  canAct: boolean;
+  timeTwistDisabled: boolean;
+  timeTwistUsed: boolean;
+  onFireball: () => void;
+  onIceShard: () => void;
+  onMirrorImage: () => void;
+  onArcaneShift: () => void;
+  onHex: () => void;
+  onTimeTwist: () => void;
+};
+
+const SpellButtons: React.FC<SpellButtonsProps> = ({
+  mana,
+  canAct,
+  timeTwistDisabled,
+  timeTwistUsed,
+  onFireball,
+  onIceShard,
+  onMirrorImage,
+  onArcaneShift,
+  onHex,
+  onTimeTwist,
+}) => {
+  const spellButtons: SpellButtonConfig[] = [
+    {
+      key: "fireball",
+      label: "Fireball (spend X mana)",
+      onClick: onFireball,
+      disabled: !canAct || mana < 1,
+      help: "Spend mana to reduce an enemy lane by X (+1 with Spell Echo).",
+    },
+    {
+      key: "ice-shard",
+      label: "Ice Shard (-1 mana)",
+      onClick: onIceShard,
+      disabled: !canAct || mana < 1,
+      help: "Freeze an enemy lane; its value can no longer change this round.",
+    },
+    {
+      key: "mirror-image",
+      label: "Mirror Image (-1 mana)",
+      onClick: onMirrorImage,
+      disabled: !canAct || mana < 1,
+      help: "Copy the opposing card on a lane you committed to.",
+    },
+    {
+      key: "arcane-shift",
+      label: "Arcane Shift (-1 mana)",
+      onClick: onArcaneShift,
+      disabled: !canAct || mana < 1,
+      help: "Move a wheel’s pointer by ±1 slice (±2 with Planar Swap).",
+    },
+    {
+      key: "hex",
+      label: "Hex (-1 mana)",
+      onClick: onHex,
+      disabled: !canAct || mana < 1,
+      help: "Reduce the opponent’s reserve sum by 2 (3 with Recall Mastery).",
+    },
+    {
+      key: "time-twist",
+      label: timeTwistUsed ? "Time Twist (used)" : "Time Twist (-1 mana)",
+      onClick: onTimeTwist,
+      disabled: timeTwistDisabled,
+      help: "Swap initiative for the rest of the round.",
+    },
+  ];
+
+  return (
+    <div className="space-y-2">
+      {spellButtons.map((spell) => (
+        <div key={spell.key} className="flex flex-col gap-0.5">
+          <button
+            onClick={spell.onClick}
+            disabled={spell.disabled}
+            className="rounded bg-amber-400/90 px-2 py-1 font-semibold text-slate-900 transition disabled:opacity-40"
+          >
+            {spell.label}
+          </button>
+          <span className="text-[11px] text-slate-300">{spell.help}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default SpellButtons;


### PR DESCRIPTION
## Summary
- add a SpellButtons component that encapsulates the spell definitions and button rendering
- update PreSpinControls to consume the new component instead of defining spell metadata inline

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d189a1c9b8833295f5cc1c24806a5a