### PR TITLE
Refactor three-wheel UI components into dedicated modules

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,8 @@ import {
 } from "./features/threeWheel/utils/combat";
 
 // components
-import type { WheelHandle } from "./components/CanvasWheel";
+import { motion } from "framer-motion";
+import CanvasWheel, { type WheelHandle } from "./components/CanvasWheel";
 import WheelPanel from "./features/threeWheel/components/WheelPanel";
 import HandDock from "./features/threeWheel/components/HandDock";
 import HUDPanels from "./features/threeWheel/components/HUDPanels";
@@ -2296,30 +2297,6 @@ const renderWheelPanel = (i: number) => {
     </div>
   );
 };
-
-// --- Hand dock (keep this) ---
-const HandDock = ({ onMeasure }: { onMeasure?: (px: number) => void }) => {
-  const dockRef = useRef<HTMLDivElement | null>(null);
-  const [liftPx, setLiftPx] = useState<number>(18);
-
-  useEffect(() => {
-    const compute = () => {
-      const root = dockRef.current; if (!root) return;
-      const sample = root.querySelector('[data-hand-card]') as HTMLElement | null; if (!sample) return;
-      const h = sample.getBoundingClientRect().height || 96;
-      const nextLift = Math.round(Math.min(44, Math.max(12, h * 0.34)));
-      setLiftPx(nextLift);
-      const clearance = Math.round(h + nextLift + 12);
-      onMeasure?.(clearance);
-    };
-    compute();
-    window.addEventListener('resize', compute);
-    window.addEventListener('orientationchange', compute);
-    return () => {
-      window.removeEventListener('resize', compute);
-      window.removeEventListener('orientationchange', compute);
-    };
-  }, [onMeasure]);
 
   const localFighter: Fighter = localLegacySide === "player" ? player : enemy;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2503,7 +2503,6 @@ return (
             </button>
           </div>
         </div>
-      </div>
     </div>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2429,6 +2429,7 @@ return (
 
         {/* Archetype selections summary + ready controls */}
         <div className="grid gap-4 sm:grid-cols-2">
+          {/* local side panel */}
           <div className="rounded-xl border border-slate-700/70 bg-slate-900/70 p-4">
             <div className="flex items-center justify-between gap-2">
               <div className="text-sm font-semibold text-slate-100">
@@ -2454,6 +2455,7 @@ return (
             </ul>
           </div>
 
+          {/* remote side panel */}
           <div className="rounded-xl border border-slate-700/70 bg-slate-900/70 p-4">
             <div className="flex items-center justify-between gap-2">
               <div className="text-sm font-semibold text-slate-100">
@@ -2480,6 +2482,7 @@ return (
           </div>
         </div>
 
+        {/* footer: status text + Ready/Next button */}
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="text-sm text-slate-300/90">
             {isMultiplayer
@@ -2500,16 +2503,11 @@ return (
             </button>
           </div>
         </div>
-      </div>
-    </div>
+      </div>{/* end modal card */}
+    </div>{/* end backdrop */}
   );
-}; // <- end renderArchetypeModal
-
-        </div>
-      </div>
-    </div>
-  );
-};
+}; // end renderArchetypeModal
+      
 
   const localResolveReady = resolveVotes[localLegacySide];
   const remoteResolveReady = resolveVotes[remoteLegacySide];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2559,8 +2559,8 @@ const renderArchetypeModal = () => (
           </button>
         </div>
       </div>
-    </div>{/* end modal card */}
-  </div>{/* end backdrop */}
+    </div>
+  </div>
 );
 
   const localResolveReady = resolveVotes[localLegacySide];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,6 @@ import React, {
   useCallback,
 } from "react";
 import { Realtime } from "ably";
-import { motion } from "framer-motion";
 
 
 /**
@@ -58,8 +57,11 @@ import {
 import { isSplit, isNormal, effectiveValue, fmtNum } from "./game/values";
 
 // components
-import CanvasWheel, { WheelHandle } from "./components/CanvasWheel";
-import StSCard from "./components/StSCard";
+import type { WheelHandle } from "./components/CanvasWheel";
+import WheelPanel from "./features/threeWheel/components/WheelPanel";
+import HandDock from "./features/threeWheel/components/HandDock";
+import HUDPanels from "./features/threeWheel/components/HUDPanels";
+import VictoryOverlay from "./features/threeWheel/components/VictoryOverlay";
 import { getSpellDefinitions, type SpellDefinition } from "./game/spells";
 
 type AblyRealtime = InstanceType<typeof Realtime>;
@@ -2174,522 +2176,6 @@ default:
     </div>
   );
 
-  const renderWheelPanel = (i: number) => {
-  const pc = assign.player[i];
-  const ec = assign.enemy[i];
-
-  const damageState = wheelDamage[i];
-  const mirrorState = wheelMirror[i];
-  const lockState = wheelLocks[i];
-  const pointerShift = pointerShifts[i];
-  const playerPenalty = reservePenalties.player;
-  const enemyPenalty = reservePenalties.enemy;
-
-  const leftSlot = { side: "player" as const, card: pc, name: namesByLegacy.player };
-  const rightSlot = { side: "enemy" as const, card: ec, name: namesByLegacy.enemy };
-
-  const ws = Math.round(lockedWheelSize ?? wheelSize);
-
-  const isLeftSelected = !!leftSlot.card && selectedCardId === leftSlot.card.id;
-  const isRightSelected = !!rightSlot.card && selectedCardId === rightSlot.card.id;
-
-  const shouldShowLeftCard =
-    !!leftSlot.card && (leftSlot.side === localLegacySide || phase !== "choose");
-  const shouldShowRightCard =
-    !!rightSlot.card && (rightSlot.side === localLegacySide || phase !== "choose");
-
-  // --- layout numbers that must match the classes below ---
-  const slotW    = 80;   // w-[80px] on both slots
-  const gapX     = 16;   // gap-2 => 8px, two gaps between three items => 16
-  const paddingX = 16;   // p-2 => 8px left + 8px right
-  const borderX  = 4;    // border-2 => 2px left + 2px right
-  const EXTRA_H  = 16;   // extra breathing room inside the panel (change to tweak height)
-
-  // panel width (border-box) so wheel is visually centered
-  const panelW = ws + slotW * 2 + gapX + paddingX + borderX;
-
-  const renderSlotCard = (slot: typeof leftSlot, isSlotSelected: boolean) => {
-    if (!slot.card) return null;
-    const card = slot.card;
-    const interactable =
-      slot.side === localLegacySide && phase === "choose" && archetypeGateOpen;
-
-    const handlePick = () => {
-      if (!interactable) return;
-      if (selectedCardId) {
-        tapAssignIfSelected();
-      } else {
-        setSelectedCardId(card.id);
-      }
-    };
-
-    const handleDragStart = (e: React.DragEvent<HTMLButtonElement>) => {
-      if (!interactable) return;
-      setSelectedCardId(card.id);
-      setDragCardId(card.id);
-      try { e.dataTransfer.setData("text/plain", card.id); } catch {}
-      e.dataTransfer.effectAllowed = "move";
-    };
-
-    const handleDragEnd = () => {
-      setDragCardId(null);
-      setDragOverWheel(null);
-    };
-
-    const handlePointerDown = (e: React.PointerEvent<HTMLButtonElement>) => {
-      if (!interactable) return;
-      e.stopPropagation();
-      startPointerDrag(card, e);
-    };
-
-    return (
-      <StSCard
-        card={card}
-        size="sm"
-        disabled={!interactable}
-        selected={isSlotSelected}
-        onPick={handlePick}
-        draggable={interactable}
-        onDragStart={handleDragStart}
-        onDragEnd={handleDragEnd}
-        onPointerDown={handlePointerDown}
-      />
-    );
-  };
-
-  const onZoneDragOver = (e: React.DragEvent) => { e.preventDefault(); if (dragCardId && active[i]) setDragOverWheel(i); };
-  const onZoneLeave = () => { if (dragCardId) setDragOverWheel(null); };
-  const handleDropCommon = (id: string | null, targetSide?: LegacySide) => {
-    if (!id || !active[i]) return;
-    const intendedSide = targetSide ?? localLegacySide;
-    if (intendedSide !== localLegacySide) {
-      setDragOverWheel(null);
-      setDragCardId(null);
-      return;
-    }
-
-    const isLocalPlayer = localLegacySide === "player";
-    const fromHand = (isLocalPlayer ? player.hand : enemy.hand).find((c) => c.id === id);
-    const fromSlots = (isLocalPlayer ? assign.player : assign.enemy).find((c) => c && c.id === id) as Card | undefined;
-    const card = fromHand || fromSlots || null;
-    if (card) assignToWheelLocal(i, card as Card);
-    setDragOverWheel(null);
-    setDragCardId(null);
-  };
-  const onZoneDrop = (e: React.DragEvent, targetSide?: LegacySide) => {
-    e.preventDefault();
-    handleDropCommon(e.dataTransfer.getData("text/plain") || dragCardId, targetSide);
-  };
-
-  const tapAssignIfSelected = () => {
-    if (!selectedCardId) return;
-    const isLocalPlayer = localLegacySide === "player";
-    const card =
-      (isLocalPlayer ? player.hand : enemy.hand).find(c => c.id === selectedCardId) ||
-      (isLocalPlayer ? assign.player : assign.enemy).find(c => c?.id === selectedCardId) ||
-      null;
-    if (card) assignToWheelLocal(i, card as Card);
-  };
-
-  const panelShadow = '0 2px 8px rgba(0,0,0,.28), inset 0 1px 0 rgba(255,255,255,.04)';
-
-  return (
-    <div
-      className="relative rounded-xl border p-2 shadow flex-none"
-      style={{
-        width: panelW,
-        height: ws + EXTRA_H,
-        background: `linear-gradient(180deg, rgba(255,255,255,.04) 0%, rgba(0,0,0,.14) 100%), ${THEME.panelBg}`,
-        borderColor: THEME.panelBorder,
-        borderWidth: 2,
-        boxShadow: panelShadow,
-        contain: 'paint',
-        backfaceVisibility: 'hidden',
-        transform: 'translateZ(0)',
-        isolation: 'isolate'
-      }}
-      data-wheel-locked={lockState ? "true" : "false"}
-      data-pointer-shift={pointerShift}
-      data-player-damage={damageState.player}
-      data-enemy-damage={damageState.enemy}
-      data-player-mirror={mirrorState.player ? "true" : "false"}
-      data-enemy-mirror={mirrorState.enemy ? "true" : "false"}
-      data-player-reserve-penalty={playerPenalty}
-      data-enemy-reserve-penalty={enemyPenalty}
-      data-initiative-override={initiativeOverride ?? ""}
-    >
-  {/* ADD: winner dots (don’t affect layout) */}
-  { (phase === "roundEnd" || phase === "ended") && (
-    <>
-      {/* Player dot (top-left) */}
-      <span
-        aria-label={`Wheel ${i+1} player result`}
-        className="absolute top-1 left-1 rounded-full border"
-        style={{
-          width: 10,
-          height: 10,
-          background: wheelHUD[i] === HUD_COLORS.player ? HUD_COLORS.player : 'transparent',
-          borderColor: wheelHUD[i] === HUD_COLORS.player ? HUD_COLORS.player : THEME.panelBorder,
-          boxShadow: '0 0 0 1px rgba(0,0,0,0.4)'
-        }}
-      />
-
-      {/* Enemy dot (top-right) */}
-      <span
-        aria-label={`Wheel ${i+1} enemy result`}
-        className="absolute top-1 right-1 rounded-full border"
-        style={{
-          width: 10,
-          height: 10,
-          background: wheelHUD[i] === HUD_COLORS.enemy ? HUD_COLORS.enemy : 'transparent',
-          borderColor: wheelHUD[i] === HUD_COLORS.enemy ? HUD_COLORS.enemy : THEME.panelBorder,
-          boxShadow: '0 0 0 1px rgba(0,0,0,0.4)'
-        }}
-      />
-    </>
-  )}
-
-  {/* the row: slots + centered wheel */}
-  <div
-    className="flex items-center justify-center gap-2"
-    style={{ height: (ws + EXTRA_H) /* removed the - 3 */ }}
-  >
-        {/* Player slot */}
-        <div
-          data-drop="slot"
-          data-idx={i}
-          onDragOver={onZoneDragOver}
-          onDragEnter={onZoneDragOver}
-          onDragLeave={onZoneLeave}
-          onDrop={(e) => onZoneDrop(e, "player")}
-          onClick={(e) => {
-            e.stopPropagation();
-            if (leftSlot.side !== localLegacySide) return;
-            if (selectedCardId) {
-              // If a hand card is already selected, assign it here (this also swaps)
-              tapAssignIfSelected();
-            } else if (leftSlot.card) {
-              // 🔸 Arm this placed card for swapping (select it)
-              setSelectedCardId(leftSlot.card.id);
-            }
-          }}
-          className="w-[80px] h-[92px] rounded-md border px-1 py-0 flex items-center justify-center flex-none"
-          style={{
-            backgroundColor: dragOverWheel === i || isLeftSelected ? 'rgba(182,138,78,.12)' : THEME.slotBg,
-            borderColor:     dragOverWheel === i || isLeftSelected ? THEME.brass          : THEME.slotBorder,
-            boxShadow: isLeftSelected ? '0 0 0 1px rgba(251,191,36,0.7)' : 'none',
-          }}
-          aria-label={`Wheel ${i+1} left slot`}
-        >
-          {shouldShowLeftCard
-            ? renderSlotCard(leftSlot, isLeftSelected)
-            : <div className="text-[11px] opacity-80 text-center">
-                {leftSlot.side === localLegacySide ? "Your card" : leftSlot.name}
-              </div>}
-        </div>
-
-  {/* Wheel face (fixed width equals wheel size; centers wheel exactly) */}
-  <div
-  data-drop="wheel"
-  data-idx={i}
-  className="relative flex-none flex items-center justify-center rounded-full overflow-hidden"
-  style={{ width: ws, height: ws }}
-  onDragOver={onZoneDragOver}
-  onDragEnter={onZoneDragOver}
-  onDragLeave={onZoneLeave}
-  onDrop={onZoneDrop}
-  onClick={(e) => { e.stopPropagation(); tapAssignIfSelected(); }}
-  aria-label={`Wheel ${i+1}`}
->
-    <CanvasWheel ref={wheelRefs[i]} sections={wheelSections[i]} size={ws} />
-    <div
-      aria-hidden
-      className="pointer-events-none absolute inset-0 rounded-full"
-      style={{ boxShadow: dragOverWheel === i ? '0 0 0 2px rgba(251,191,36,0.7) inset' : 'none' }}
-    />
-  </div>
-    
-        {/* Enemy slot */}
-        <div
-          className="w-[80px] h-[92px] rounded-md border px-1 py-0 flex items-center justify-center flex-none"
-          style={{
-            backgroundColor: dragOverWheel === i || isRightSelected ? 'rgba(182,138,78,.12)' : THEME.slotBg,
-            borderColor:     dragOverWheel === i || isRightSelected ? THEME.brass          : THEME.slotBorder,
-            boxShadow: isRightSelected ? '0 0 0 1px rgba(251,191,36,0.7)' : 'none',
-          }}
-          aria-label={`Wheel ${i+1} right slot`}
-          data-drop="slot"
-          data-idx={i}
-          onDragOver={onZoneDragOver}
-          onDragEnter={onZoneDragOver}
-          onDragLeave={onZoneLeave}
-          onDrop={(e) => onZoneDrop(e, "enemy")}
-          onClick={(e) => {
-            e.stopPropagation();
-            if (rightSlot.side !== localLegacySide) return;
-            if (selectedCardId) {
-              tapAssignIfSelected();
-            } else if (rightSlot.card) {
-              setSelectedCardId(rightSlot.card.id);
-            }
-          }}
-        >
-          {shouldShowRightCard
-            ? renderSlotCard(rightSlot, isRightSelected)
-            : <div className="text-[11px] opacity-60 text-center">
-                {rightSlot.side === localLegacySide ? "Your card" : rightSlot.name}
-              </div>}
-        </div>
-      </div>
-    </div>
-  );
-};
-
-  const HandDock = ({ onMeasure }: { onMeasure?: (px: number) => void }) => {
-    const dockRef = useRef<HTMLDivElement | null>(null);
-    const [liftPx, setLiftPx] = useState<number>(18);
-    useEffect(() => {
-      const compute = () => {
-        const root = dockRef.current; if (!root) return;
-        const sample = root.querySelector('[data-hand-card]') as HTMLElement | null; if (!sample) return;
-        const h = sample.getBoundingClientRect().height || 96;
-        const nextLift = Math.round(Math.min(44, Math.max(12, h * 0.34)));
-        setLiftPx(nextLift);
-        const clearance = Math.round(h + nextLift + 12);
-        onMeasure?.(clearance);
-      };
-      compute(); window.addEventListener('resize', compute); window.addEventListener('orientationchange', compute);
-      return () => { window.removeEventListener('resize', compute); window.removeEventListener('orientationchange', compute); };
-    }, [onMeasure]);
-
-    const localFighter: Fighter = localLegacySide === "player" ? player : enemy;
-
-    return (
-      <div ref={dockRef} className="fixed left-0 right-0 bottom-0 z-50 pointer-events-none select-none" style={{ bottom: 'calc(env(safe-area-inset-bottom, 0px) + -30px)' }}>
-        <div className="mx-auto max-w-[1400px] flex justify-center gap-1.5 py-0.5">
-          {localFighter.hand.map((card, idx) => {
-            const isSelected = selectedCardId === card.id;
-            return (
-              <div key={card.id} className="group relative pointer-events-auto" style={{ zIndex: 10 + idx }}>
-                <motion.div data-hand-card initial={false} animate={{ y: isSelected ? -Math.max(8, liftPx - 10) : -liftPx, opacity: 1, scale: isSelected ? 1.06 : 1 }} whileHover={{ y: -Math.max(8, liftPx - 10), opacity: 1, scale: 1.04 }} transition={{ type: 'spring', stiffness: 320, damping: 22 }} className={`drop-shadow-xl ${isSelected ? 'ring-2 ring-amber-300' : ''}`}>
-                  <button
-  data-hand-card
-  className="pointer-events-auto"
-  onClick={(e) => {
-    e.stopPropagation();
-    if (!selectedCardId) {
-      setSelectedCardId(card.id);
-      return;
-    }
-
-    if (selectedCardId === card.id) {
-      setSelectedCardId(null);
-      return;
-    }
-
-    const lane = localLegacySide === "player" ? assign.player : assign.enemy;
-    const slotIdx = lane.findIndex((c) => c?.id === selectedCardId);
-    if (slotIdx !== -1) {
-      assignToWheelLocal(slotIdx, card);
-      return;
-    }
-
-    setSelectedCardId(card.id);
-  }}
-  draggable
-  onDragStart={(e) => {
-    // Desktop HTML5 drag
-    setDragCardId(card.id);
-    try { e.dataTransfer.setData("text/plain", card.id); } catch {}
-    e.dataTransfer.effectAllowed = "move";
-  }}
-  onDragEnd={() => setDragCardId(null)}
-  onPointerDown={(e) => startPointerDrag(card, e)}   // ← NEW: touch/pen drag
-  aria-pressed={isSelected}
-  aria-label={`Select ${card.name}`}
->
-  <StSCard card={card} />
-</button>
-
-                </motion.div>
-              </div>
-            );
-          })}
-        </div>
-{/* Touch drag ghost (mobile) */}
-{isPtrDragging && ptrDragCard && (
-  <div
-    style={{
-      position: 'fixed',
-      left: 0,
-      top: 0,
-      transform: `translate(${ptrPos.current.x - 48}px, ${ptrPos.current.y - 64}px)`,
-      pointerEvents: 'none',
-      zIndex: 9999,
-    }}
-    aria-hidden
-  >
-    <div style={{ transform: 'scale(0.9)', filter: 'drop-shadow(0 6px 8px rgba(0,0,0,.35))' }}>
-      <StSCard card={ptrDragCard} />
-    </div>
-  </div>
-)}
-
-      </div>
-    );
-  };
-
-const HUDPanels = ({
-  manaPools,
-  isGrimoireMode,
-}: {
-  manaPools: { player: number; enemy: number };
-  isGrimoireMode: boolean;
-}) => {
-  const rsP = reserveSums ? reserveSums.player : null;
-  const rsE = reserveSums ? reserveSums.enemy : null;
-
-  const Panel = ({ side }: { side: LegacySide }) => {
-    const isPlayer = side === 'player';
-    const color = isPlayer ? (players.left.color ?? HUD_COLORS.player) : (players.right.color ?? HUD_COLORS.enemy);
-    const name = isPlayer ? players.left.name : players.right.name;
-    const win = isPlayer ? wins.player : wins.enemy;
-    const manaCount = isPlayer ? manaPools.player : manaPools.enemy;
-    const rs = isPlayer ? rsP : rsE;
-    const hasInit = initiative === side;
-    const isReserveVisible =
-      (phase === 'showEnemy' || phase === 'anim' || phase === 'roundEnd' || phase === 'ended') &&
-      rs !== null;
-
-    return (
-      <div className="flex h-full flex-col items-center w-full">
-        {/* HUD row (flag moved inside; absolute to avoid layout shift) */}
-        <div
-          className="relative flex min-w-0 items-center gap-2 rounded-lg border px-2 py-1 text-[12px] shadow w-full"
-          style={{
-            maxWidth: '100%',
-            background: THEME.panelBg,
-            borderColor: THEME.panelBorder,
-            color: THEME.textWarm,
-          }}
-        >
-          <div className="w-1.5 h-6 rounded" style={{ background: color }} />
-          <div className="flex items-center min-w-0 flex-1">
-            <span className="truncate block font-semibold">{name}</span>
-            {(isPlayer ? "player" : "enemy") === localLegacySide && (
-              <span className="ml-2 rounded bg-white/10 px-1.5 py-0.5 text-[10px]">You</span>
-            )}
-          </div>
-          <div className="flex items-center gap-3 ml-1 flex-shrink-0">
-            <div className="flex items-center gap-1">
-              <span className="opacity-80">Wins</span>
-              <span className="text-base font-extrabold tabular-nums">{win}</span>
-            </div>
-            <div
-              className={`flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-semibold transition-opacity ${
-                isGrimoireMode ? 'opacity-100 visible' : 'opacity-0 invisible'
-              }`}
-              style={{
-                background: '#1b1209ee',
-                borderColor: THEME.slotBorder,
-                color: THEME.textWarm,
-                minWidth: '62px',
-                justifyContent: 'center',
-              }}
-              aria-hidden={!isGrimoireMode}
-              title={isGrimoireMode ? `Mana: ${manaCount}` : undefined}
-            >
-              <span role="img" aria-label="Mana" className="text-sm leading-none">
-                🔮
-              </span>
-              <span className="tabular-nums text-sm leading-none">{manaCount}</span>
-            </div>
-          </div>
-          <div
-            className={`ml-2 hidden sm:flex rounded-full border px-2 py-0.5 text-[11px] overflow-hidden text-ellipsis whitespace-nowrap transition-opacity ${
-              isReserveVisible ? 'opacity-100 visible' : 'opacity-0 invisible'
-            }`}
-            style={{
-              maxWidth: '44vw',
-              minWidth: '90px',
-              background: '#1b1209ee',
-              borderColor: THEME.slotBorder,
-              color: THEME.textWarm,
-            }}
-            title={rs !== null ? `Reserve: ${rs}` : undefined}
-          >
-            Reserve: <span className="font-bold tabular-nums">{rs ?? 0}</span>
-          </div>
-
-          {/* Initiative flag — absolute, no extra height */}
-          {hasInit && (
-            <span
-              aria-label="Has initiative"
-              className="absolute -top-1 -right-1 leading-none select-none"
-              style={{
-                fontSize: 24,
-                filter: 'drop-shadow(0 1px 1px rgba(0,0,0,.6))',
-              }}
-            >
-              ⚑
-            </span>
-          )}
-        </div>
-
-        {isReserveVisible && (
-          <div className="mt-1 w-full sm:hidden">
-            <div className="w-full flex flex-col gap-1">
-              <div
-                className="w-full rounded-full border px-3 py-1 text-[11px] text-center"
-                style={{
-                  background: '#1b1209ee',
-                  borderColor: THEME.slotBorder,
-                  color: THEME.textWarm,
-                }}
-                title={rs !== null ? `Reserve: ${rs}` : undefined}
-              >
-                Reserve: <span className="font-bold tabular-nums">{rs ?? 0}</span>
-              </div>
-              <div
-                className={`w-full rounded-full border px-3 py-1 text-[11px] text-center transition-opacity ${
-                  isGrimoireMode ? 'opacity-100 visible' : 'opacity-0 invisible'
-                }`}
-                style={{
-                  background: '#1b1209ee',
-                  borderColor: THEME.slotBorder,
-                  color: THEME.textWarm,
-                }}
-                aria-hidden={!isGrimoireMode}
-                title={isGrimoireMode ? `Mana: ${manaCount}` : undefined}
-              >
-                <span className="font-semibold">Mana:</span>{' '}
-                <span className="font-bold tabular-nums">{manaCount}</span>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* (removed) old outside flag that was pushing layout down */}
-        {/* {hasInit && <span className="mt-1" aria-label="Has initiative">⚑</span>} */}
-      </div>
-    );
-  };
-
-  return (
-    <div className="w-full flex flex-col items-center">
-      <div className="grid w-full max-w-[900px] grid-cols-2 items-stretch gap-2 overflow-x-hidden">
-        <div className="min-w-0 w-full max-w-[420px] mx-auto h-full">
-          <Panel side="player" />
-        </div>
-        <div className="min-w-0 w-full max-w-[420px] mx-auto h-full">
-          <Panel side="enemy" />
-        </div>
-      </div>
-    </div>
-  );
-};
-
-
   const localResolveReady = resolveVotes[localLegacySide];
   const remoteResolveReady = resolveVotes[remoteLegacySide];
 
@@ -2927,146 +2413,105 @@ const HUDPanels = ({
       </div>
 
       {/* HUD */}
-      <div className="relative z-10"><HUDPanels manaPools={manaPools} isGrimoireMode={isGrimoireMode} /></div>
+      <div className="relative z-10">
+        <HUDPanels
+          manaPools={manaPools}
+          isGrimoireMode={isGrimoireMode}
+          reserveSums={reserveSums}
+          players={players}
+          hudColors={HUD_COLORS}
+          wins={wins}
+          initiative={initiative}
+          localLegacySide={localLegacySide}
+          phase={phase}
+          theme={THEME}
+        />
+      </div>
 
       {/* Wheels center */}
       <div className="relative z-0" style={{ paddingBottom: handClearance }}>
         <div className="flex flex-col items-center justify-start gap-1">
           {[0, 1, 2].map((i) => (
-            <div key={i} className="flex-shrink-0">{renderWheelPanel(i)}</div>
+            <div key={i} className="flex-shrink-0">
+              <WheelPanel
+                index={i}
+                assign={assign}
+                namesByLegacy={namesByLegacy}
+                wheelSize={wheelSize}
+                lockedWheelSize={lockedWheelSize}
+                wheelDamage={wheelDamage[i]}
+                wheelMirror={wheelMirror[i]}
+                wheelLocked={wheelLocks[i]}
+                pointerShift={pointerShifts[i]}
+                reservePenalties={reservePenalties}
+                selectedCardId={selectedCardId}
+                setSelectedCardId={setSelectedCardId}
+                localLegacySide={localLegacySide}
+                phase={phase}
+                archetypeGateOpen={archetypeGateOpen}
+                setDragCardId={setDragCardId}
+                dragCardId={dragCardId}
+                setDragOverWheel={setDragOverWheel}
+                dragOverWheel={dragOverWheel}
+                player={player}
+                enemy={enemy}
+                assignToWheelLocal={assignToWheelLocal}
+                isWheelActive={active[i]}
+                wheelRef={wheelRefs[i]}
+                wheelSection={wheelSections[i]}
+                hudColors={HUD_COLORS}
+                theme={THEME}
+                initiativeOverride={initiativeOverride}
+                startPointerDrag={startPointerDrag}
+                wheelHudColor={wheelHUD[i]}
+              />
+            </div>
           ))}
         </div>
       </div>
 
       {/* Docked hand overlay */}
-      <HandDock onMeasure={setHandClearance} />
+      <HandDock
+        localLegacySide={localLegacySide}
+        player={player}
+        enemy={enemy}
+        selectedCardId={selectedCardId}
+        setSelectedCardId={setSelectedCardId}
+        assign={assign}
+        assignToWheelLocal={assignToWheelLocal}
+        setDragCardId={setDragCardId}
+        startPointerDrag={startPointerDrag}
+        isPtrDragging={isPtrDragging}
+        ptrDragCard={ptrDragCard}
+        ptrPos={ptrPos}
+        onMeasure={setHandClearance}
+      />
 
       {/* Ended overlay (banner + modal) */}
       {phase === "ended" && (
-        <>
-          {victoryCollapsed ? (
-            <button
-              onClick={() => setVictoryCollapsed(false)}
-              className={`fixed top-3 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-full border px-4 py-2 text-sm font-semibold shadow-lg transition hover:-translate-y-[1px] focus:outline-none focus:ring-2 focus:ring-emerald-400/60 ${
-                localWon
-                  ? "border-emerald-500/40 bg-emerald-900/70 text-emerald-100"
-                  : "border-slate-700 bg-slate-900/80 text-slate-100"
-              }`}
-            >
-              <span className="rounded-full bg-slate-950/40 px-2 py-0.5 text-xs uppercase tracking-wide">
-                {localWon ? "Victory" : "Defeat"}
-              </span>
-              <span className="text-xs opacity-80">Tap to reopen results</span>
-              {localWon && matchSummary?.expGained ? (
-                <span className="rounded-full bg-emerald-500/20 px-2 py-0.5 text-[11px] text-emerald-100">
-                  +{matchSummary.expGained} XP
-                </span>
-              ) : null}
-            </button>
-          ) : null}
-
-          {!victoryCollapsed && (
-            <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 backdrop-blur-sm px-3">
-              <div className="relative w-full max-w-sm rounded-lg border border-slate-700 bg-slate-900/95 p-6 text-center shadow-2xl space-y-4">
-                {/* Minimize */}
-          <button
-            onClick={() => setVictoryCollapsed(true)}
-            
-            className="group absolute top-2 right-2 flex h-10 w-10 items-center justify-center rounded-lg border border-slate-700/70 bg-slate-800/80 text-slate-200 transition hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-emerald-400/60"
-            aria-label="Minimize results"
-            title="Minimize"
-          >
-            <div className="flex flex-col items-end text-right leading-none">
-              <span className="text-[10px] font-semibold uppercase tracking-wide text-emerald-200/80 transition group-hover:text-emerald-100">
-                Hide
-              </span>
-              <svg
-                aria-hidden
-                focusable="false"
-                className="mt-1 h-5 w-5 text-emerald-200 transition group-hover:text-emerald-100"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path d="M4 10a1 1 0 0 1 1-1h6.586L9.293 6.707a1 1 0 1 1 1.414-1.414l4.5 4.5a1 1 0 0 1 0 1.414l-4.5 4.5a1 1 0 0 1-1.414-1.414L11.586 11H5a1 1 0 0 1-1-1Z" />
-              </svg>
-            </div>
-            <span className="text-lg font-semibold leading-none text-slate-200 transition group-hover:text-white">–</span>
-          </button>
-
-          <div className={`text-3xl font-bold ${localWon ? "text-emerald-300" : "text-rose-300"}`}>
-            {localWon ? "Victory" : "Defeat"}
-          </div>
-
-          <div className="text-sm text-slate-200">
-            {localWon
-              ? `You reached ${winGoal} wins.`
-              : `${winnerName ?? remoteName} reached ${winGoal} wins.`}
-          </div>
-
-          <div className="rounded-md border border-slate-700 bg-slate-800/80 px-4 py-3 text-sm text-slate-100">
-            <div className="font-semibold tracking-wide uppercase text-xs text-slate-400">Final Score</div>
-            <div className="mt-2 flex items-center justify-center gap-3 text-base font-semibold">
-              <span className="text-emerald-300">{localName}</span>
-              <span className="px-2 py-0.5 rounded bg-slate-900/60 text-slate-200 tabular-nums">{localWinsCount}</span>
-              <span className="text-slate-500">—</span>
-              <span className="px-2 py-0.5 rounded bg-slate-900/60 text-slate-200 tabular-nums">{remoteWinsCount}</span>
-              <span className="text-rose-300">{remoteName}</span>
-            </div>
-          </div>
-
-          {localWon && matchSummary?.didWin && xpDisplay && (
-            <div className="rounded-md border border-emerald-500/40 bg-emerald-900/15 px-4 py-3 text-sm text-emerald-50">
-              <div className="flex items-center justify-between text-[11px] uppercase tracking-wide text-emerald-200/80">
-                <span>Level {xpDisplay.level}</span>
-                <span>
-                  {xpDisplay.exp} / {xpDisplay.expToNext} XP
-                </span>
-              </div>
-              <div className="mt-2 h-2 rounded-full bg-emerald-950/50">
-                <div
-                  className="h-2 rounded-full bg-emerald-400 transition-[width] duration-500"
-                  style={{ width: `${xpProgressPercent}%` }}
-                />
-              </div>
-              <div className="mt-2 flex items-center justify-between text-xs text-emerald-100/90">
-                <span>+{matchSummary.expGained} XP</span>
-                <span>Win streak: {matchSummary.streak}</span>
-              </div>
-              {levelUpFlash && (
-                <div className="mt-2 text-base font-semibold uppercase tracking-wide text-amber-200">
-                  Level up!
-                </div>
-              )}
-            </div>
-          )}
-
-          <div className="flex flex-col gap-2">
-            <button
-              disabled={isMultiplayer && localRematchReady}
-              onClick={handleRematchClick}
-              className="w-full rounded bg-emerald-500 px-4 py-2 font-semibold text-slate-900 disabled:opacity-50"
-            >
-              {rematchButtonLabel}
-            </button>
-            {isMultiplayer && rematchStatusText && (
-              <span className="text-[11px] italic text-amber-200 leading-tight">
-                {rematchStatusText}
-              </span>
-            )}
-            {onExit && (
-              <button
-                onClick={handleExitClick}
-                className="w-full rounded border border-slate-600 px-4 py-2 text-sm font-semibold text-slate-200 hover:bg-slate-800"
-              >
-                Exit to Main Menu
-              </button>
-            )}
-          </div>
-        </div>
-      </div>
-    )}
-  </>
-  )}
+        <VictoryOverlay
+          victoryCollapsed={victoryCollapsed}
+          onCollapseChange={setVictoryCollapsed}
+          localWon={localWon}
+          matchSummary={matchSummary}
+          winGoal={winGoal}
+          winnerName={winnerName}
+          remoteName={remoteName}
+          localName={localName}
+          localWinsCount={localWinsCount}
+          remoteWinsCount={remoteWinsCount}
+          xpDisplay={xpDisplay}
+          xpProgressPercent={xpProgressPercent}
+          levelUpFlash={levelUpFlash}
+          onRematch={handleRematchClick}
+          rematchButtonLabel={rematchButtonLabel}
+          isMultiplayer={isMultiplayer}
+          localRematchReady={localRematchReady}
+          rematchStatusText={rematchStatusText}
+          onExitClick={handleExitClick}
+          onExit={onExit}
+        />
+      )}
   
       </div>
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2032,13 +2032,88 @@ const renderArchetypeModal = () => (
                 className="mt-4 rounded-lg border border-amber-400/70 px-3 py-1.5 text-sm font-semibold text-amber-100 transition hover:bg-amber-400/10 disabled:cursor-not-allowed disabled:border-amber-200/40 disabled:text-amber-200/70"
               >
                 {isLocalChoice ? "Selected" : "Choose"}
-              </button>
+    </button>
             </div>
           );
         })}
       </div>
 
