### PR TITLE
Fix grimoire state initialization order

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -383,6 +383,8 @@ export default function ThreeWheel_WinsOnly({
     ]
   );
 
+  const [showGrimoire, setShowGrimoire] = useState(false);
+
   useEffect(() => {
     if (!pendingSpell) return;
 
@@ -413,7 +415,6 @@ export default function ThreeWheel_WinsOnly({
 
   const infoPopoverRootRef = useRef<HTMLDivElement | null>(null);
   const [showRef, setShowRef] = useState(false);
-  const [showGrimoire, setShowGrimoire] = useState(false);
 
   const handlePlayerManaToggle = useCallback(() => {
     if (!isGrimoireMode) return;


### PR DESCRIPTION
## Summary
- declare the grimoire visibility state before any effects that reference it so the setter exists when the component renders

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2f7b952f08332a65d6a95d85b80b8