### PR TITLE
Ensure grimoire closes after casting spells

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -547,9 +547,12 @@ export default function ThreeWheel_WinsOnly({
       const requiresManualTarget = spellTargetRequiresManualSelection(
         spell.target
       );
-      if (requiresManualTarget) {
-        setShowGrimoire(false);
-      }
+
+      // Always close the grimoire once we've successfully started a spell cast so
+      // the targeting overlay can take focus. Previously we only hid it for
+      // manual-target spells, which meant the popover stayed open if manual
+      // detection ever failed and the player never saw the targeting state.
+      setShowGrimoire(false);
 
       const initialTarget: SpellTargetInstance | null = (() => {
         switch (spell.target.type) {


### PR DESCRIPTION
## Summary
- always hide the grimoire once a spell successfully starts so the targeting overlay can take over
- add explanatory comment around the new behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3cd513c808332ae52d10ee7cf5751