-      {/* ...keep the rest of the modal footer/buttons you already had here... */}
+      {/* Archetype selections summary + ready controls */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        {/* local side panel */}
+        <div className="rounded-xl border border-slate-700/70 bg-slate-900/70 p-4">
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-sm font-semibold text-slate-100">
+              {namesByLegacy[localLegacySide]}
+            </div>
+            <span
+              className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+                localReady ? "bg-emerald-500/20 text-emerald-300" : "bg-slate-700/60 text-slate-300"
+              }`}
+            >
+              {localReady ? "Ready" : "Not Ready"}
+            </span>
+          </div>
+          <div className="mt-2 text-xs text-slate-300/90">
+            {localArchetypeDef ? localArchetypeDef.name : "Select an archetype"}
+          </div>
+          <ul className="mt-3 space-y-1 text-xs text-slate-100/90">
+            {localSpells.length === 0 ? (
+              <li className="italic text-slate-400">No spells yet</li>
+            ) : (
+              localSpells.map((spell) => <li key={spell}>{formatSpellId(spell)}</li>)
+            )}
+          </ul>
+        </div>
+
+        {/* remote side panel */}
+        <div className="rounded-xl border border-slate-700/70 bg-slate-900/70 p-4">
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-sm font-semibold text-slate-100">
+              {namesByLegacy[remoteLegacySide]}
+            </div>
+            <span
+              className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+                remoteReady ? "bg-emerald-500/20 text-emerald-300" : "bg-slate-700/60 text-slate-300"
+              }`}
+            >
+              {remoteReady ? "Ready" : "Waiting"}
+            </span>
+          </div>
+          <div className="mt-2 text-xs text-slate-300/90">
+            {remoteArchetypeDef ? remoteArchetypeDef.name : "Awaiting selection"}
+          </div>
+          <ul className="mt-3 space-y-1 text-xs text-slate-100/90">
+            {remoteSpells.length === 0 ? (
+              <li className="italic text-slate-400">Hidden</li>
+            ) : (
+              remoteSpells.map((spell) => <li key={spell}>{formatSpellId(spell)}</li>)
+            )}
+          </ul>
+        </div>
+      </div>
+
+      {/* footer: status text + Ready/Next button */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-sm text-slate-300/90">
+          {isMultiplayer
+            ? remoteReady
+              ? `${namesByLegacy[remoteLegacySide]} is ready.`
+              : `Waiting for ${namesByLegacy[remoteLegacySide]}...`
+            : remoteArchetypeDef
+            ? `${namesByLegacy[remoteLegacySide]} is ready.`
+            : `${namesByLegacy[remoteLegacySide]} is choosing an archetype...`}
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={handleLocalArchetypeReady}
+            disabled={readyButtonDisabled}
+            className="rounded-lg bg-amber-400 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-amber-300 disabled:cursor-not-allowed disabled:bg-amber-200/80"
+          >
+            {readyButtonLabel}
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 );
@@ -2401,165 +2476,6 @@ return (
         </div>
       </div>
     )}
