### PR TITLE
Fix Mirror Image preserving player view

### DIFF
--- a/src/game/spellEngine.ts
+++ b/src/game/spellEngine.ts
@@ -321,10 +321,16 @@ export function applySpellEffects<CardT extends { id: string }>(
         const sourceCard = sourceLane[laneIndex];
         if (!sourceCard) return;
 
+        const { id: _sourceId, ...sourceCardRest } = sourceCard as CardT & {
+          id: string;
+          [key: string]: unknown;
+        };
+
         const copied: CardT = {
           ...(targetCard as CardT),
-          ...(sourceCard as Partial<CardT>),
+          ...(sourceCardRest as Partial<CardT>),
         };
+        copied.id = (targetCard as CardT).id;
         if (Array.isArray((sourceCard as Record<string, unknown>).tags)) {
           (copied as Record<string, unknown>).tags = [
             ...((sourceCard as Record<string, unknown>).tags as unknown[]),


### PR DESCRIPTION
## Summary
- prevent Mirror Image from overwriting the copying card's id
- ensure copied cards keep their original identity so the opponent's card stays visible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4429ab6e483328c9ccedfeec93da8