### PR TITLE
Fix slot visibility during spell targeting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
+dist-tests/
 .env

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo 'No tests'"
+    "test": "tsc --project tsconfig.tests.json && node dist-tests/tests/slotVisibility.test.js"
   },
   "dependencies": {
     "ably": "^2.12.0",

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -8,8 +8,11 @@ import {
   type SpellTargetInstance,
   type SpellTargetOwnership,
 } from "../../../game/spells";
-
-export type LegacySide = "player" | "enemy";
+import {
+  isChooseLikePhase,
+  shouldShowSlotCard,
+  type LegacySide,
+} from "../utils/slotVisibility";
 
 type SideState<T> = Record<LegacySide, T>;
 
@@ -140,13 +143,6 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
   const isLeftSelected = !!leftSlot.card && selectedCardId === leftSlot.card.id;
   const isRightSelected = !!rightSlot.card && selectedCardId === rightSlot.card.id;
 
-  const isPhaseChooseLike = phase === "choose" || phase === "spellTargeting";
-
-  const shouldShowLeftCard =
-    !!leftSlot.card && (leftSlot.side === localLegacySide || !isPhaseChooseLike);
-  const shouldShowRightCard =
-    !!rightSlot.card && (rightSlot.side === localLegacySide || !isPhaseChooseLike);
-
   const leftSlotOwnership: SpellTargetOwnership | null = pendingSpell
     ? leftSlot.side === pendingSpell.side
       ? "ally"
@@ -167,6 +163,23 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
     awaitingCardTarget &&
     !!rightSlot.card &&
     (pendingOwnership === "any" || pendingOwnership === rightSlotOwnership);
+
+  const isPhaseChooseLike = isChooseLikePhase(phase);
+
+  const shouldShowLeftCard = shouldShowSlotCard({
+    hasCard: !!leftSlot.card,
+    slotSide: leftSlot.side,
+    localLegacySide,
+    isPhaseChooseLike,
+    slotTargetable: leftSlotTargetable,
+  });
+  const shouldShowRightCard = shouldShowSlotCard({
+    hasCard: !!rightSlot.card,
+    slotSide: rightSlot.side,
+    localLegacySide,
+    isPhaseChooseLike,
+    slotTargetable: rightSlotTargetable,
+  });
 
   const wheelScope = pendingSpell?.spell.target.type === "wheel" ? pendingSpell.spell.target.scope : null;
   const wheelTargetable =

--- a/src/features/threeWheel/utils/slotVisibility.ts
+++ b/src/features/threeWheel/utils/slotVisibility.ts
@@ -1,0 +1,25 @@
+export type LegacySide = "player" | "enemy";
+
+interface ShouldShowSlotCardArgs {
+  hasCard: boolean;
+  slotSide: LegacySide;
+  localLegacySide: LegacySide;
+  isPhaseChooseLike: boolean;
+  slotTargetable: boolean;
+}
+
+export const shouldShowSlotCard = ({
+  hasCard,
+  slotSide,
+  localLegacySide,
+  isPhaseChooseLike,
+  slotTargetable,
+}: ShouldShowSlotCardArgs): boolean => {
+  if (!hasCard) return false;
+  if (slotSide === localLegacySide) return true;
+  if (!isPhaseChooseLike) return true;
+  return slotTargetable;
+};
+
+export const isChooseLikePhase = (phase: string) =>
+  phase === "choose" || phase === "spellTargeting";

--- a/tests/slotVisibility.test.ts
+++ b/tests/slotVisibility.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+
+import {
+  isChooseLikePhase,
+  shouldShowSlotCard,
+  type LegacySide,
+} from "../src/features/threeWheel/utils/slotVisibility.js";
+
+const player: LegacySide = "player";
+const enemy: LegacySide = "enemy";
+
+// Enemy card hidden during choose phase when it isn't targetable.
+assert.equal(
+  shouldShowSlotCard({
+    hasCard: true,
+    slotSide: enemy,
+    localLegacySide: player,
+    isPhaseChooseLike: isChooseLikePhase("choose"),
+    slotTargetable: false,
+  }),
+  false,
+  "Enemy slots should remain hidden during a normal choose phase",
+);
+
+// Enemy card remains visible when it is a valid target during spell targeting.
+assert.equal(
+  shouldShowSlotCard({
+    hasCard: true,
+    slotSide: enemy,
+    localLegacySide: player,
+    isPhaseChooseLike: isChooseLikePhase("spellTargeting"),
+    slotTargetable: true,
+  }),
+  true,
+  "Targetable enemy slots should stay visible while selecting spell targets",
+);
+
+// Friendly cards are always visible to the local player when present.
+assert.equal(
+  shouldShowSlotCard({
+    hasCard: true,
+    slotSide: player,
+    localLegacySide: player,
+    isPhaseChooseLike: isChooseLikePhase("spellTargeting"),
+    slotTargetable: false,
+  }),
+  true,
+  "Friendly slots should remain visible whenever a card is present",
+);
+
+console.log("slotVisibility tests passed");

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist-tests",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2020",
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "tests/**/*.ts",
+    "src/features/threeWheel/utils/slotVisibility.ts"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary
- ensure WheelPanel shows opponent cards that are valid spell targets during spell targeting
- share card-visibility helpers for slot logic and reuse them in WheelPanel
- add a lightweight regression test covering choose and spell-targeting visibility rules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3c97f4e748332bfe7feb404939ca5