### PR TITLE
Add archetype gating for Grimoire mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,8 +71,6 @@ type AblyChannel = ReturnType<AblyRealtime["channels"]["get"]>;
 // keep your local alias
 type LegacySide = "player" | "enemy";
 
-type GameMode = "classic" | "grimoire";
-
 // your existing MPIntent union (merged from conflict)
 type MPIntent =
   | { type: "assign"; lane: number; side: LegacySide; card: Card }
@@ -108,7 +106,6 @@ export default function ThreeWheel_WinsOnly({
   hostId,
   targetWins,
   onExit,
-  gameMode = "classic",
 }: {
   localSide: TwoSide;
   localPlayerId: string;
@@ -119,7 +116,6 @@ export default function ThreeWheel_WinsOnly({
   hostId?: string;
   targetWins?: number;
   onExit?: () => void;
-  gameMode?: GameMode;
 }) {
   const mountedRef = useRef(true);
   useEffect(() => { mountedRef.current = true; return () => { mountedRef.current = false; timeoutsRef.current.forEach(clearTimeout); timeoutsRef.current.clear(); }; }, []);
@@ -186,8 +182,6 @@ const effectiveGameMode: GameMode =
     typeof targetWins === "number" && Number.isFinite(targetWins)
       ? Math.max(1, Math.min(15, Math.round(targetWins)))
       : TARGET_WINS;
-
-  const isGrimoireMode = gameMode === "grimoire";
 
   const createInitialArchetypeSelection = () => ({
     player: isGrimoireMode ? null : DEFAULT_ARCHETYPE,
@@ -625,16 +619,18 @@ const storeReserveReport = useCallback(
     return typeof maybe === "number" && Number.isFinite(maybe) ? maybe : 0;
   }, [player]);
 
-  const playerSpells = useMemo(() => {
-    if (gameMode !== "grimoire") return [] as SpellDefinition[];
-    return getLearnedSpellsForFighter(player);
-  }, [gameMode, player]);
+const playerSpells = useMemo(() => {
+  if (!isGrimoireMode) return [] as SpellDefinition[];
+  return getLearnedSpellsForFighter(player);
+}, [isGrimoireMode, player]);
 
-  useEffect(() => {
-    if (gameMode !== "grimoire" && showGrimoire) {
-      setShowGrimoire(false);
-    }
-  }, [gameMode, showGrimoire]);
+
+useEffect(() => {
+  if (!isGrimoireMode && showGrimoire) {
+    setShowGrimoire(false);
+  }
+}, [isGrimoireMode, showGrimoire]);
+
 
   useEffect(() => {
     if (!showRef && !showGrimoire) return;
@@ -2197,7 +2193,6 @@ const HUDPanels = ({
   data-archetypes-enabled={grimoireAttrValue}
 >
   {showArchetypeModal && renderArchetypeModal()}
-    >
 
 
       {/* Controls */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,12 @@ import {
 import { easeInOutCubic, inSection, createSeededRng } from "./game/math";
 import { VC_META, genWheelSections } from "./game/wheel";
 import {
+  ARCHETYPE_DEFINITIONS,
+  ARCHETYPE_IDS,
+  DEFAULT_ARCHETYPE,
+  type ArchetypeId,
+} from "./game/archetypes";
+import {
   makeFighter,
   drawOne,
   refillTo,
@@ -59,6 +65,8 @@ type AblyChannel = ReturnType<AblyRealtime["channels"]["get"]>;
 // keep your local alias
 type LegacySide = "player" | "enemy";
 
+type GameMode = "classic" | "grimoire";
+
 // your existing MPIntent union (merged from conflict)
 type MPIntent =
   | { type: "assign"; lane: number; side: LegacySide; card: Card }
@@ -66,7 +74,9 @@ type MPIntent =
   | { type: "reveal"; side: LegacySide }
   | { type: "nextRound"; side: LegacySide }
   | { type: "rematch"; side: LegacySide }
-  | { type: "reserve"; side: LegacySide; reserve: number; round: number };
+  | { type: "reserve"; side: LegacySide; reserve: number; round: number }
+  | { type: "archetypeSelect"; side: LegacySide; archetype: ArchetypeId }
+  | { type: "archetypeReady"; side: LegacySide; ready: boolean };
 
 // ---------------- Constants ----------------
 const MIN_WHEEL = 160;
@@ -87,6 +97,7 @@ export default function ThreeWheel_WinsOnly({
   localPlayerId,
   players,
   seed,
+  gameMode = "classic",
   roomCode,
   hostId,
   targetWins,
@@ -96,6 +107,7 @@ export default function ThreeWheel_WinsOnly({
   localPlayerId: string;
   players: Players;
   seed: number;
+  gameMode?: GameMode;
   roomCode?: string;
   hostId?: string;
   targetWins?: number;
@@ -124,6 +136,18 @@ export default function ThreeWheel_WinsOnly({
       ? Math.max(1, Math.min(15, Math.round(targetWins)))
       : TARGET_WINS;
 
+  const isGrimoireMode = gameMode === "grimoire";
+
+  const createInitialArchetypeSelection = () => ({
+    player: isGrimoireMode ? null : DEFAULT_ARCHETYPE,
+    enemy: isGrimoireMode ? null : DEFAULT_ARCHETYPE,
+  } satisfies Record<LegacySide, ArchetypeId | null>);
+
+  const createInitialArchetypeReady = () => ({
+    player: !isGrimoireMode,
+    enemy: !isGrimoireMode,
+  } satisfies Record<LegacySide, boolean>);
+
 
   const hostLegacySide: LegacySide = (() => {
     if (!hostId) return "player";
@@ -144,6 +168,78 @@ export default function ThreeWheel_WinsOnly({
   );
   const [wins, setWins] = useState<{ player: number; enemy: number }>({ player: 0, enemy: 0 });
   const [round, setRound] = useState(1);
+
+  const [archetypeSelections, setArchetypeSelections] = useState<
+    Record<LegacySide, ArchetypeId | null>
+  >(createInitialArchetypeSelection);
+  const [archetypeReady, setArchetypeReady] = useState<Record<LegacySide, boolean>>(
+    createInitialArchetypeReady
+  );
+
+  const archetypeSpellIdsBySide = useMemo(
+    () => ({
+      player: archetypeSelections.player
+        ? [...ARCHETYPE_DEFINITIONS[archetypeSelections.player].spellIds]
+        : [],
+      enemy: archetypeSelections.enemy
+        ? [...ARCHETYPE_DEFINITIONS[archetypeSelections.enemy].spellIds]
+        : [],
+    }),
+    [archetypeSelections]
+  );
+
+  const archetypeGateOpen =
+    !isGrimoireMode ||
+    (!!archetypeSelections.player &&
+      !!archetypeSelections.enemy &&
+      archetypeReady.player &&
+      archetypeReady.enemy);
+
+  useEffect(() => {
+    setArchetypeSelections(
+      isGrimoireMode
+        ? { player: null, enemy: null }
+        : { player: DEFAULT_ARCHETYPE, enemy: DEFAULT_ARCHETYPE }
+    );
+    setArchetypeReady(
+      isGrimoireMode
+        ? { player: false, enemy: false }
+        : { player: true, enemy: true }
+    );
+  }, [isGrimoireMode, setArchetypeReady, setArchetypeSelections]);
+
+  useEffect(() => {
+    if (!isGrimoireMode) return;
+    if (isMultiplayer) return;
+    const cpuSide = remoteLegacySide;
+    if (archetypeSelections[cpuSide]) return;
+
+    const timeoutId = setSafeTimeout(() => {
+      const ids = ARCHETYPE_IDS;
+      const pick = ids[Math.floor(Math.random() * ids.length)];
+      setArchetypeSelections((prev) => {
+        if (prev[cpuSide]) return prev;
+        return { ...prev, [cpuSide]: pick };
+      });
+      setArchetypeReady((prev) => {
+        if (prev[cpuSide]) return prev;
+        return { ...prev, [cpuSide]: true };
+      });
+      timeoutsRef.current.delete(timeoutId);
+    }, 450);
+
+    return () => {
+      clearTimeout(timeoutId);
+      timeoutsRef.current.delete(timeoutId);
+    };
+  }, [
+    archetypeSelections,
+    isGrimoireMode,
+    isMultiplayer,
+    remoteLegacySide,
+    setArchetypeReady,
+    setArchetypeSelections,
+  ]);
 
   // Freeze layout during resolution
   const [freezeLayout, setFreezeLayout] = useState(false);
@@ -469,9 +565,10 @@ const storeReserveReport = useCallback(
   const [log, setLog] = useState<string[]>([START_LOG]);
 
   const canReveal = useMemo(() => {
+    if (!archetypeGateOpen) return false;
     const lane = localLegacySide === "player" ? assign.player : assign.enemy;
     return lane.every((c, i) => !active[i] || !!c);
-  }, [assign, active, localLegacySide]);
+  }, [assign, active, archetypeGateOpen, localLegacySide]);
 
   // Wheel refs for imperative token updates
   const wheelRefs = [useRef<WheelHandle | null>(null), useRef<WheelHandle | null>(null), useRef<WheelHandle | null>(null)];
@@ -479,6 +576,7 @@ const storeReserveReport = useCallback(
   // ---- Assignment helpers (batched) ----
   const assignToWheelFor = useCallback(
     (side: LegacySide, laneIndex: number, card: Card) => {
+      if (!archetypeGateOpen) return false;
       if (!active[laneIndex]) return false;
 
 
@@ -533,12 +631,13 @@ const storeReserveReport = useCallback(
 
       return true;
     },
-    [active, clearResolveVotes, localLegacySide]
+    [active, archetypeGateOpen, clearResolveVotes, localLegacySide]
 
   );
 
   const clearAssignFor = useCallback(
     (side: LegacySide, laneIndex: number) => {
+      if (!archetypeGateOpen) return false;
       const lane = side === "player" ? assignRef.current.player : assignRef.current.enemy;
       const prev = lane[laneIndex];
       if (!prev) return false;
@@ -577,7 +676,7 @@ const storeReserveReport = useCallback(
 
       return true;
     },
-    [clearResolveVotes, localLegacySide]
+    [archetypeGateOpen, clearResolveVotes, localLegacySide]
   );
 
   function assignToWheelLocal(i: number, card: Card) {
@@ -930,6 +1029,27 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
           clearAssignFor(msg.side, msg.lane);
           break;
         }
+        case "archetypeSelect": {
+          if (msg.side === localLegacySide) break;
+          if (!msg.archetype || !(msg.archetype in ARCHETYPE_DEFINITIONS)) break;
+          setArchetypeSelections((prev) => {
+            if (prev[msg.side] === msg.archetype) return prev;
+            return { ...prev, [msg.side]: msg.archetype };
+          });
+          setArchetypeReady((prev) => {
+            if (!prev[msg.side]) return prev;
+            return { ...prev, [msg.side]: false };
+          });
+          break;
+        }
+        case "archetypeReady": {
+          if (msg.side === localLegacySide) break;
+          setArchetypeReady((prev) => {
+            if (prev[msg.side] === msg.ready) return prev;
+            return { ...prev, [msg.side]: !!msg.ready };
+          });
+          break;
+        }
         case "reveal": {
           if (msg.side === localLegacySide) break;
 
@@ -957,7 +1077,17 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
           break;
       }
     },
-    [assignToWheelFor, clearAssignFor, localLegacySide, markAdvanceVote, markRematchVote, markResolveVote, storeReserveReport]
+    [
+      assignToWheelFor,
+      clearAssignFor,
+      localLegacySide,
+      markAdvanceVote,
+      markRematchVote,
+      markResolveVote,
+      storeReserveReport,
+      setArchetypeReady,
+      setArchetypeSelections,
+    ]
   );
 
   useEffect(() => {
@@ -1067,6 +1197,17 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
     setRound(1);
     setPhase("choose");
 
+    setArchetypeSelections(
+      isGrimoireMode
+        ? { player: null, enemy: null }
+        : { player: DEFAULT_ARCHETYPE, enemy: DEFAULT_ARCHETYPE }
+    );
+    setArchetypeReady(
+      isGrimoireMode
+        ? { player: false, enemy: false }
+        : { player: true, enemy: true }
+    );
+
     const emptyAssign: { player: (Card | null)[]; enemy: (Card | null)[] } = {
       player: [null, null, null],
       enemy: [null, null, null],
@@ -1094,8 +1235,11 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
     generateWheelSet,
     hostId,
     hostLegacySide,
+    isGrimoireMode,
     localLegacySide,
     seed,
+    setArchetypeReady,
+    setArchetypeSelections,
     setAssign,
     setDragCardId,
     setEnemy,
@@ -1150,8 +1294,229 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
   }, [onExit]);
 
 
+  const showArchetypeModal = isGrimoireMode && !archetypeGateOpen;
+  const localSelection = archetypeSelections[localLegacySide];
+  const remoteSelection = archetypeSelections[remoteLegacySide];
+  const localReady = archetypeReady[localLegacySide];
+  const remoteReady = archetypeReady[remoteLegacySide];
+
+  const localSpells = archetypeSpellIdsBySide[localLegacySide];
+  const remoteSpells = archetypeSpellIdsBySide[remoteLegacySide];
+
+  const localArchetypeDef = localSelection
+    ? ARCHETYPE_DEFINITIONS[localSelection]
+    : null;
+  const remoteArchetypeDef = remoteSelection
+    ? ARCHETYPE_DEFINITIONS[remoteSelection]
+    : null;
+
+  const formatSpellId = useCallback((spellId: string) => {
+    if (!spellId) return spellId;
+    return spellId
+      .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+      .replace(/(^|\s)([a-z])/g, (_, prefix, char) => prefix + char.toUpperCase());
+  }, []);
+
+  const handleLocalArchetypeSelect = useCallback(
+    (id: ArchetypeId) => {
+      let changed = false;
+      setArchetypeSelections((prev) => {
+        if (prev[localLegacySide] === id) return prev;
+        changed = true;
+        return { ...prev, [localLegacySide]: id };
+      });
+      if (changed) {
+        setArchetypeReady((prev) => {
+          if (!prev[localLegacySide]) return prev;
+          return { ...prev, [localLegacySide]: false };
+        });
+        sendIntent({ type: "archetypeSelect", side: localLegacySide, archetype: id });
+      }
+    },
+    [localLegacySide, sendIntent, setArchetypeReady, setArchetypeSelections]
+  );
+
+  const handleLocalArchetypeReady = useCallback(() => {
+    if (!localSelection) return;
+    if (!isMultiplayer) {
+      setArchetypeReady((prev) => {
+        if (prev[localLegacySide]) return prev;
+        return { ...prev, [localLegacySide]: true };
+      });
+      return;
+    }
+
+    let nextReady: boolean | null = null;
+    setArchetypeReady((prev) => {
+      const toggled = !prev[localLegacySide];
+      nextReady = toggled;
+      return { ...prev, [localLegacySide]: toggled };
+    });
+    if (nextReady !== null) {
+      sendIntent({ type: "archetypeReady", side: localLegacySide, ready: nextReady });
+    }
+  }, [isMultiplayer, localLegacySide, localSelection, sendIntent, setArchetypeReady]);
+
+  const readyButtonLabel = isMultiplayer
+    ? localReady
+      ? "Unready"
+      : "Ready"
+    : "Next";
+  const readyButtonDisabled = !localSelection || (!isMultiplayer && localReady);
+
+
 
   // ---------------- UI ----------------
+
+  const renderArchetypeModal = () => (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 backdrop-blur-sm px-4 py-6">
+      <div className="w-full max-w-4xl space-y-6 rounded-2xl border border-slate-700 bg-slate-900/95 p-6 shadow-2xl">
+        <div className="space-y-2 text-center">
+          <h2 className="text-2xl font-semibold text-amber-200">Choose Your Archetype</h2>
+          <p className="text-sm text-slate-200/80">
+            Archetypes determine which spells appear in your grimoire. Pick one, then press
+            {" "}
+            {isMultiplayer ? "Ready" : "Next"} to begin.
+          </p>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-3">
+          {ARCHETYPE_IDS.map((id) => {
+            const def = ARCHETYPE_DEFINITIONS[id];
+            const isLocalChoice = localSelection === id;
+            const isRemoteChoice = remoteSelection === id;
+            return (
+              <div
+                key={id}
+                className="relative flex h-full flex-col rounded-xl border border-slate-700/70 bg-slate-800/70 p-4 shadow"
+                style={{
+                  borderColor: isLocalChoice
+                    ? HUD_COLORS[localLegacySide]
+                    : isRemoteChoice
+                    ? HUD_COLORS[remoteLegacySide]
+                    : undefined,
+                }}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <div className="text-lg font-semibold text-slate-100">{def.name}</div>
+                    <p className="mt-1 text-xs text-slate-300/80 leading-snug">{def.description}</p>
+                  </div>
+                  <div className="flex flex-col items-end gap-1 text-[10px] font-semibold uppercase tracking-wide">
+                    {isLocalChoice && (
+                      <span
+                        className="rounded-full px-2 py-0.5"
+                        style={{ background: `${HUD_COLORS[localLegacySide]}22`, color: HUD_COLORS[localLegacySide] }}
+                      >
+                        You
+                      </span>
+                    )}
+                    {isRemoteChoice && (
+                      <span
+                        className="rounded-full px-2 py-0.5"
+                        style={{ background: `${HUD_COLORS[remoteLegacySide]}22`, color: HUD_COLORS[remoteLegacySide] }}
+                      >
+                        {namesByLegacy[remoteLegacySide]}
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                <div className="mt-3 flex-1 rounded-lg border border-slate-700/70 bg-slate-900/60 p-3">
+                  <div className="text-xs font-semibold uppercase text-slate-300/80">Spells</div>
+                  <ul className="mt-2 space-y-1 text-xs text-slate-100/90">
+                    {def.spellIds.map((spell) => (
+                      <li key={spell} className="flex items-center gap-2">
+                        <span className="h-1.5 w-1.5 rounded-full bg-slate-500" aria-hidden />
+                        <span>{formatSpellId(spell)}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <button
+                  onClick={() => handleLocalArchetypeSelect(id)}
+                  disabled={isLocalChoice}
+                  className="mt-4 rounded-lg border border-amber-400/70 px-3 py-1.5 text-sm font-semibold text-amber-100 transition hover:bg-amber-400/10 disabled:cursor-not-allowed disabled:border-amber-200/40 disabled:text-amber-200/70"
+                >
+                  {isLocalChoice ? "Selected" : "Choose"}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="rounded-xl border border-slate-700/70 bg-slate-900/70 p-4">
+            <div className="flex items-center justify-between gap-2">
+              <div className="text-sm font-semibold text-slate-100">{namesByLegacy[localLegacySide]}</div>
+              <span
+                className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+                  localReady ? "bg-emerald-500/20 text-emerald-300" : "bg-slate-700/60 text-slate-300"
+                }`}
+              >
+                {localReady ? "Ready" : "Not Ready"}
+              </span>
+            </div>
+            <div className="mt-2 text-xs text-slate-300/90">
+              {localArchetypeDef ? localArchetypeDef.name : "Select an archetype"}
+            </div>
+            <ul className="mt-3 space-y-1 text-xs text-slate-100/90">
+              {localSpells.length === 0 ? (
+                <li className="italic text-slate-400">No spells yet</li>
+              ) : (
+                localSpells.map((spell) => <li key={spell}>{formatSpellId(spell)}</li>)
+              )}
+            </ul>
+          </div>
+
+          <div className="rounded-xl border border-slate-700/70 bg-slate-900/70 p-4">
+            <div className="flex items-center justify-between gap-2">
+              <div className="text-sm font-semibold text-slate-100">{namesByLegacy[remoteLegacySide]}</div>
+              <span
+                className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+                  remoteReady ? "bg-emerald-500/20 text-emerald-300" : "bg-slate-700/60 text-slate-300"
+                }`}
+              >
+                {remoteReady ? "Ready" : "Waiting"}
+              </span>
+            </div>
+            <div className="mt-2 text-xs text-slate-300/90">
+              {remoteArchetypeDef ? remoteArchetypeDef.name : "Awaiting selection"}
+            </div>
+            <ul className="mt-3 space-y-1 text-xs text-slate-100/90">
+              {remoteSpells.length === 0 ? (
+                <li className="italic text-slate-400">Hidden</li>
+              ) : (
+                remoteSpells.map((spell) => <li key={spell}>{formatSpellId(spell)}</li>)
+              )}
+            </ul>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-sm text-slate-300/90">
+            {isMultiplayer
+              ? remoteReady
+                ? `${namesByLegacy[remoteLegacySide]} is ready.`
+                : `Waiting for ${namesByLegacy[remoteLegacySide]}...`
+              : remoteArchetypeDef
+              ? `${namesByLegacy[remoteLegacySide]} is ready.`
+              : `${namesByLegacy[remoteLegacySide]} is choosing an archetype...`}
+          </div>
+          <div className="flex justify-end gap-2">
+            <button
+              onClick={handleLocalArchetypeReady}
+              disabled={readyButtonDisabled}
+              className="rounded-lg bg-amber-400 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-amber-300 disabled:cursor-not-allowed disabled:bg-amber-200/80"
+            >
+              {readyButtonLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 
   const renderWheelPanel = (i: number) => {
   const pc = assign.player[i];
@@ -1183,7 +1548,8 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
   const renderSlotCard = (slot: typeof leftSlot, isSlotSelected: boolean) => {
     if (!slot.card) return null;
     const card = slot.card;
-    const interactable = slot.side === localLegacySide && phase === "choose";
+    const interactable =
+      slot.side === localLegacySide && phase === "choose" && archetypeGateOpen;
 
     const handlePick = () => {
       if (!interactable) return;
@@ -1655,6 +2021,7 @@ const HUDPanels = () => {
 
   return (
     <div className="h-screen w-screen overflow-x-hidden overflow-y-hidden text-slate-100 p-1 grid gap-2" style={{ gridTemplateRows: "auto auto 1fr auto" }}>
+      {showArchetypeModal && renderArchetypeModal()}
       {/* Controls */}
       <div className="flex items-center justify-between text-[12px] min-h-[24px]">
         <div className="flex items-center gap-3">

--- a/src/game/archetypes.ts
+++ b/src/game/archetypes.ts
@@ -1,0 +1,49 @@
+export type SpellId = string;
+
+export type ArchetypeId = "bandit" | "sorcerer" | "beast";
+
+export type ArchetypeDefinition = {
+  id: ArchetypeId;
+  name: string;
+  description: string;
+  spellIds: SpellId[];
+};
+
+const definitions: Record<ArchetypeId, ArchetypeDefinition> = {
+  bandit: {
+    id: "bandit",
+    name: "Shade Bandit",
+    description:
+      "A cunning rogue who manipulates momentum with tricks and stolen reserves.",
+    spellIds: ["smokeBomb", "shadowStep", "cutpurse", "ambush"],
+  },
+  sorcerer: {
+    id: "sorcerer",
+    name: "Chronomancer",
+    description:
+      "A master of temporal magic who bends slices and values to their will.",
+    spellIds: ["timeWarp", "arcaneShield", "manaSurge", "scry"],
+  },
+  beast: {
+    id: "beast",
+    name: "Wildshifter",
+    description:
+      "A primal force that overwhelms foes with ferocity and relentless pressure.",
+    spellIds: ["feralRoar", "pounce", "packTactics", "regenerate"],
+  },
+};
+
+export const ARCHETYPE_DEFINITIONS = definitions;
+
+export const ARCHETYPE_IDS: ArchetypeId[] = Object.keys(definitions) as ArchetypeId[];
+
+export const DEFAULT_ARCHETYPE: ArchetypeId = "bandit";
+
+export const ALL_SPELL_IDS: SpellId[] = Array.from(
+  new Set(ARCHETYPE_IDS.flatMap((id) => definitions[id].spellIds))
+);
+
+export function getArchetypeDefinition(id: ArchetypeId): ArchetypeDefinition {
+  return definitions[id];
+}
+


### PR DESCRIPTION
## Summary
- add a canonical archetype definition map with spell lists
- derive available spells per side and gate gameplay behind a grimoire setup modal
- broadcast archetype picks/ready state in multiplayer and auto-pick for CPU opponents

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d190c041488332899cee427f61a34b