### PR TITLE
Add configurable match length inputs

### DIFF
--- a/src/ModeSelect.tsx
+++ b/src/ModeSelect.tsx
@@ -1,9 +1,13 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+
+import { TARGET_WINS } from "./game/types";
 import { DEFAULT_GAME_MODE, GAME_MODE_DETAILS, type GameMode } from "./gameModes";
 
 type ModeSelectProps = {
   initialMode?: GameMode;
-  onConfirm: (mode: GameMode) => void;
+  initialTargetWins?: number;
+  showTargetWinsInput?: boolean;
+  onConfirm: (mode: GameMode, targetWins: number) => void;
   onBack: () => void;
   backLabel?: string;
   confirmLabel?: string;
@@ -11,14 +15,53 @@ type ModeSelectProps = {
 
 export default function ModeSelect({
   initialMode = DEFAULT_GAME_MODE,
+  initialTargetWins = TARGET_WINS,
+  showTargetWinsInput = false,
   onConfirm,
   onBack,
   backLabel = "← Back",
   confirmLabel = "Confirm Mode",
 }: ModeSelectProps) {
   const [selectedMode, setSelectedMode] = useState<GameMode>(initialMode);
+  const [targetWins, setTargetWins] = useState<number>(() => clampTargetWins(initialTargetWins));
+  const [targetWinsInput, setTargetWinsInput] = useState<string>(String(clampTargetWins(initialTargetWins)));
 
-  const detailEntries = useMemo(() => Object.entries(GAME_MODE_DETAILS) as [GameMode, typeof GAME_MODE_DETAILS[GameMode]][], []);
+  const detailEntries = useMemo(
+    () => Object.entries(GAME_MODE_DETAILS) as [GameMode, (typeof GAME_MODE_DETAILS)[GameMode]][],
+    [],
+  );
+
+  useEffect(() => {
+    const next = clampTargetWins(initialTargetWins);
+    setTargetWins(next);
+    setTargetWinsInput(String(next));
+  }, [initialTargetWins]);
+
+  const handleWinsChange = (value: string) => {
+    if (!/^\d*$/.test(value)) return;
+    setTargetWinsInput(value);
+    if (value === "") return;
+
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) {
+      setTargetWins(clampTargetWins(parsed));
+    }
+  };
+
+  const handleWinsBlur = () => {
+    if (targetWinsInput === "") {
+      setTargetWins(TARGET_WINS);
+      setTargetWinsInput(String(TARGET_WINS));
+      return;
+    }
+
+    const parsed = Number.parseInt(targetWinsInput, 10);
+    if (Number.isFinite(parsed)) {
+      const next = clampTargetWins(parsed);
+      setTargetWins(next);
+      setTargetWinsInput(String(next));
+    }
+  };
 
   return (
     <div className="min-h-dvh bg-slate-950 text-slate-100">
@@ -77,12 +120,31 @@ export default function ModeSelect({
         </div>
 
         <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="text-xs text-slate-400 sm:text-sm">
-            You can swap modes later from the main menu.
-          </div>
+          <div className="text-xs text-slate-400 sm:text-sm">You can swap modes later from the main menu.</div>
+          {showTargetWinsInput && (
+            <div className="flex flex-col gap-1 text-left sm:flex-row sm:items-center sm:gap-3">
+              <label className="text-xs font-medium text-slate-300 sm:text-sm" htmlFor="target-wins-input">
+                Wins to take the match
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="target-wins-input"
+                  type="number"
+                  inputMode="numeric"
+                  min={1}
+                  max={25}
+                  className="w-24 rounded-full border border-slate-700 bg-slate-900/60 px-3 py-1.5 text-center text-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+                  value={targetWinsInput}
+                  onChange={(event) => handleWinsChange(event.target.value)}
+                  onBlur={handleWinsBlur}
+                />
+                <span className="text-xs text-slate-400 sm:text-sm">First to {targetWins} wins.</span>
+              </div>
+            </div>
+          )}
           <button
             type="button"
-            onClick={() => onConfirm(selectedMode)}
+            onClick={() => onConfirm(selectedMode, targetWins)}
             className="inline-flex items-center justify-center rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300"
           >
             {confirmLabel}
@@ -91,4 +153,10 @@ export default function ModeSelect({
       </div>
     </div>
   );
+}
+
+function clampTargetWins(value: number) {
+  if (!Number.isFinite(value)) return TARGET_WINS;
+  const rounded = Math.round(value);
+  return Math.max(1, Math.min(25, rounded));
 }

--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -174,7 +174,7 @@ export function useThreeWheelGame({
 
   const winGoal =
     typeof targetWins === "number" && Number.isFinite(targetWins)
-      ? Math.max(1, Math.min(15, Math.round(targetWins)))
+      ? Math.max(1, Math.min(25, Math.round(targetWins)))
       : TARGET_WINS;
 
   const hostLegacySide: LegacySide = (() => {


### PR DESCRIPTION
## Summary
- allow solo players to set a target wins value during mode selection and persist it into matches
- keep multiplayer payload target wins in sync when launching the game
- align runtime win goal clamping with the new 1-25 range

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2daa2c7148332b6350b6da7051558