-  </div>
-);
-// --- Archetype modal (inline version) ---
-const renderArchetypeModal = () => (
-  <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 backdrop-blur-sm px-4 py-6">
-    <div className="w-full max-w-4xl space-y-6 rounded-2xl border border-slate-700 bg-slate-900/95 p-6 shadow-2xl">
-      {/* header */}
-      <div className="space-y-2 text-center">
-        <h2 className="text-2xl font-semibold text-amber-200">Choose Your Archetype</h2>
-        <p className="text-sm text-slate-200/80">
-          Archetypes determine which spells appear in your grimoire. Pick one, then press{" "}
-          {isMultiplayer ? "Ready" : "Next"} to begin.
-        </p>
-      </div>
-
-      {/* grid of archetype cards */}
-      <div className="grid gap-4 sm:grid-cols-3">
-        {ARCHETYPE_IDS.map((id) => {
-          const def = ARCHETYPE_DEFINITIONS[id];
-          const isLocalChoice = localSelection === id;
-          const isRemoteChoice = remoteSelection === id;
-          return (
-            <div
-              key={id}
-              className="relative flex h-full flex-col rounded-xl border border-slate-700/70 bg-slate-800/70 p-4 shadow"
-              style={{
-                borderColor: isLocalChoice
-                  ? HUD_COLORS[localLegacySide]
-                  : isRemoteChoice
-                  ? HUD_COLORS[remoteLegacySide]
-                  : undefined,
-              }}
-            >
-              <div className="flex items-start justify-between gap-2">
-                <div>
-                  <div className="text-lg font-semibold text-slate-100">{def.name}</div>
-                  <p className="mt-1 text-xs text-slate-300/80 leading-snug">{def.description}</p>
-                </div>
-                <div className="flex flex-col items-end gap-1 text-[10px] font-semibold uppercase tracking-wide">
-                  {isLocalChoice && (
-                    <span
-                      className="rounded-full px-2 py-0.5"
-                      style={{ background: `${HUD_COLORS[localLegacySide]}22`, color: HUD_COLORS[localLegacySide] }}
-                    >
-                      You
-                    </span>
-                  )}
-                  {isRemoteChoice && (
-                    <span
-                      className="rounded-full px-2 py-0.5"
-                      style={{ background: `${HUD_COLORS[remoteLegacySide]}22`, color: HUD_COLORS[remoteLegacySide] }}
-                    >
-                      {namesByLegacy[remoteLegacySide]}
-                    </span>
-                  )}
-                </div>
-              </div>
-
-              <div className="mt-3 flex-1 rounded-lg border border-slate-700/70 bg-slate-900/60 p-3">
-                <div className="text-xs font-semibold uppercase text-slate-300/80">Spells</div>
-                <ul className="mt-2 space-y-1 text-xs text-slate-100/90">
-                  {def.spellIds.map((spell) => (
-                    <li key={spell} className="flex items-center gap-2">
-                      <span className="h-1.5 w-1.5 rounded-full bg-slate-500" aria-hidden />
-                      <span>{formatSpellId(spell)}</span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-
-              <button
-                onClick={() => handleLocalArchetypeSelect(id)}
-                disabled={isLocalChoice}
-                className="mt-4 rounded-lg border border-amber-400/70 px-3 py-1.5 text-sm font-semibold text-amber-100 transition hover:bg-amber-400/10 disabled:cursor-not-allowed disabled:border-amber-200/40 disabled:text-amber-200/70"
-              >
-                {isLocalChoice ? "Selected" : "Choose"}
-              </button>
-            </div>
-          );
-        })}
-      </div>
-
-      {/* Archetype selections summary + ready controls */}
-      <div className="grid gap-4 sm:grid-cols-2">
-        {/* local side panel */}
-        <div className="rounded-xl border border-slate-700/70 bg-slate-900/70 p-4">
-          <div className="flex items-center justify-between gap-2">
-            <div className="text-sm font-semibold text-slate-100">
-              {namesByLegacy[localLegacySide]}
-            </div>
-            <span
-              className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
-                localReady ? "bg-emerald-500/20 text-emerald-300" : "bg-slate-700/60 text-slate-300"
-              }`}
-            >
-              {localReady ? "Ready" : "Not Ready"}
-            </span>
-          </div>
-          <div className="mt-2 text-xs text-slate-300/90">
-            {localArchetypeDef ? localArchetypeDef.name : "Select an archetype"}
-          </div>
-          <ul className="mt-3 space-y-1 text-xs text-slate-100/90">
-            {localSpells.length === 0 ? (
-              <li className="italic text-slate-400">No spells yet</li>
-            ) : (
-              localSpells.map((spell) => <li key={spell}>{formatSpellId(spell)}</li>)
-            )}
-          </ul>
-        </div>
-
-        {/* remote side panel */}
-        <div className="rounded-xl border border-slate-700/70 bg-slate-900/70 p-4">
-          <div className="flex items-center justify-between gap-2">
-            <div className="text-sm font-semibold text-slate-100">
-              {namesByLegacy[remoteLegacySide]}
-            </div>
-            <span
-              className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
-                remoteReady ? "bg-emerald-500/20 text-emerald-300" : "bg-slate-700/60 text-slate-300"
-              }`}
-            >
-              {remoteReady ? "Ready" : "Waiting"}
-            </span>
-          </div>
-          <div className="mt-2 text-xs text-slate-300/90">
-            {remoteArchetypeDef ? remoteArchetypeDef.name : "Awaiting selection"}
-          </div>
-          <ul className="mt-3 space-y-1 text-xs text-slate-100/90">
-            {remoteSpells.length === 0 ? (
-              <li className="italic text-slate-400">Hidden</li>
-            ) : (
-              remoteSpells.map((spell) => <li key={spell}>{formatSpellId(spell)}</li>)
-            )}
-          </ul>
-        </div>
-      </div>
-
-      {/* footer: status text + Ready/Next button */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="text-sm text-slate-300/90">
-          {isMultiplayer
-            ? remoteReady
-              ? `${namesByLegacy[remoteLegacySide]} is ready.`
-              : `Waiting for ${namesByLegacy[remoteLegacySide]}...`
-            : remoteArchetypeDef
-            ? `${namesByLegacy[remoteLegacySide]} is ready.`
-            : `${namesByLegacy[remoteLegacySide]} is choosing an archetype...`}
-        </div>
-        <div className="flex justify-end gap-2">
-          <button
-            onClick={handleLocalArchetypeReady}
-            disabled={readyButtonDisabled}
-            className="rounded-lg bg-amber-400 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-amber-300 disabled:cursor-not-allowed disabled:bg-amber-200/80"
-          >
-            {readyButtonLabel}
-          </button>
-        </div>
-      </div>
-    </div>
   </div>
 );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2403,87 +2403,165 @@ return (
     )}
   </div>
 );
