### PR TITLE
Support manual spell targeting interactions in wheel and hand UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1111,6 +1111,7 @@ const renderWheelPanel = (i: number) => {
         onMeasure={setHandClearance}
         pendingSpell={pendingSpell}
         isAwaitingSpellTarget={isAwaitingSpellTarget}
+        onSpellTargetSelect={handleSpellTargetSelect}
       />
 
       {/* Ended overlay (banner + modal) */}


### PR DESCRIPTION
## Summary
- allow wheel clicks to report spell targeting when a wheel spell is awaiting selection
- route slot clicks through spell targeting logic with ownership checks before normal assignment
- enable hand cards to submit card target selections and wire the new selection payload through spell casting

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d418532b48833286f1bfc2078e344d