### PR TITLE
Fix grimoire manual targeting flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,7 @@ import HUDPanels from "./features/threeWheel/components/HUDPanels";
 import VictoryOverlay from "./features/threeWheel/components/VictoryOverlay";
 import {
   getSpellDefinitions,
+  spellTargetRequiresManualSelection,
   type SpellDefinition,
   type SpellRuntimeState,
   type SpellTargetInstance,
@@ -366,10 +367,9 @@ export default function ThreeWheel_WinsOnly({
       descriptor: PendingSpellDescriptor,
       targetOverride?: SpellTargetInstance | null
     ) => {
-      const manualTargetRequired =
-        (descriptor.spell.target.type === "card" &&
-          descriptor.spell.target.automatic !== true) ||
-        descriptor.spell.target.type === "wheel";
+      const manualTargetRequired = spellTargetRequiresManualSelection(
+        descriptor.spell.target
+      );
 
       const finalTarget =
         targetOverride !== undefined
@@ -378,6 +378,7 @@ export default function ThreeWheel_WinsOnly({
 
       if (manualTargetRequired && !finalTarget) {
         setPendingSpell({ ...descriptor, target: null });
+        setShowGrimoire(false);
         return;
       }
 
@@ -434,9 +435,9 @@ export default function ThreeWheel_WinsOnly({
 
       setPhaseBeforeSpell((current) => current ?? phaseForLogic);
 
-      const requiresManualTarget =
-        (spell.target.type === "card" && spell.target.automatic !== true) ||
-        spell.target.type === "wheel";
+      const requiresManualTarget = spellTargetRequiresManualSelection(
+        spell.target
+      );
       if (requiresManualTarget) {
         setShowGrimoire(false);
       }
@@ -561,9 +562,7 @@ export default function ThreeWheel_WinsOnly({
 
   const awaitingSpellTarget =
     pendingSpell &&
-    ((pendingSpell.spell.target.type === "card" &&
-      pendingSpell.spell.target.automatic !== true) ||
-      pendingSpell.spell.target.type === "wheel") &&
+    spellTargetRequiresManualSelection(pendingSpell.spell.target) &&
     !pendingSpell.target;
 
   useEffect(() => {

--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -3,7 +3,11 @@ import { motion } from "framer-motion";
 import StSCard from "../../../components/StSCard";
 import type { Card, Fighter } from "../../../game/types";
 import type { LegacySide } from "./WheelPanel";
-import type { SpellDefinition, SpellTargetInstance } from "../../../game/spells";
+import {
+  spellTargetRequiresManualSelection,
+  type SpellDefinition,
+  type SpellTargetInstance,
+} from "../../../game/spells";
 
 interface HandDockProps {
   localLegacySide: LegacySide;
@@ -76,7 +80,7 @@ const HandDock: React.FC<HandDockProps> = ({
     isAwaitingSpellTarget &&
     pendingSpell &&
     pendingSpell.spell.target.type === "card" &&
-    pendingSpell.spell.target.automatic !== true;
+    spellTargetRequiresManualSelection(pendingSpell.spell.target);
 
   return (
     <div

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import CanvasWheel, { WheelHandle } from "../../../components/CanvasWheel";
 import StSCard from "../../../components/StSCard";
 import type { Card, Fighter, Phase, Section } from "../../../game/types";
-import type {
-  SpellDefinition,
-  SpellTargetInstance,
-  SpellTargetOwnership,
+import {
+  spellTargetRequiresManualSelection,
+  type SpellDefinition,
+  type SpellTargetInstance,
+  type SpellTargetOwnership,
 } from "../../../game/spells";
 
 export type LegacySide = "player" | "enemy";
@@ -113,20 +114,19 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
   const playerPenalty = reservePenalties.player;
   const enemyPenalty = reservePenalties.enemy;
 
-  const awaitingCardTarget =
+  const awaitingManualTarget =
     isAwaitingSpellTarget &&
     pendingSpell &&
-    pendingSpell.spell.target.type === "card" &&
-    pendingSpell.spell.target.automatic !== true &&
+    spellTargetRequiresManualSelection(pendingSpell.spell.target) &&
     !pendingSpell.target;
+
+  const awaitingCardTarget =
+    awaitingManualTarget && pendingSpell?.spell.target.type === "card";
 
   const awaitingWheelTarget =
-    isAwaitingSpellTarget &&
-    pendingSpell &&
-    pendingSpell.spell.target.type === "wheel" &&
-    !pendingSpell.target;
+    awaitingManualTarget && pendingSpell?.spell.target.type === "wheel";
 
-  const awaitingSpellTarget = awaitingCardTarget || awaitingWheelTarget;
+  const awaitingSpellTarget = awaitingManualTarget;
 
   const pendingOwnership: SpellTargetOwnership | null = awaitingCardTarget
     ? pendingSpell!.spell.target.ownership

--- a/src/game/spells.ts
+++ b/src/game/spells.ts
@@ -15,6 +15,19 @@ export type SpellTargetDefinition =
   | { type: "card"; ownership: SpellTargetOwnership; automatic?: boolean }
   | { type: "wheel"; scope: "current" | "any" };
 
+export const spellTargetRequiresManualSelection = (
+  target: SpellTargetDefinition
+): boolean => {
+  switch (target.type) {
+    case "card":
+      return target.automatic !== true;
+    case "wheel":
+      return true;
+    default:
+      return false;
+  }
+};
+
 export function getSpellDefinitions(ids: SpellId[]): SpellDefinition[] {
   return ids
     .map((id) => getSpellById(id))


### PR DESCRIPTION
## Summary
- add a shared helper to determine when spells require manual target selection
- ensure the grimoire closes and pending spell state is set whenever manual targeting starts
- update wheel and hand UIs to reflect the new targeting helper for cards and wheels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d34247c0f08332b555faf52d612403