### PR TITLE
Support manual spell targeting interactions in wheel and hand UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -342,8 +342,18 @@ export default function ThreeWheel_WinsOnly({
     isWheelActive,
   });
 
+  const [spellTargetingSide, setSpellTargetingSide] = useState<LegacySide | null>(null);
+
+  useEffect(() => {
+    if (awaitingSpellTarget && pendingSpell) {
+      setSpellTargetingSide(pendingSpell.side);
+    } else if (!awaitingSpellTarget) {
+      setSpellTargetingSide(null);
+    }
+  }, [awaitingSpellTarget, pendingSpell]);
+
   const phaseForLogic: CorePhase = phaseBeforeSpell ?? basePhase;
-  const phase: Phase = phaseBeforeSpell ? "spellTargeting" : basePhase;
+  const phase: Phase = spellTargetingSide ? "spellTargeting" : basePhase;
 
   const handleLocalArchetypeSelect = useCallback((id: ArchetypeId) => {
     setLocalSelection(id);
@@ -1111,6 +1121,7 @@ const renderWheelPanel = (i: number) => {
         onMeasure={setHandClearance}
         pendingSpell={pendingSpell}
         isAwaitingSpellTarget={isAwaitingSpellTarget}
+        onSpellTargetSelect={handleSpellTargetSelect}
       />
 
       {/* Ended overlay (banner + modal) */}


### PR DESCRIPTION
## Summary
- allow wheel clicks to report spell targeting when a wheel spell is awaiting selection
- route slot clicks through spell targeting logic with ownership checks before normal assignment
- enable hand cards to submit card target selections and wire the new selection payload through spell casting
- track the active spell-targeting side so the overall phase moves into spell targeting and returns to the prior phase once targeting completes

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d418532b48833286f1bfc2078e344d