### PR TITLE
Add spell targeting flow with manual card selection

### DIFF
--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -13,6 +13,8 @@ export default memo(function StSCard({
   onDragStart,
   onDragEnd,
   onPointerDown,
+  className,
+  spellTargetable,
 }: {
   card: Card;
   disabled?: boolean;
@@ -23,19 +25,22 @@ export default memo(function StSCard({
   onDragStart?: React.DragEventHandler<HTMLButtonElement>;
   onDragEnd?: React.DragEventHandler<HTMLButtonElement>;
   onPointerDown?: React.PointerEventHandler<HTMLButtonElement>;
+  className?: string;
+  spellTargetable?: boolean;
 }) {
   const dims = size === "lg" ? { w: 120, h: 160 } : size === "md" ? { w: 92, h: 128 } : { w: 72, h: 96 };
   return (
     <button
       onClick={(e) => { e.stopPropagation(); onPick?.(); }}
       disabled={disabled}
-      className={`relative select-none ${disabled ? 'opacity-60' : 'hover:scale-[1.02]'} transition will-change-transform ${selected ? 'ring-2 ring-amber-400' : ''}`}
+      className={`relative select-none ${disabled ? 'opacity-60' : 'hover:scale-[1.02]'} transition will-change-transform ${selected ? 'ring-2 ring-amber-400' : ''} ${className ?? ''}`.trim()}
       style={{ width: dims.w, height: dims.h }}
       aria-label={`Card`}
       draggable={draggable}
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
       onPointerDown={onPointerDown}
+      data-spell-targetable={spellTargetable ? "true" : undefined}
     >
       <div className="absolute inset-0 rounded-xl border bg-gradient-to-br from-slate-600 to-slate-800 border-slate-400"></div>
       <div className="absolute inset-px rounded-[10px] bg-slate-900/85 backdrop-blur-[1px] border border-slate-700/70" />


### PR DESCRIPTION
## Summary
- extend pending spell tracking to store manual card targets and delay resolution until a selection is made
- add spell target selection and cancellation UI while disabling normal card interactions during targeting
- highlight valid targets in WheelPanel and plumb targeting callbacks through hand and wheel components

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d30856129c8332894cdd4cc579a344