### PR TITLE
Close grimoire when selecting targeted spells

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -280,6 +280,8 @@ export default function ThreeWheel_WinsOnly({
   const [manaPools, setManaPools] = useState<SideState<number>>({ player: 0, enemy: 0 });
   const localMana = manaPools[localLegacySide];
 
+  const [showGrimoire, setShowGrimoire] = useState(false);
+
   const [localSelection, setLocalSelection] = useState<ArchetypeId>(() => DEFAULT_ARCHETYPE);
   const remoteSelection: ArchetypeId = DEFAULT_ARCHETYPE;
   const [localReady, setLocalReady] = useState(() => !isGrimoireMode);
@@ -370,6 +372,11 @@ export default function ThreeWheel_WinsOnly({
 
       if (!didSpend) return;
 
+      const requiresManualTarget = spell.target.type === "card" && spell.target.automatic !== true;
+      if (requiresManualTarget) {
+        setShowGrimoire(false);
+      }
+
       setPendingSpell({ side: localLegacySide, spell });
     },
     [
@@ -378,12 +385,11 @@ export default function ThreeWheel_WinsOnly({
       localMana,
       pendingSpell,
       phase,
+      setShowGrimoire,
       setManaPools,
       setPendingSpell,
     ]
   );
-
-  const [showGrimoire, setShowGrimoire] = useState(false);
 
   useEffect(() => {
     if (!pendingSpell) return;


### PR DESCRIPTION
## Summary
* close the grimoire immediately after activating spells that require a manual card target so the board is visible for targeting
* keep the existing flow for non-targeted spells while ensuring the toggle state lives before spell activation logic

## Testing
* npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2ff3000988332a044cf667af0fc9c