### PR TITLE
Keep opponent card visible during Mirror Image targeting

### DIFF
--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -166,20 +166,27 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
 
   const isPhaseChooseLike = isChooseLikePhase(phase);
 
-  const shouldShowLeftCard = shouldShowSlotCard({
-    hasCard: !!leftSlot.card,
-    slotSide: leftSlot.side,
-    localLegacySide,
-    isPhaseChooseLike,
-    slotTargetable: leftSlotTargetable,
-  });
-  const shouldShowRightCard = shouldShowSlotCard({
-    hasCard: !!rightSlot.card,
-    slotSide: rightSlot.side,
-    localLegacySide,
-    isPhaseChooseLike,
-    slotTargetable: rightSlotTargetable,
-  });
+  const revealOpposingCardDuringMirror =
+    awaitingCardTarget &&
+    pendingSpell?.spell.id === "mirrorImage" &&
+    pendingSpell.side === localLegacySide;
+
+  const shouldShowLeftCard =
+    shouldShowSlotCard({
+      hasCard: !!leftSlot.card,
+      slotSide: leftSlot.side,
+      localLegacySide,
+      isPhaseChooseLike,
+      slotTargetable: leftSlotTargetable,
+    }) || (revealOpposingCardDuringMirror && leftSlot.side !== localLegacySide);
+  const shouldShowRightCard =
+    shouldShowSlotCard({
+      hasCard: !!rightSlot.card,
+      slotSide: rightSlot.side,
+      localLegacySide,
+      isPhaseChooseLike,
+      slotTargetable: rightSlotTargetable,
+    }) || (revealOpposingCardDuringMirror && rightSlot.side !== localLegacySide);
 
   const wheelScope = pendingSpell?.spell.target.type === "wheel" ? pendingSpell.spell.target.scope : null;
   const wheelTargetable =


### PR DESCRIPTION
## Summary
- ensure the opposing slot stays visible while selecting a Mirror Image target so casters can see what they will copy

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d446b3f8a08332a2f36497b48d0823