+// --- Archetype modal (inline version) ---
+const renderArchetypeModal = () => (
+  <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 backdrop-blur-sm px-4 py-6">
+    <div className="w-full max-w-4xl space-y-6 rounded-2xl border border-slate-700 bg-slate-900/95 p-6 shadow-2xl">
+      {/* header */}
+      <div className="space-y-2 text-center">
+        <h2 className="text-2xl font-semibold text-amber-200">Choose Your Archetype</h2>
+        <p className="text-sm text-slate-200/80">
+          Archetypes determine which spells appear in your grimoire. Pick one, then press{" "}
+          {isMultiplayer ? "Ready" : "Next"} to begin.
+        </p>
+      </div>
 
-        {/* Archetype selections summary + ready controls */}
-        <div className="grid gap-4 sm:grid-cols-2">
-          {/* local side panel */}
-          <div className="rounded-xl border border-slate-700/70 bg-slate-900/70 p-4">
-            <div className="flex items-center justify-between gap-2">
-              <div className="text-sm font-semibold text-slate-100">
-                {namesByLegacy[localLegacySide]}
-              </div>
-              <span
-                className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
-                  localReady ? "bg-emerald-500/20 text-emerald-300" : "bg-slate-700/60 text-slate-300"
-                }`}
-              >
-                {localReady ? "Ready" : "Not Ready"}
-              </span>
-            </div>
-            <div className="mt-2 text-xs text-slate-300/90">
-              {localArchetypeDef ? localArchetypeDef.name : "Select an archetype"}
-            </div>
-            <ul className="mt-3 space-y-1 text-xs text-slate-100/90">
-              {localSpells.length === 0 ? (
-                <li className="italic text-slate-400">No spells yet</li>
-              ) : (
-                localSpells.map((spell) => <li key={spell}>{formatSpellId(spell)}</li>)
-              )}
-            </ul>
-          </div>
-
-          {/* remote side panel */}
-          <div className="rounded-xl border border-slate-700/70 bg-slate-900/70 p-4">
-            <div className="flex items-center justify-between gap-2">
-              <div className="text-sm font-semibold text-slate-100">
-                {namesByLegacy[remoteLegacySide]}
-              </div>
-              <span
-                className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
-                  remoteReady ? "bg-emerald-500/20 text-emerald-300" : "bg-slate-700/60 text-slate-300"
-                }`}
-              >
-                {remoteReady ? "Ready" : "Waiting"}
-              </span>
-            </div>
-            <div className="mt-2 text-xs text-slate-300/90">
-              {remoteArchetypeDef ? remoteArchetypeDef.name : "Awaiting selection"}
-            </div>
-            <ul className="mt-3 space-y-1 text-xs text-slate-100/90">
-              {remoteSpells.length === 0 ? (
-                <li className="italic text-slate-400">Hidden</li>
-              ) : (
-                remoteSpells.map((spell) => <li key={spell}>{formatSpellId(spell)}</li>)
-              )}
-            </ul>
-          </div>
-        </div>
-
-        {/* footer: status text + Ready/Next button */}
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="text-sm text-slate-300/90">
-            {isMultiplayer
-              ? remoteReady
-                ? `${namesByLegacy[remoteLegacySide]} is ready.`
-                : `Waiting for ${namesByLegacy[remoteLegacySide]}...`
-              : remoteArchetypeDef
-              ? `${namesByLegacy[remoteLegacySide]} is ready.`
-              : `${namesByLegacy[remoteLegacySide]} is choosing an archetype...`}
-          </div>
-          <div className="flex justify-end gap-2">
-            <button
-              onClick={handleLocalArchetypeReady}
-              disabled={readyButtonDisabled}
-              className="rounded-lg bg-amber-400 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-amber-300 disabled:cursor-not-allowed disabled:bg-amber-200/80"
+      {/* grid of archetype cards */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        {ARCHETYPE_IDS.map((id) => {
+          const def = ARCHETYPE_DEFINITIONS[id];
+          const isLocalChoice = localSelection === id;
+          const isRemoteChoice = remoteSelection === id;
+          return (
+            <div
+              key={id}
+              className="relative flex h-full flex-col rounded-xl border border-slate-700/70 bg-slate-800/70 p-4 shadow"
+              style={{
+                borderColor: isLocalChoice
+                  ? HUD_COLORS[localLegacySide]
+                  : isRemoteChoice
+                  ? HUD_COLORS[remoteLegacySide]
+                  : undefined,
+              }}
             >
-              {readyButtonLabel}
-            </button>
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <div className="text-lg font-semibold text-slate-100">{def.name}</div>
+                  <p className="mt-1 text-xs text-slate-300/80 leading-snug">{def.description}</p>
+                </div>
+                <div className="flex flex-col items-end gap-1 text-[10px] font-semibold uppercase tracking-wide">
+                  {isLocalChoice && (
+                    <span
+                      className="rounded-full px-2 py-0.5"
+                      style={{ background: `${HUD_COLORS[localLegacySide]}22`, color: HUD_COLORS[localLegacySide] }}
+                    >
+                      You
+                    </span>
+                  )}
+                  {isRemoteChoice && (
+                    <span
+                      className="rounded-full px-2 py-0.5"
+                      style={{ background: `${HUD_COLORS[remoteLegacySide]}22`, color: HUD_COLORS[remoteLegacySide] }}
+                    >
+                      {namesByLegacy[remoteLegacySide]}
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              <div className="mt-3 flex-1 rounded-lg border border-slate-700/70 bg-slate-900/60 p-3">
+                <div className="text-xs font-semibold uppercase text-slate-300/80">Spells</div>
+                <ul className="mt-2 space-y-1 text-xs text-slate-100/90">
+                  {def.spellIds.map((spell) => (
+                    <li key={spell} className="flex items-center gap-2">
+                      <span className="h-1.5 w-1.5 rounded-full bg-slate-500" aria-hidden />
+                      <span>{formatSpellId(spell)}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <button
+                onClick={() => handleLocalArchetypeSelect(id)}
+                disabled={isLocalChoice}
+                className="mt-4 rounded-lg border border-amber-400/70 px-3 py-1.5 text-sm font-semibold text-amber-100 transition hover:bg-amber-400/10 disabled:cursor-not-allowed disabled:border-amber-200/40 disabled:text-amber-200/70"
+              >
+                {isLocalChoice ? "Selected" : "Choose"}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Archetype selections summary + ready controls */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        {/* local side panel */}
+        <div className="rounded-xl border border-slate-700/70 bg-slate-900/70 p-4">
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-sm font-semibold text-slate-100">
+              {namesByLegacy[localLegacySide]}
+            </div>
+            <span
+              className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+                localReady ? "bg-emerald-500/20 text-emerald-300" : "bg-slate-700/60 text-slate-300"
+              }`}
+            >
+              {localReady ? "Ready" : "Not Ready"}
+            </span>
           </div>
+          <div className="mt-2 text-xs text-slate-300/90">
+            {localArchetypeDef ? localArchetypeDef.name : "Select an archetype"}
+          </div>
+          <ul className="mt-3 space-y-1 text-xs text-slate-100/90">
+            {localSpells.length === 0 ? (
+              <li className="italic text-slate-400">No spells yet</li>
+            ) : (
+              localSpells.map((spell) => <li key={spell}>{formatSpellId(spell)}</li>)
+            )}
+          </ul>
         </div>
-    </div>
-  );
-};
-      
+
+        {/* remote side panel */}
+        <div className="rounded-xl border border-slate-700/70 bg-slate-900/70 p-4">
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-sm font-semibold text-slate-100">
+              {namesByLegacy[remoteLegacySide]}
+            </div>
+            <span
+              className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+                remoteReady ? "bg-emerald-500/20 text-emerald-300" : "bg-slate-700/60 text-slate-300"
+              }`}
+            >
+              {remoteReady ? "Ready" : "Waiting"}
+            </span>
+          </div>
+          <div className="mt-2 text-xs text-slate-300/90">
+            {remoteArchetypeDef ? remoteArchetypeDef.name : "Awaiting selection"}
+          </div>
+          <ul className="mt-3 space-y-1 text-xs text-slate-100/90">
+            {remoteSpells.length === 0 ? (
+              <li className="italic text-slate-400">Hidden</li>
+            ) : (
+              remoteSpells.map((spell) => <li key={spell}>{formatSpellId(spell)}</li>)
+            )}
+          </ul>
+        </div>
+      </div>
+
+      {/* footer: status text + Ready/Next button */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-sm text-slate-300/90">
+          {isMultiplayer
+            ? remoteReady
+              ? `${namesByLegacy[remoteLegacySide]} is ready.`
+              : `Waiting for ${namesByLegacy[remoteLegacySide]}...`
+            : remoteArchetypeDef
+            ? `${namesByLegacy[remoteLegacySide]} is ready.`
+            : `${namesByLegacy[remoteLegacySide]} is choosing an archetype...`}
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={handleLocalArchetypeReady}
+            disabled={readyButtonDisabled}
+            className="rounded-lg bg-amber-400 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-amber-300 disabled:cursor-not-allowed disabled:bg-amber-200/80"
+          >
+            {readyButtonLabel}
+          </button>
+        </div>
+      </div>
+    </div>{/* end modal card */}
+  </div>{/* end backdrop */}
+);
 
   const localResolveReady = resolveVotes[localLegacySide];
   const remoteResolveReady = resolveVotes[remoteLegacySide];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2323,82 +2323,110 @@ const HandDock = ({ onMeasure }: { onMeasure?: (px: number) => void }) => {
 
   const localFighter: Fighter = localLegacySide === "player" ? player : enemy;
 
-  return (
-    <div
-      ref={dockRef}
-      className="fixed left-0 right-0 bottom-0 z-50 pointer-events-none select-none"
-      style={{ bottom: 'calc(env(safe-area-inset-bottom, 0px) + -30px)' }}
-    >
-      <div className="mx-auto max-w-[1400px] flex justify-center gap-1.5 py-0.5">
-        {localFighter.hand.map((card, idx) => {
-          const isSelected = selectedCardId === card.id;
-          return (
-            <div key={card.id} className="group relative pointer-events-auto" style={{ zIndex: 10 + idx }}>
-              <motion.div
+return (
+  <div
+    ref={dockRef}
+    className="fixed left-0 right-0 bottom-0 z-50 pointer-events-none select-none"
+    style={{ bottom: "calc(env(safe-area-inset-bottom, 0px) - 30px)" }}
+  >
+    <div className="mx-auto max-w-[1400px] flex justify-center gap-1.5 py-0.5">
+      {localFighter.hand.map((card, idx) => {
+        const isSelected = selectedCardId === card.id;
+        return (
+          <div
+            key={card.id}
+            className="group relative pointer-events-auto"
+            style={{ zIndex: 10 + idx }}
+          >
+            <motion.div
+              data-hand-card
+              initial={false}
+              animate={{
+                y: isSelected ? -Math.max(8, liftPx - 10) : -liftPx,
+                opacity: 1,
+                scale: isSelected ? 1.06 : 1,
+              }}
+              whileHover={{
+                y: -Math.max(8, liftPx - 10),
+                opacity: 1,
+                scale: 1.04,
+              }}
+              transition={{ type: "spring", stiffness: 320, damping: 22 }}
+              className={`drop-shadow-xl ${
+                isSelected ? "ring-2 ring-amber-300" : ""
+              }`}
+            >
+              <button
                 data-hand-card
-                initial={false}
-                animate={{ y: isSelected ? -Math.max(8, liftPx - 10) : -liftPx, opacity: 1, scale: isSelected ? 1.06 : 1 }}
-                whileHover={{ y: -Math.max(8, liftPx - 10), opacity: 1, scale: 1.04 }}
-                transition={{ type: 'spring', stiffness: 320, damping: 22 }}
-                className={`drop-shadow-xl ${isSelected ? 'ring-2 ring-amber-300' : ''}`}
-              >
-                <button
-                  data-hand-card
-                  className="pointer-events-auto"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (!selectedCardId) { setSelectedCardId(card.id); return; }
-                    if (selectedCardId === card.id) { setSelectedCardId(null); return; }
-                    const lane = localLegacySide === "player" ? assign.player : assign.enemy;
-                    const slotIdx = lane.findIndex((c) => c?.id === selectedCardId);
-                    if (slotIdx !== -1) { assignToWheelLocal(slotIdx, card); return; }
+                className="pointer-events-auto"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (!selectedCardId) {
                     setSelectedCardId(card.id);
-                  }}
-                  draggable
-                  onDragStart={(e) => {
-                    setDragCardId(card.id);
-                    try { e.dataTransfer.setData("text/plain", card.id); } catch {}
-                    e.dataTransfer.effectAllowed = "move";
-                  }}
-                  onDragEnd={() => setDragCardId(null)}
-                  onPointerDown={(e) => startPointerDrag(card, e)}
-                  aria-pressed={isSelected}
-                  aria-label={`Select ${card.name}`}
-                >
-                  <StSCard card={card} />
-                </button>
-              </motion.div>
-            </div>
-          );
-        })}
-      </div>
+                    return;
+                  }
+                  if (selectedCardId === card.id) {
+                    setSelectedCardId(null);
+                    return;
+                  }
+                  const lane =
+                    localLegacySide === "player" ? assign.player : assign.enemy;
+                  const slotIdx = lane.findIndex((c) => c?.id === selectedCardId);
+                  if (slotIdx !== -1) {
+                    assignToWheelLocal(slotIdx, card);
+                    return;
+                  }
+                  setSelectedCardId(card.id);
+                }}
+                draggable
+                onDragStart={(e) => {
+                  setDragCardId(card.id);
+                  try {
+                    e.dataTransfer.setData("text/plain", card.id);
+                  } catch {}
+                  e.dataTransfer.effectAllowed = "move";
+                }}
+                onDragEnd={() => setDragCardId(null)}
+                onPointerDown={(e) => startPointerDrag(card, e)}
+                aria-pressed={isSelected}
+                aria-label={`Select ${card.name}`}
+              >
+                <StSCard card={card} />
+              </button>
+            </motion.div>
+          </div>
+        );
+      })}
+    </div>
 
-      {/* Touch drag ghost (mobile) */}
-      {isPtrDragging && ptrDragCard && (
+    {/* Touch drag ghost (mobile) */}
+    {isPtrDragging && ptrDragCard && (
+      <div
+        style={{
+          position: "fixed",
+          left: 0,
+          top: 0,
+          transform: `translate(${ptrPos.current.x - 48}px, ${
+            ptrPos.current.y - 64
+          }px)`,
+          pointerEvents: "none",
+          zIndex: 9999,
+        }}
+        aria-hidden
+      >
         <div
           style={{
-            position: 'fixed',
-            left: 0,
-            top: 0,
-            transform: `translate(${ptrPos.current.x - 48}px, ${ptrPos.current.y - 64}px)`,
-            pointerEvents: 'none',
-            zIndex: 9999,
+            transform: "scale(0.9)",
+            filter: "drop-shadow(0 6px 8px rgba(0,0,0,.35))",
           }}
-          aria-hidden
         >
-          <div style={{ transform: 'scale(0.9)', filter: 'drop-shadow(0 6px 8px rgba(0,0,0,.35))' }}>
-            <StSCard card={ptrDragCard} />
-          </div>
+          <StSCard card={ptrDragCard} />
         </div>
-      )}
-    </div>
-  );
-};
+      </div>
+    )}
+  </div>
+);
 
-              </div>
-            );
-          })}
-        </div>
         {/* Archetype selections summary + ready controls */}
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="rounded-xl border border-slate-700/70 bg-slate-900/70 p-4">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2503,10 +2503,10 @@ return (
             </button>
           </div>
         </div>
-      </div>{/* end modal card */}
-    </div>{/* end backdrop */}
+      </div>
+    </div>
   );
