### PR TITLE
Add derived spell state and round-effect tracking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1049,14 +1049,19 @@ const storeReserveReport = useCallback(
     };
   }, [showRef, showGrimoire]);
 
-  const handleSpellActivate = useCallback(
-    (spell: SpellDefinition) => {
-      if (gameMode !== "grimoire") return;
-setPendingSpell({ side: localLegacySide, spell }); // local pending state
-syncLocalSpellSelection(spell.id);                  // sync to peer/remote UI
-spellCastRequestRef.current(spell);
-setShowGrimoire(false);
-  );
+// keep this near the other callbacks
+const handleSpellActivate = useCallback(
+  (spell: SpellDefinition) => {
+    if (gameMode !== "grimoire") return;
+
+    // if you’re syncing selection to MP
+    syncLocalSpellSelection?.(spell.id);
+
+    spellCastRequestRef.current(spell);
+    setShowGrimoire(false);
+  },
+  [gameMode, syncLocalSpellSelection] // <-- dependency array, then close the hook
+);
 
   const canReveal = useMemo(() => {
     if (!archetypeGateOpen) return false;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -234,9 +234,10 @@ const effectiveGameMode: GameMode =
     hostId ? hostLegacySide : localLegacySide
   );
   const [wins, setWins] = useState<{ player: number; enemy: number }>({ player: 0, enemy: 0 });
-  const [manaPools, setManaPools] = useState<SideState<number>>({ player: 0, enemy: 0 });
-  const [round, setRound] = useState(1);
-
+  const [manaPools, setManaPools] = useState<SideState<number>>({
+    player: 0,
+    enemy: 0,
+  });
   const [pendingSpell, setPendingSpell] = useState<PendingSpellDescriptor | null>(null);
   const [wheelDamage, setWheelDamage] = useState<WheelSideState<number>>(() =>
     createWheelSideState(0)
@@ -253,7 +254,10 @@ const effectiveGameMode: GameMode =
   const [pointerShifts, setPointerShifts] = useState<[number, number, number]>(
     createPointerShiftState
   );
-  const [initiativeOverride, setInitiativeOverride] = useState<LegacySide | null>(null);
+  const [initiativeOverride, setInitiativeOverride] = useState<LegacySide | null>(
+    null
+  );
+  const [round, setRound] = useState(1);
 
   const resetRoundTransientState = useCallback(() => {
     setPendingSpell(null);
@@ -693,13 +697,10 @@ const storeReserveReport = useCallback(
     if (!isGrimoireMode && showGrimoire) {
       setShowGrimoire(false);
     }
-  }, [isGrimoireMode, showGrimoire]);
-
-  useEffect(() => {
     if (!isGrimoireMode) {
       setPendingSpell(null);
     }
-  }, [isGrimoireMode, setPendingSpell]);
+  }, [isGrimoireMode, setPendingSpell, showGrimoire]);
 
 
   useEffect(() => {
@@ -738,7 +739,7 @@ const storeReserveReport = useCallback(
       spellCastRequestRef.current(spell);
       setShowGrimoire(false);
     },
-    [gameMode, localLegacySide]
+    [gameMode, localLegacySide, setPendingSpell]
   );
 
   const canReveal = useMemo(() => {
@@ -1448,9 +1449,9 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
     setWheelHUD,
     setWheelSections,
     setWins,
+    resetRoundTransientState,
     _setDragOverWheel,
-    wheelRefs,
-    resetRoundTransientState
+    wheelRefs
   ]);
 
   useEffect(() => {
@@ -1715,6 +1716,13 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
   const pc = assign.player[i];
   const ec = assign.enemy[i];
 
+  const damageState = wheelDamage[i];
+  const mirrorState = wheelMirror[i];
+  const lockState = wheelLocks[i];
+  const pointerShift = pointerShifts[i];
+  const playerPenalty = reservePenalties.player;
+  const enemyPenalty = reservePenalties.enemy;
+
   const leftSlot = { side: "player" as const, card: pc, name: namesByLegacy.player };
   const rightSlot = { side: "enemy" as const, card: ec, name: namesByLegacy.enemy };
 
@@ -1838,6 +1846,15 @@ function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
         transform: 'translateZ(0)',
         isolation: 'isolate'
       }}
+      data-wheel-locked={lockState ? "true" : "false"}
+      data-pointer-shift={pointerShift}
+      data-player-damage={damageState.player}
+      data-enemy-damage={damageState.enemy}
+      data-player-mirror={mirrorState.player ? "true" : "false"}
+      data-enemy-mirror={mirrorState.enemy ? "true" : "false"}
+      data-player-reserve-penalty={playerPenalty}
+      data-enemy-reserve-penalty={enemyPenalty}
+      data-initiative-override={initiativeOverride ?? ""}
     >
   {/* ADD: winner dots (don’t affect layout) */}
   { (phase === "roundEnd" || phase === "ended") && (
@@ -2268,6 +2285,8 @@ const HUDPanels = ({
   data-mana-enabled={grimoireAttrValue}
   data-spells-enabled={grimoireAttrValue}
   data-archetypes-enabled={grimoireAttrValue}
+  data-pending-spell={pendingSpell ? pendingSpell.spell.id : ""}
+  data-local-mana={localMana}
 >
   {showArchetypeModal && renderArchetypeModal()}
 

--- a/src/game/spells.ts
+++ b/src/game/spells.ts
@@ -15,6 +15,12 @@ export type SpellTargetDefinition =
   | { type: "card"; ownership: SpellTargetOwnership; automatic?: boolean }
   | { type: "wheel"; scope: "current" | "any" };
 
+export function getSpellDefinitions(ids: SpellId[]): SpellDefinition[] {
+  return ids
+    .map((id) => getSpellById(id))
+    .filter((s): s is SpellDefinition => Boolean(s));
+}
+
 export type SpellTargetInstance =
   | { type: "none" }
   | { type: "self" }

--- a/src/game/spells.ts
+++ b/src/game/spells.ts
@@ -10,7 +10,7 @@ export type SpellDefinition = {
   allowedPhases?: Phase[];
 };
 
-export const SPELL_CATALOGUE: Record<SpellId, SpellDefinition> = {
+const SPELL_CATALOGUE: Record<SpellId, SpellDefinition> = {
   smokeBomb: {
     id: "smokeBomb",
     name: "Smoke Bomb",

--- a/src/game/spells.ts
+++ b/src/game/spells.ts
@@ -1,9 +1,8 @@
-import type { Fighter, Phase } from "./types";
-
-export type SpellArchetype = "wanderer" | "bandit" | "sorcerer" | "beast";
+import type { SpellId } from "./archetypes";
+import type { Phase } from "./types";
 
 export type SpellDefinition = {
-  id: string;
+  id: SpellId;
   name: string;
   cost: number;
   description: string;
@@ -11,147 +10,112 @@ export type SpellDefinition = {
   allowedPhases?: Phase[];
 };
 
-const SPELLBOOK: Record<SpellArchetype, SpellDefinition[]> = {
-  wanderer: [
-    {
-      id: "spark-bolt",
-      name: "Spark Bolt",
-      cost: 1,
-      description: "Send a jolt through a visible enemy card, reducing its value by 1.",
-      icon: "⚡",
-      allowedPhases: ["choose"],
-    },
-    {
-      id: "lightstep",
-      name: "Lightstep",
-      cost: 2,
-      description: "Swap one of your assigned cards with another in hand.",
-      icon: "🚶",
-      allowedPhases: ["choose"],
-    },
-    {
-      id: "aether-wash",
-      name: "Aether Wash",
-      cost: 3,
-      description: "Return all cards from discard to hand, then redraw down to five.",
-      icon: "💧",
-      allowedPhases: ["roundEnd"],
-    },
-  ],
-  bandit: [
-    {
-      id: "smokescreen",
-      name: "Smokescreen",
-      cost: 1,
-      description: "Obscure one enemy slot so it cannot be targeted this round.",
-      icon: "💨",
-      allowedPhases: ["choose"],
-    },
-    {
-      id: "blade-flurry",
-      name: "Blade Flurry",
-      cost: 2,
-      description: "Increase the value of one of your revealed cards by 2 for this round.",
-      icon: "🗡️",
-      allowedPhases: ["showEnemy", "anim"],
-    },
-    {
-      id: "cut-purse",
-      name: "Cut Purse",
-      cost: 3,
-      description: "Steal 2 mana from the opponent if they have any remaining.",
-      icon: "🪙",
-      allowedPhases: ["choose"],
-    },
-  ],
-  sorcerer: [
-    {
-      id: "scry",
-      name: "Scry",
-      cost: 1,
-      description: "Peek at the top card of your deck and optionally draw it.",
-      icon: "🔮",
-      allowedPhases: ["choose"],
-    },
-    {
-      id: "arcane-shift",
-      name: "Arcane Shift",
-      cost: 2,
-      description: "Change the victory condition of the current wheel to Closest to Target.",
-      icon: "🌀",
-      allowedPhases: ["choose"],
-    },
-    {
-      id: "mana-surge",
-      name: "Mana Surge",
-      cost: 3,
-      description: "Refresh 2 mana and draw a card.",
-      icon: "✨",
-      allowedPhases: ["roundEnd"],
-    },
-  ],
-  beast: [
-    {
-      id: "feral-roar",
-      name: "Feral Roar",
-      cost: 1,
-      description: "Force the opponent to reroll their chosen card on a wheel.",
-      icon: "🦁",
-      allowedPhases: ["choose"],
-    },
-    {
-      id: "pack-hunt",
-      name: "Pack Hunt",
-      cost: 2,
-      description: "Duplicate one of your assigned cards for this resolution.",
-      icon: "🐺",
-      allowedPhases: ["showEnemy"],
-    },
-    {
-      id: "alpha-claim",
-      name: "Alpha Claim",
-      cost: 3,
-      description: "Seize initiative for the next round.",
-      icon: "👑",
-      allowedPhases: ["roundEnd"],
-    },
-  ],
+export const SPELL_CATALOGUE: Record<SpellId, SpellDefinition> = {
+  smokeBomb: {
+    id: "smokeBomb",
+    name: "Smoke Bomb",
+    cost: 1,
+    description: "Obscure an enemy slot so it cannot be targeted until the round resets.",
+    icon: "💨",
+    allowedPhases: ["choose"],
+  },
+  shadowStep: {
+    id: "shadowStep",
+    name: "Shadow Step",
+    cost: 2,
+    description: "Swap one of your assigned cards with another wheel slot you control.",
+    icon: "🕳️",
+    allowedPhases: ["choose"],
+  },
+  cutpurse: {
+    id: "cutpurse",
+    name: "Cutpurse",
+    cost: 2,
+    description: "Steal 1 mana from the opponent if they have any remaining this round.",
+    icon: "🪙",
+    allowedPhases: ["choose"],
+  },
+  ambush: {
+    id: "ambush",
+    name: "Ambush",
+    cost: 3,
+    description: "Mark a wheel to deal 2 bonus damage if you win it during resolution.",
+    icon: "🗡️",
+    allowedPhases: ["showEnemy", "anim"],
+  },
+  timeWarp: {
+    id: "timeWarp",
+    name: "Time Warp",
+    cost: 3,
+    description: "Shift every wheel pointer forward by 2 before resolution.",
+    icon: "⏳",
+    allowedPhases: ["choose"],
+  },
+  arcaneShield: {
+    id: "arcaneShield",
+    name: "Arcane Shield",
+    cost: 2,
+    description: "Mirror the opponent's revealed value on a wheel during resolution.",
+    icon: "🛡️",
+    allowedPhases: ["showEnemy", "anim"],
+  },
+  manaSurge: {
+    id: "manaSurge",
+    name: "Mana Surge",
+    cost: 2,
+    description: "Refresh 2 mana and draw a replacement card at round end.",
+    icon: "✨",
+    allowedPhases: ["roundEnd"],
+  },
+  scry: {
+    id: "scry",
+    name: "Scry",
+    cost: 1,
+    description: "Peek at the next card in your deck; optionally swap it with one in hand.",
+    icon: "🔮",
+    allowedPhases: ["choose"],
+  },
+  feralRoar: {
+    id: "feralRoar",
+    name: "Feral Roar",
+    cost: 1,
+    description: "Force the opponent to reroll one of their assigned cards before reveal.",
+    icon: "🦁",
+    allowedPhases: ["choose"],
+  },
+  pounce: {
+    id: "pounce",
+    name: "Pounce",
+    cost: 2,
+    description: "Move one of your cards to an empty wheel slot and add +1 to its value.",
+    icon: "🐾",
+    allowedPhases: ["choose"],
+  },
+  packTactics: {
+    id: "packTactics",
+    name: "Pack Tactics",
+    cost: 3,
+    description: "Duplicate one of your wheel results when determining reserve totals.",
+    icon: "🐺",
+    allowedPhases: ["showEnemy", "anim"],
+  },
+  regenerate: {
+    id: "regenerate",
+    name: "Regenerate",
+    cost: 2,
+    description: "Gain 1 mana and heal 1 damage on each wheel you control this round.",
+    icon: "🌿",
+    allowedPhases: ["roundEnd"],
+  },
 };
 
-const ARCHETYPES: SpellArchetype[] = ["wanderer", "bandit", "sorcerer", "beast"];
-
-function isSpellArchetype(value: unknown): value is SpellArchetype {
-  return typeof value === "string" && (ARCHETYPES as string[]).includes(value);
+export function getSpellDefinition(spellId: SpellId): SpellDefinition | undefined {
+  return SPELL_CATALOGUE[spellId];
 }
 
-export function inferSpellArchetypeFromFighter(fighter: Fighter): SpellArchetype {
-  const maybeArchetype = (fighter as Fighter & { archetype?: unknown }).archetype;
-  if (isSpellArchetype(maybeArchetype)) {
-    return maybeArchetype;
-  }
-
-  const normalized = fighter.name?.toLowerCase?.() ?? "";
-  if (normalized.includes("bandit")) return "bandit";
-  if (normalized.includes("sorcerer")) return "sorcerer";
-  if (normalized.includes("beast")) return "beast";
-  return "wanderer";
+export function getSpellDefinitions(spellIds: SpellId[]): SpellDefinition[] {
+  return spellIds
+    .map((spellId) => getSpellDefinition(spellId))
+    .filter((spell): spell is SpellDefinition => Boolean(spell));
 }
 
-export function getSpellbookForArchetype(archetype: SpellArchetype): SpellDefinition[] {
-  return SPELLBOOK[archetype] ?? [];
-}
-
-export function getLearnedSpellsForFighter(fighter: Fighter): SpellDefinition[] {
-  const archetype = inferSpellArchetypeFromFighter(fighter);
-  const book = getSpellbookForArchetype(archetype);
-  const learned = (fighter as Fighter & { learnedSpells?: unknown }).learnedSpells;
-
-  if (Array.isArray(learned) && learned.length > 0) {
-    const allowed = new Set(learned.filter((id): id is string => typeof id === "string"));
-    if (allowed.size > 0) {
-      return book.filter((spell) => allowed.has(spell.id));
-    }
-  }
-
-  return book;
-}


### PR DESCRIPTION
## Summary
- add a spell catalogue keyed by archetype spell ids plus helpers to collect definitions
- track mana pools, pending spells, and wheel-side effects with a shared reset routine that runs at round transitions
- derive grimoire spell lists and HUD mana counts from the new state so UI reflects catalogue data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d19c417ea48332958e86411a031b31