### PR TITLE
Add mode select flow and game mode flag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import React, {
 } from "react";
 import { Realtime } from "ably";
 import { motion } from "framer-motion";
+import type { GameMode } from "./gameModes";
 
 
 /**
@@ -91,6 +92,7 @@ export default function ThreeWheel_WinsOnly({
   hostId,
   targetWins,
   onExit,
+  gameMode = "classic",
 }: {
   localSide: TwoSide;
   localPlayerId: string;
@@ -100,6 +102,7 @@ export default function ThreeWheel_WinsOnly({
   hostId?: string;
   targetWins?: number;
   onExit?: () => void;
+  gameMode?: GameMode;
 }) {
   const mountedRef = useRef(true);
   useEffect(() => { mountedRef.current = true; return () => { mountedRef.current = false; timeoutsRef.current.forEach(clearTimeout); timeoutsRef.current.clear(); }; }, []);
@@ -133,6 +136,7 @@ export default function ThreeWheel_WinsOnly({
   })();
 
   const isMultiplayer = !!roomCode;
+  const isGrimoireMode = gameMode === "grimoire";
   const ablyRef = useRef<AblyRealtime | null>(null);
   const chanRef = useRef<AblyChannel | null>(null);
 
@@ -1653,8 +1657,18 @@ const HUDPanels = () => {
     if (phase !== "ended") setVictoryCollapsed(false); // reset when leaving "ended"
   }, [phase]);
 
+  const rootModeClassName = isGrimoireMode ? "grimoire-mode" : "classic-mode";
+  const grimoireAttrValue = isGrimoireMode ? "true" : "false";
+
   return (
-    <div className="h-screen w-screen overflow-x-hidden overflow-y-hidden text-slate-100 p-1 grid gap-2" style={{ gridTemplateRows: "auto auto 1fr auto" }}>
+    <div
+      className={`h-screen w-screen overflow-x-hidden overflow-y-hidden text-slate-100 p-1 grid gap-2 ${rootModeClassName}`}
+      style={{ gridTemplateRows: "auto auto 1fr auto" }}
+      data-game-mode={gameMode}
+      data-mana-enabled={grimoireAttrValue}
+      data-spells-enabled={grimoireAttrValue}
+      data-archetypes-enabled={grimoireAttrValue}
+    >
       {/* Controls */}
       <div className="flex items-center justify-between text-[12px] min-h-[24px]">
         <div className="flex items-center gap-3">

--- a/src/ModeSelect.tsx
+++ b/src/ModeSelect.tsx
@@ -1,0 +1,94 @@
+import React, { useMemo, useState } from "react";
+import { DEFAULT_GAME_MODE, GAME_MODE_DETAILS, type GameMode } from "./gameModes";
+
+type ModeSelectProps = {
+  initialMode?: GameMode;
+  onConfirm: (mode: GameMode) => void;
+  onBack: () => void;
+  backLabel?: string;
+  confirmLabel?: string;
+};
+
+export default function ModeSelect({
+  initialMode = DEFAULT_GAME_MODE,
+  onConfirm,
+  onBack,
+  backLabel = "← Back",
+  confirmLabel = "Confirm Mode",
+}: ModeSelectProps) {
+  const [selectedMode, setSelectedMode] = useState<GameMode>(initialMode);
+
+  const detailEntries = useMemo(() => Object.entries(GAME_MODE_DETAILS) as [GameMode, typeof GAME_MODE_DETAILS[GameMode]][], []);
+
+  return (
+    <div className="min-h-dvh bg-slate-950 text-slate-100">
+      <div className="mx-auto flex min-h-dvh w-full max-w-4xl flex-col px-4 py-6 sm:px-8">
+        <div>
+          <button
+            type="button"
+            onClick={onBack}
+            className="text-sm font-semibold text-emerald-300 hover:text-emerald-200"
+          >
+            {backLabel}
+          </button>
+        </div>
+
+        <div className="mt-6 flex flex-col gap-3 text-left">
+          <h1 className="text-3xl font-bold sm:text-4xl">Choose a Mode</h1>
+          <p className="max-w-2xl text-sm text-slate-300 sm:text-base">
+            Classic keeps today&apos;s streamlined experience. Grimoire layers in experimental systems for seasoned players.
+          </p>
+        </div>
+
+        <div className="mt-8 grid gap-4 sm:grid-cols-2">
+          {detailEntries.map(([mode, info]) => {
+            const isSelected = selectedMode === mode;
+            return (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setSelectedMode(mode)}
+                className={[
+                  "rounded-2xl border p-5 text-left transition focus:outline-none",
+                  "bg-slate-900/60 hover:bg-slate-900/80",
+                  isSelected ? "border-emerald-400 shadow-[0_0_0_2px_rgba(16,185,129,0.35)]" : "border-slate-700",
+                ].join(" ")}
+                aria-pressed={isSelected}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <div className="text-lg font-semibold sm:text-xl">{info.title}</div>
+                    <div className="text-sm text-slate-300 sm:text-base">{info.subtitle}</div>
+                  </div>
+                  {isSelected && (
+                    <span className="rounded-full bg-emerald-500/20 px-2 py-0.5 text-xs font-semibold text-emerald-200">
+                      Selected
+                    </span>
+                  )}
+                </div>
+                <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-slate-300">
+                  {info.highlights.map((line) => (
+                    <li key={line}>{line}</li>
+                  ))}
+                </ul>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-xs text-slate-400 sm:text-sm">
+            You can swap modes later from the main menu.
+          </div>
+          <button
+            type="button"
+            onClick={() => onConfirm(selectedMode)}
+            className="inline-flex items-center justify-center rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/gameModes.ts
+++ b/src/gameModes.ts
@@ -1,0 +1,31 @@
+export type GameMode = "classic" | "grimoire";
+
+export const DEFAULT_GAME_MODE: GameMode = "classic";
+
+export const GAME_MODE_DETAILS: Record<
+  GameMode,
+  {
+    title: string;
+    subtitle: string;
+    highlights: string[];
+  }
+> = {
+  classic: {
+    title: "Classic",
+    subtitle: "Pure spins and tactical cardplay.",
+    highlights: [
+      "Original ruleset with straightforward drafting",
+      "No mana, spells, or archetype management",
+      "Great for quick matches and onboarding",
+    ],
+  },
+  grimoire: {
+    title: "Grimoire",
+    subtitle: "Experimental systems and power-ups.",
+    highlights: [
+      "Adds mana economy and spellcasting windows",
+      "Wheel archetypes and progression modifiers",
+      "Best for advanced players seeking depth",
+    ],
+  },
+};


### PR DESCRIPTION
## Summary
- add a reusable mode select screen that introduces Classic vs Grimoire and wire it into hub and multiplayer start flows
- persist multiplayer start payloads while choosing a mode, track the selected gameMode, and pass it through AppShell into App
- provide shared game mode metadata and data attributes so Grimoire-specific affordances stay hidden for Classic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d190b0e5988332811a12063d66f46d