-}; // end renderArchetypeModal
+};
       
 
   const localResolveReady = resolveVotes[localLegacySide];

--- a/src/features/threeWheel/components/HUDPanels.tsx
+++ b/src/features/threeWheel/components/HUDPanels.tsx
@@ -1,0 +1,175 @@
+import React from "react";
+import type { Phase, Players } from "../../../game/types";
+import type { LegacySide } from "./WheelPanel";
+
+interface Theme {
+  panelBg: string;
+  panelBorder: string;
+  slotBg: string;
+  slotBorder: string;
+  brass: string;
+  textWarm: string;
+}
+
+interface HUDPanelsProps {
+  manaPools: { player: number; enemy: number };
+  isGrimoireMode: boolean;
+  reserveSums: { player: number; enemy: number } | null;
+  players: Players;
+  hudColors: Record<LegacySide, string>;
+  wins: { player: number; enemy: number };
+  initiative: LegacySide;
+  localLegacySide: LegacySide;
+  phase: Phase;
+  theme: Theme;
+}
+
+const HUDPanels: React.FC<HUDPanelsProps> = ({
+  manaPools,
+  isGrimoireMode,
+  reserveSums,
+  players,
+  hudColors,
+  wins,
+  initiative,
+  localLegacySide,
+  phase,
+  theme,
+}) => {
+  const rsP = reserveSums ? reserveSums.player : null;
+  const rsE = reserveSums ? reserveSums.enemy : null;
+
+  const Panel = ({ side }: { side: LegacySide }) => {
+    const isPlayer = side === "player";
+    const color = isPlayer ? players.left.color ?? hudColors.player : players.right.color ?? hudColors.enemy;
+    const name = isPlayer ? players.left.name : players.right.name;
+    const win = isPlayer ? wins.player : wins.enemy;
+    const manaCount = isPlayer ? manaPools.player : manaPools.enemy;
+    const rs = isPlayer ? rsP : rsE;
+    const hasInit = initiative === side;
+    const isReserveVisible =
+      (phase === "showEnemy" || phase === "anim" || phase === "roundEnd" || phase === "ended") && rs !== null;
+
+    return (
+      <div className="flex h-full flex-col items-center w-full">
+        <div
+          className="relative flex min-w-0 items-center gap-2 rounded-lg border px-2 py-1 text-[12px] shadow w-full"
+          style={{
+            maxWidth: "100%",
+            background: theme.panelBg,
+            borderColor: theme.panelBorder,
+            color: theme.textWarm,
+          }}
+        >
+          <div className="w-1.5 h-6 rounded" style={{ background: color }} />
+          <div className="flex items-center min-w-0 flex-1">
+            <span className="truncate block font-semibold">{name}</span>
+            {(isPlayer ? "player" : "enemy") === localLegacySide && (
+              <span className="ml-2 rounded bg-white/10 px-1.5 py-0.5 text-[10px]">You</span>
+            )}
+          </div>
+          <div className="flex items-center gap-3 ml-1 flex-shrink-0">
+            <div className="flex items-center gap-1">
+              <span className="opacity-80">Wins</span>
+              <span className="text-base font-extrabold tabular-nums">{win}</span>
+            </div>
+            <div
+              className={`flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-semibold transition-opacity ${
+                isGrimoireMode ? "opacity-100 visible" : "opacity-0 invisible"
+              }`}
+              style={{
+                background: "#1b1209ee",
+                borderColor: theme.slotBorder,
+                color: theme.textWarm,
+                minWidth: "62px",
+                justifyContent: "center",
+              }}
+              aria-hidden={!isGrimoireMode}
+              title={isGrimoireMode ? `Mana: ${manaCount}` : undefined}
+            >
+              <span role="img" aria-label="Mana" className="text-sm leading-none">
+                🔮
+              </span>
+              <span className="tabular-nums text-sm leading-none">{manaCount}</span>
+            </div>
+          </div>
+          <div
+            className={`ml-2 hidden sm:flex rounded-full border px-2 py-0.5 text-[11px] overflow-hidden text-ellipsis whitespace-nowrap transition-opacity ${
+              isReserveVisible ? "opacity-100 visible" : "opacity-0 invisible"
+            }`}
+            style={{
+              maxWidth: "44vw",
+              minWidth: "90px",
+              background: "#1b1209ee",
+              borderColor: theme.slotBorder,
+              color: theme.textWarm,
+            }}
+            title={rs !== null ? `Reserve: ${rs}` : undefined}
+          >
+            Reserve: <span className="font-bold tabular-nums">{rs ?? 0}</span>
+          </div>
+          {hasInit && (
+            <span
+              aria-label="Has initiative"
+              className="absolute -top-1 -right-1 leading-none select-none"
+              style={{
+                fontSize: 24,
+                filter: "drop-shadow(0 1px 1px rgba(0,0,0,.6))",
+              }}
+            >
+              ⚑
+            </span>
+          )}
+        </div>
+
+        {isReserveVisible && (
+          <div className="mt-1 w-full sm:hidden">
+            <div className="w-full flex flex-col gap-1">
+              <div
+                className="w-full rounded-full border px-3 py-1 text-[11px] text-center"
+                style={{
+                  background: "#1b1209ee",
+                  borderColor: theme.slotBorder,
+                  color: theme.textWarm,
+                }}
+                title={rs !== null ? `Reserve: ${rs}` : undefined}
+              >
+                Reserve: <span className="font-bold tabular-nums">{rs ?? 0}</span>
+              </div>
+              <div
+                className={`w-full rounded-full border px-3 py-1 text-[11px] text-center transition-opacity ${
+                  isGrimoireMode ? "opacity-100 visible" : "opacity-0 invisible"
+                }`}
+                style={{
+                  background: "#1b1209ee",
+                  borderColor: theme.slotBorder,
+                  color: theme.textWarm,
+                }}
+                aria-hidden={!isGrimoireMode}
+                title={isGrimoireMode ? `Mana: ${manaCount}` : undefined}
+              >
+                <span className="font-semibold">Mana:</span>{" "}
+                <span className="font-bold tabular-nums">{manaCount}</span>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="w-full flex flex-col items-center">
+      <div className="grid w-full max-w-[900px] grid-cols-2 items-stretch gap-2 overflow-x-hidden">
+        <div className="min-w-0 w-full max-w-[420px] mx-auto h-full">
+          <Panel side="player" />
+        </div>
+        <div className="min-w-0 w-full max-w-[420px] mx-auto h-full">
+          <Panel side="enemy" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HUDPanels;

--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useRef, useState } from "react";
+import { motion } from "framer-motion";
+import StSCard from "../../../components/StSCard";
+import type { Card, Fighter } from "../../../game/types";
+import type { LegacySide } from "./WheelPanel";
+
+interface HandDockProps {
+  localLegacySide: LegacySide;
+  player: Fighter;
+  enemy: Fighter;
+  selectedCardId: string | null;
+  setSelectedCardId: (value: string | null) => void;
+  assign: { player: (Card | null)[]; enemy: (Card | null)[] };
+  assignToWheelLocal: (laneIndex: number, card: Card) => void;
+  setDragCardId: (value: string | null) => void;
+  startPointerDrag: (card: Card, e: React.PointerEvent<HTMLButtonElement>) => void;
+  isPtrDragging: boolean;
+  ptrDragCard: Card | null;
+  ptrPos: React.MutableRefObject<{ x: number; y: number }>;
+  onMeasure?: (px: number) => void;
+}
+
+const HandDock: React.FC<HandDockProps> = ({
+  localLegacySide,
+  player,
+  enemy,
+  selectedCardId,
+  setSelectedCardId,
+  assign,
+  assignToWheelLocal,
+  setDragCardId,
+  startPointerDrag,
+  isPtrDragging,
+  ptrDragCard,
+  ptrPos,
+  onMeasure,
+}) => {
+  const dockRef = useRef<HTMLDivElement | null>(null);
+  const [liftPx, setLiftPx] = useState<number>(18);
+
+  useEffect(() => {
+    const compute = () => {
+      const root = dockRef.current;
+      if (!root) return;
+      const sample = root.querySelector("[data-hand-card]") as HTMLElement | null;
+      if (!sample) return;
+      const h = sample.getBoundingClientRect().height || 96;
+      const nextLift = Math.round(Math.min(44, Math.max(12, h * 0.34)));
+      setLiftPx(nextLift);
+      const clearance = Math.round(h + nextLift + 12);
+      onMeasure?.(clearance);
+    };
+
+    compute();
+    window.addEventListener("resize", compute);
+    window.addEventListener("orientationchange", compute);
+
+    return () => {
+      window.removeEventListener("resize", compute);
+      window.removeEventListener("orientationchange", compute);
+    };
+  }, [onMeasure]);
+
+  const localFighter: Fighter = localLegacySide === "player" ? player : enemy;
+
+  return (
+    <div
+      ref={dockRef}
+      className="fixed left-0 right-0 bottom-0 z-50 pointer-events-none select-none"
+      style={{ bottom: "calc(env(safe-area-inset-bottom, 0px) + -30px)" }}
+    >
+      <div className="mx-auto max-w-[1400px] flex justify-center gap-1.5 py-0.5">
+        {localFighter.hand.map((card, idx) => {
+          const isSelected = selectedCardId === card.id;
+          return (
+            <div key={card.id} className="group relative pointer-events-auto" style={{ zIndex: 10 + idx }}>
+              <motion.div
+                data-hand-card
+                initial={false}
+                animate={{
+                  y: isSelected ? -Math.max(8, liftPx - 10) : -liftPx,
+                  opacity: 1,
+                  scale: isSelected ? 1.06 : 1,
+                }}
+                whileHover={{ y: -Math.max(8, liftPx - 10), opacity: 1, scale: 1.04 }}
+                transition={{ type: "spring", stiffness: 320, damping: 22 }}
+                className={`drop-shadow-xl ${isSelected ? "ring-2 ring-amber-300" : ""}`}
+              >
+                <button
+                  data-hand-card
+                  className="pointer-events-auto"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (!selectedCardId) {
+                      setSelectedCardId(card.id);
+                      return;
+                    }
+
+                    if (selectedCardId === card.id) {
+                      setSelectedCardId(null);
+                      return;
+                    }
+
+                    const lane = localLegacySide === "player" ? assign.player : assign.enemy;
+                    const slotIdx = lane.findIndex((c) => c?.id === selectedCardId);
+                    if (slotIdx !== -1) {
+                      assignToWheelLocal(slotIdx, card);
+                      return;
+                    }
+
+                    setSelectedCardId(card.id);
+                  }}
+                  draggable
+                  onDragStart={(e) => {
+                    setDragCardId(card.id);
+                    try {
+                      e.dataTransfer.setData("text/plain", card.id);
+                    } catch {}
+                    e.dataTransfer.effectAllowed = "move";
+                  }}
+                  onDragEnd={() => setDragCardId(null)}
+                  onPointerDown={(e) => startPointerDrag(card, e)}
+                  aria-pressed={isSelected}
+                  aria-label={`Select ${card.name}`}
+                >
+                  <StSCard card={card} />
+                </button>
+              </motion.div>
+            </div>
+          );
+        })}
+      </div>
+      {isPtrDragging && ptrDragCard && (
+        <div
+          style={{
+            position: "fixed",
+            left: 0,
+            top: 0,
+            transform: `translate(${ptrPos.current.x - 48}px, ${ptrPos.current.y - 64}px)`,
+            pointerEvents: "none",
+            zIndex: 9999,
+          }}
+          aria-hidden
+        >
+          <div style={{ transform: "scale(0.9)", filter: "drop-shadow(0 6px 8px rgba(0,0,0,.35))" }}>
+            <StSCard card={ptrDragCard} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HandDock;

--- a/src/features/threeWheel/components/VictoryOverlay.tsx
+++ b/src/features/threeWheel/components/VictoryOverlay.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+import type { MatchResultSummary, LevelProgress } from "../../../player/profileStore";
+
+interface VictoryOverlayProps {
+  victoryCollapsed: boolean;
+  onCollapseChange: (collapsed: boolean) => void;
+  localWon: boolean;
+  matchSummary: MatchResultSummary | null;
+  winGoal: number;
+  winnerName: string | null;
+  remoteName: string;
+  localName: string;
+  localWinsCount: number;
+  remoteWinsCount: number;
+  xpDisplay: LevelProgress | null;
+  xpProgressPercent: number;
+  levelUpFlash: boolean;
+  onRematch: () => void;
+  rematchButtonLabel: string;
+  isMultiplayer: boolean;
+  localRematchReady: boolean;
+  rematchStatusText: string | null;
+  onExitClick: () => void;
+  onExit?: () => void;
+}
+
+const VictoryOverlay: React.FC<VictoryOverlayProps> = ({
+  victoryCollapsed,
+  onCollapseChange,
+  localWon,
+  matchSummary,
+  winGoal,
+  winnerName,
+  remoteName,
+  localName,
+  localWinsCount,
+  remoteWinsCount,
+  xpDisplay,
+  xpProgressPercent,
+  levelUpFlash,
+  onRematch,
+  rematchButtonLabel,
+  isMultiplayer,
+  localRematchReady,
+  rematchStatusText,
+  onExitClick,
+  onExit,
+}) => {
+  return (
+    <>
+      {victoryCollapsed ? (
+        <button
+          onClick={() => onCollapseChange(false)}
+          className={`fixed top-3 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-full border px-4 py-2 text-sm font-semibold shadow-lg transition hover:-translate-y-[1px] focus:outline-none focus:ring-2 focus:ring-emerald-400/60 ${
+            localWon
+              ? "border-emerald-500/40 bg-emerald-900/70 text-emerald-100"
+              : "border-slate-700 bg-slate-900/80 text-slate-100"
+          }`}
+        >
+          <span className="rounded-full bg-slate-950/40 px-2 py-0.5 text-xs uppercase tracking-wide">
+            {localWon ? "Victory" : "Defeat"}
+          </span>
+          <span className="text-xs opacity-80">Tap to reopen results</span>
+          {localWon && matchSummary?.expGained ? (
+            <span className="rounded-full bg-emerald-500/20 px-2 py-0.5 text-[11px] text-emerald-100">
+              +{matchSummary.expGained} XP
+            </span>
+          ) : null}
+        </button>
+      ) : null}
+
+      {!victoryCollapsed && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 backdrop-blur-sm px-3">
+          <div className="relative w-full max-w-sm rounded-lg border border-slate-700 bg-slate-900/95 p-6 text-center shadow-2xl space-y-4">
+            <button
+              onClick={() => onCollapseChange(true)}
+              className="group absolute top-2 right-2 flex h-10 w-10 items-center justify-center rounded-lg border border-slate-700/70 bg-slate-800/80 text-slate-200 transition hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-emerald-400/60"
+              aria-label="Minimize results"
+              title="Minimize"
+            >
+              <div className="flex flex-col items-end text-right leading-none">
+                <span className="text-[10px] font-semibold uppercase tracking-wide text-emerald-200/80 transition group-hover:text-emerald-100">
+                  Hide
+                </span>
+                <svg
+                  aria-hidden
+                  focusable="false"
+                  className="mt-1 h-5 w-5 text-emerald-200 transition group-hover:text-emerald-100"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path d="M4 10a1 1 0 0 1 1-1h6.586L9.293 6.707a1 1 0 1 1 1.414-1.414l4.5 4.5a1 1 0 0 1 0 1.414l-4.5 4.5a1 1 0 0 1-1.414-1.414L11.586 11H5a1 1 0 0 1-1-1Z" />
+                </svg>
+              </div>
+              <span className="text-lg font-semibold leading-none text-slate-200 transition group-hover:text-white">–</span>
+            </button>
+
+            <div className={`text-3xl font-bold ${localWon ? "text-emerald-300" : "text-rose-300"}`}>
+              {localWon ? "Victory" : "Defeat"}
+            </div>
+
+            <div className="text-sm text-slate-200">
+              {localWon
+                ? `You reached ${winGoal} wins.`
+                : `${winnerName ?? remoteName} reached ${winGoal} wins.`}
+            </div>
+
+            <div className="rounded-md border border-slate-700 bg-slate-800/80 px-4 py-3 text-sm text-slate-100">
+              <div className="font-semibold tracking-wide uppercase text-xs text-slate-400">Final Score</div>
+              <div className="mt-2 flex items-center justify-center gap-3 text-base font-semibold">
+                <span className="text-emerald-300">{localName}</span>
+                <span className="px-2 py-0.5 rounded bg-slate-900/60 text-slate-200 tabular-nums">{localWinsCount}</span>
+                <span className="text-slate-500">—</span>
+                <span className="px-2 py-0.5 rounded bg-slate-900/60 text-slate-200 tabular-nums">{remoteWinsCount}</span>
+                <span className="text-rose-300">{remoteName}</span>
+              </div>
+            </div>
+
+            {localWon && matchSummary?.didWin && xpDisplay && (
+              <div className="rounded-md border border-emerald-500/40 bg-emerald-900/15 px-4 py-3 text-sm text-emerald-50">
+                <div className="flex items-center justify-between text-[11px] uppercase tracking-wide text-emerald-200/80">
+                  <span>Level {xpDisplay.level}</span>
+                  <span>
+                    {xpDisplay.exp} / {xpDisplay.expToNext} XP
+                  </span>
+                </div>
+                <div className="mt-2 h-2 rounded-full bg-emerald-950/50">
+                  <div
+                    className="h-2 rounded-full bg-emerald-400 transition-[width] duration-500"
+                    style={{ width: `${xpProgressPercent}%` }}
+                  />
+                </div>
+                <div className="mt-2 flex items-center justify-between text-xs text-emerald-100/90">
+                  <span>+{matchSummary.expGained} XP</span>
+                  <span>Win streak: {matchSummary.streak}</span>
+                </div>
+                {levelUpFlash && (
+                  <div className="mt-2 text-base font-semibold uppercase tracking-wide text-amber-200">
+                    Level up!
+                  </div>
+                )}
+              </div>
+            )}
+
+            <div className="flex flex-col gap-2">
+              <button
+                disabled={isMultiplayer && localRematchReady}
+                onClick={onRematch}
+                className="w-full rounded bg-emerald-500 px-4 py-2 font-semibold text-slate-900 disabled:opacity-50"
+              >
+                {rematchButtonLabel}
+              </button>
+              {isMultiplayer && rematchStatusText && (
+                <span className="text-[11px] italic text-amber-200 leading-tight">
+                  {rematchStatusText}
+                </span>
+              )}
+              {onExit && (
+                <button
+                  onClick={onExitClick}
+                  className="w-full rounded border border-slate-600 px-4 py-2 text-sm font-semibold text-slate-200 hover:bg-slate-800"
+                >
+                  Exit to Main Menu
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default VictoryOverlay;

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -1,0 +1,362 @@
+import React from "react";
+import CanvasWheel, { WheelHandle } from "../../../components/CanvasWheel";
+import StSCard from "../../../components/StSCard";
+import type { Card, Fighter, Phase, Section } from "../../../game/types";
+
+export type LegacySide = "player" | "enemy";
+
+type SideState<T> = Record<LegacySide, T>;
+
+interface Theme {
+  panelBg: string;
+  panelBorder: string;
+  slotBg: string;
+  slotBorder: string;
+  brass: string;
+  textWarm: string;
+}
+
+export interface WheelPanelProps {
+  index: number;
+  assign: { player: (Card | null)[]; enemy: (Card | null)[] };
+  namesByLegacy: Record<LegacySide, string>;
+  wheelSize: number;
+  lockedWheelSize: number | null;
+  wheelDamage: SideState<number>;
+  wheelMirror: SideState<boolean>;
+  wheelLocked: boolean;
+  pointerShift: number;
+  reservePenalties: SideState<number>;
+  selectedCardId: string | null;
+  setSelectedCardId: (value: string | null) => void;
+  localLegacySide: LegacySide;
+  phase: Phase;
+  archetypeGateOpen: boolean;
+  setDragCardId: (value: string | null) => void;
+  dragCardId: string | null;
+  setDragOverWheel: (value: number | null) => void;
+  dragOverWheel: number | null;
+  player: Fighter;
+  enemy: Fighter;
+  assignToWheelLocal: (laneIndex: number, card: Card) => void;
+  isWheelActive: boolean;
+  wheelRef: React.RefObject<WheelHandle | null>;
+  wheelSection: Section[];
+  hudColors: Record<LegacySide, string>;
+  theme: Theme;
+  initiativeOverride: LegacySide | null;
+  startPointerDrag: (card: Card, e: React.PointerEvent<HTMLButtonElement>) => void;
+  wheelHudColor: string | null;
+}
+
+const slotWidthPx = 80;
+const gapXPx = 16;
+const paddingXPx = 16;
+const borderXPx = 4;
+const extraHeightPx = 16;
+
+const WheelPanel: React.FC<WheelPanelProps> = ({
+  index,
+  assign,
+  namesByLegacy,
+  wheelSize,
+  lockedWheelSize,
+  wheelDamage,
+  wheelMirror,
+  wheelLocked,
+  pointerShift,
+  reservePenalties,
+  selectedCardId,
+  setSelectedCardId,
+  localLegacySide,
+  phase,
+  archetypeGateOpen,
+  setDragCardId,
+  dragCardId,
+  setDragOverWheel,
+  dragOverWheel,
+  player,
+  enemy,
+  assignToWheelLocal,
+  isWheelActive,
+  wheelRef,
+  wheelSection,
+  hudColors,
+  theme,
+  initiativeOverride,
+  startPointerDrag,
+  wheelHudColor,
+}) => {
+  const playerCard = assign.player[index];
+  const enemyCard = assign.enemy[index];
+
+  const damageState = wheelDamage;
+  const mirrorState = wheelMirror;
+  const lockState = wheelLocked;
+  const playerPenalty = reservePenalties.player;
+  const enemyPenalty = reservePenalties.enemy;
+
+  const leftSlot = { side: "player" as const, card: playerCard, name: namesByLegacy.player };
+  const rightSlot = { side: "enemy" as const, card: enemyCard, name: namesByLegacy.enemy };
+
+  const ws = Math.round(lockedWheelSize ?? wheelSize);
+
+  const isLeftSelected = !!leftSlot.card && selectedCardId === leftSlot.card.id;
+  const isRightSelected = !!rightSlot.card && selectedCardId === rightSlot.card.id;
+
+  const shouldShowLeftCard =
+    !!leftSlot.card && (leftSlot.side === localLegacySide || phase !== "choose");
+  const shouldShowRightCard =
+    !!rightSlot.card && (rightSlot.side === localLegacySide || phase !== "choose");
+
+  const panelWidth = ws + slotWidthPx * 2 + gapXPx + paddingXPx + borderXPx;
+
+  const renderSlotCard = (slot: typeof leftSlot, isSlotSelected: boolean) => {
+    if (!slot.card) return null;
+    const card = slot.card;
+    const interactable =
+      slot.side === localLegacySide && phase === "choose" && archetypeGateOpen;
+
+    const handlePick = () => {
+      if (!interactable) return;
+      if (selectedCardId) {
+        tapAssignIfSelected();
+      } else {
+        setSelectedCardId(card.id);
+      }
+    };
+
+    const handleDragStart = (e: React.DragEvent<HTMLButtonElement>) => {
+      if (!interactable) return;
+      setSelectedCardId(card.id);
+      setDragCardId(card.id);
+      try {
+        e.dataTransfer.setData("text/plain", card.id);
+      } catch {}
+      e.dataTransfer.effectAllowed = "move";
+    };
+
+    const handleDragEnd = () => {
+      setDragCardId(null);
+      setDragOverWheel(null);
+    };
+
+    const handlePointerDown = (e: React.PointerEvent<HTMLButtonElement>) => {
+      if (!interactable) return;
+      e.stopPropagation();
+      startPointerDrag(card, e);
+    };
+
+    return (
+      <StSCard
+        card={card}
+        size="sm"
+        disabled={!interactable}
+        selected={isSlotSelected}
+        onPick={handlePick}
+        draggable={interactable}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onPointerDown={handlePointerDown}
+      />
+    );
+  };
+
+  const onZoneDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (dragCardId && isWheelActive) setDragOverWheel(index);
+  };
+  const onZoneLeave = () => {
+    if (dragCardId) setDragOverWheel(null);
+  };
+
+  const handleDropCommon = (id: string | null, targetSide?: LegacySide) => {
+    if (!id || !isWheelActive) return;
+    const intendedSide = targetSide ?? localLegacySide;
+    if (intendedSide !== localLegacySide) {
+      setDragOverWheel(null);
+      setDragCardId(null);
+      return;
+    }
+
+    const isLocalPlayer = localLegacySide === "player";
+    const fromHand = (isLocalPlayer ? player.hand : enemy.hand).find((c) => c.id === id);
+    const fromSlots = (isLocalPlayer ? assign.player : assign.enemy).find((c) => c && c.id === id);
+    const card = fromHand || fromSlots || null;
+    if (card) assignToWheelLocal(index, card);
+    setDragOverWheel(null);
+    setDragCardId(null);
+  };
+
+  const onZoneDrop = (e: React.DragEvent, targetSide?: LegacySide) => {
+    e.preventDefault();
+    handleDropCommon(e.dataTransfer.getData("text/plain") || dragCardId, targetSide);
+  };
+
+  const tapAssignIfSelected = () => {
+    if (!selectedCardId) return;
+    const isLocalPlayer = localLegacySide === "player";
+    const card =
+      (isLocalPlayer ? player.hand : enemy.hand).find((c) => c.id === selectedCardId) ||
+      (isLocalPlayer ? assign.player : assign.enemy).find((c) => c?.id === selectedCardId) ||
+      null;
+    if (card) assignToWheelLocal(index, card);
+  };
+
+  const panelShadow = "0 2px 8px rgba(0,0,0,.28), inset 0 1px 0 rgba(255,255,255,.04)";
+
+  return (
+    <div
+      className="relative rounded-xl border p-2 shadow flex-none"
+      style={{
+        width: panelWidth,
+        height: ws + extraHeightPx,
+        background: `linear-gradient(180deg, rgba(255,255,255,.04) 0%, rgba(0,0,0,.14) 100%), ${theme.panelBg}`,
+        borderColor: theme.panelBorder,
+        borderWidth: 2,
+        boxShadow: panelShadow,
+        contain: "paint",
+        backfaceVisibility: "hidden",
+        transform: "translateZ(0)",
+        isolation: "isolate",
+      }}
+      data-wheel-locked={lockState ? "true" : "false"}
+      data-pointer-shift={pointerShift}
+      data-player-damage={damageState.player}
+      data-enemy-damage={damageState.enemy}
+      data-player-mirror={mirrorState.player ? "true" : "false"}
+      data-enemy-mirror={mirrorState.enemy ? "true" : "false"}
+      data-player-reserve-penalty={playerPenalty}
+      data-enemy-reserve-penalty={enemyPenalty}
+      data-initiative-override={initiativeOverride ?? ""}
+    >
+      {(phase === "roundEnd" || phase === "ended") && (
+        <>
+          <span
+            aria-label={`Wheel ${index + 1} player result`}
+            className="absolute top-1 left-1 rounded-full border"
+            style={{
+              width: 10,
+              height: 10,
+              background: wheelHudColor === hudColors.player ? hudColors.player : "transparent",
+              borderColor: wheelHudColor === hudColors.player ? hudColors.player : theme.panelBorder,
+              boxShadow: "0 0 0 1px rgba(0,0,0,0.4)",
+            }}
+          />
+          <span
+            aria-label={`Wheel ${index + 1} enemy result`}
+            className="absolute top-1 right-1 rounded-full border"
+            style={{
+              width: 10,
+              height: 10,
+              background: wheelHudColor === hudColors.enemy ? hudColors.enemy : "transparent",
+              borderColor: wheelHudColor === hudColors.enemy ? hudColors.enemy : theme.panelBorder,
+              boxShadow: "0 0 0 1px rgba(0,0,0,0.4)",
+            }}
+          />
+        </>
+      )}
+
+      <div
+        className="flex items-center justify-center gap-2"
+        style={{ height: ws + extraHeightPx }}
+      >
+        <div
+          data-drop="slot"
+          data-idx={index}
+          onDragOver={onZoneDragOver}
+          onDragEnter={onZoneDragOver}
+          onDragLeave={onZoneLeave}
+          onDrop={(e) => onZoneDrop(e, "player")}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (leftSlot.side !== localLegacySide) return;
+            if (selectedCardId) {
+              tapAssignIfSelected();
+            } else if (leftSlot.card) {
+              setSelectedCardId(leftSlot.card.id);
+            }
+          }}
+          className="w-[80px] h-[92px] rounded-md border px-1 py-0 flex items-center justify-center flex-none"
+          style={{
+            backgroundColor:
+              dragOverWheel === index || isLeftSelected ? "rgba(182,138,78,.12)" : theme.slotBg,
+            borderColor: dragOverWheel === index || isLeftSelected ? theme.brass : theme.slotBorder,
+            boxShadow: isLeftSelected ? "0 0 0 1px rgba(251,191,36,0.7)" : "none",
+          }}
+          aria-label={`Wheel ${index + 1} left slot`}
+        >
+          {shouldShowLeftCard ? (
+            renderSlotCard(leftSlot, isLeftSelected)
+          ) : (
+            <div className="text-[11px] opacity-80 text-center">
+              {leftSlot.side === localLegacySide ? "Your card" : leftSlot.name}
+            </div>
+          )}
+        </div>
+
+        <div
+          data-drop="wheel"
+          data-idx={index}
+          className="relative flex-none flex items-center justify-center rounded-full overflow-hidden"
+          style={{ width: ws, height: ws }}
+          onDragOver={onZoneDragOver}
+          onDragEnter={onZoneDragOver}
+          onDragLeave={onZoneLeave}
+          onDrop={onZoneDrop}
+          onClick={(e) => {
+            e.stopPropagation();
+            tapAssignIfSelected();
+          }}
+          aria-label={`Wheel ${index + 1}`}
+        >
+          <CanvasWheel ref={wheelRef as React.RefObject<WheelHandle>} sections={wheelSection} size={ws} />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 rounded-full"
+            style={{
+              boxShadow:
+                dragOverWheel === index ? "0 0 0 2px rgba(251,191,36,0.7) inset" : "none",
+            }}
+          />
+        </div>
+
+        <div
+          className="w-[80px] h-[92px] rounded-md border px-1 py-0 flex items-center justify-center flex-none"
+          style={{
+            backgroundColor:
+              dragOverWheel === index || isRightSelected ? "rgba(182,138,78,.12)" : theme.slotBg,
+            borderColor: dragOverWheel === index || isRightSelected ? theme.brass : theme.slotBorder,
+            boxShadow: isRightSelected ? "0 0 0 1px rgba(251,191,36,0.7)" : "none",
+          }}
+          aria-label={`Wheel ${index + 1} right slot`}
+          data-drop="slot"
+          data-idx={index}
+          onDragOver={onZoneDragOver}
+          onDragEnter={onZoneDragOver}
+          onDragLeave={onZoneLeave}
+          onDrop={(e) => onZoneDrop(e, "enemy")}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (rightSlot.side !== localLegacySide) return;
+            if (selectedCardId) {
+              tapAssignIfSelected();
+            } else if (rightSlot.card) {
+              setSelectedCardId(rightSlot.card.id);
+            }
+          }}
+        >
+          {shouldShowRightCard ? (
+            renderSlotCard(rightSlot, isRightSelected)
+          ) : (
+            <div className="text-[11px] opacity-60 text-center">
+              {rightSlot.side === localLegacySide ? "Your card" : rightSlot.name}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WheelPanel;


### PR DESCRIPTION
## Summary
- extract the wheel panel, docked hand, HUD, and victory overlay views into feature components
- update ThreeWheel_WinsOnly to render the new components with the existing state and handlers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1b4352a708332b6310a8dc86f16ad