### PR TITLE
Fix spell activation mana spend check

### DIFF
--- a/src/game/hooks/useSpellCasting.ts
+++ b/src/game/hooks/useSpellCasting.ts
@@ -194,18 +194,14 @@ export function useSpellCasting(options: UseSpellCastingOptions): UseSpellCastin
         handlePendingSpellCancel(true);
       }
 
-      let didSpend = false;
       setManaPools((current) => {
         const currentMana = current[localSide];
         if (currentMana < effectiveCost) return current;
 
-        didSpend = true;
         const next: SideState<number> = { ...current };
         next[localSide] = currentMana - effectiveCost;
         return next;
       });
-
-      if (!didSpend) return;
 
       setPhaseBeforeSpell((current) => current ?? phaseForLogic);
 


### PR DESCRIPTION
## Summary
- stop relying on a synchronous state updater side effect to detect mana spending
- always proceed with pending spell setup once affordability is confirmed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d43c62c98c8332820f67ff2ff4d58f