### PR TITLE
Align reference button with resolve controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -764,7 +764,7 @@ const renderWheelPanel = (i: number) => {
           </div>
         </div>
 
-        <div ref={infoPopoverRootRef} className="flex items-center gap-2 relative">
+        <div ref={infoPopoverRootRef} className="flex items-center gap-2">
           {/* Reference button + popover */}
           <div className="relative">
             <button
@@ -818,6 +818,39 @@ const renderWheelPanel = (i: number) => {
               </div>
             )}
           </div>
+
+          {phase === "choose" && (
+            <div className="flex flex-col items-end gap-1">
+              <button
+                disabled={resolveButtonDisabled}
+                onClick={handleRevealClick}
+                className="px-2.5 py-0.5 rounded bg-amber-400 text-slate-900 font-semibold disabled:opacity-50"
+              >
+                {resolveButtonLabel}
+              </button>
+              {isMultiplayer && resolveStatusText && (
+                <span className="text-[11px] italic text-amber-200 text-right leading-tight">
+                  {resolveStatusText}
+                </span>
+              )}
+            </div>
+          )}
+          {phase === "roundEnd" && (
+            <div className="flex flex-col items-end gap-1">
+              <button
+                disabled={advanceButtonDisabled}
+                onClick={handleNextClick}
+                className="px-2.5 py-0.5 rounded bg-emerald-500 text-slate-900 font-semibold disabled:opacity-50"
+              >
+                {advanceButtonLabel}
+              </button>
+              {isMultiplayer && advanceStatusText && (
+                <span className="text-[11px] italic text-emerald-200 text-right leading-tight">
+                  {advanceStatusText}
+                </span>
+              )}
+            </div>
+          )}
 
           {/* Grimoire button + popover/modal */}
           {gameMode === "grimoire" && (
@@ -1010,39 +1043,6 @@ const renderWheelPanel = (i: number) => {
           )}
         </div>
 
-        {/* Resolve/Next controls (right side) */}
-        {phase === "choose" && (
-          <div className="flex flex-col items-end gap-1">
-            <button
-              disabled={resolveButtonDisabled}
-              onClick={handleRevealClick}
-              className="px-2.5 py-0.5 rounded bg-amber-400 text-slate-900 font-semibold disabled:opacity-50"
-            >
-              {resolveButtonLabel}
-            </button>
-            {isMultiplayer && resolveStatusText && (
-              <span className="text-[11px] italic text-amber-200 text-right leading-tight">
-                {resolveStatusText}
-              </span>
-            )}
-          </div>
-        )}
-        {phase === "roundEnd" && (
-          <div className="flex flex-col items-end gap-1">
-            <button
-              disabled={advanceButtonDisabled}
-              onClick={handleNextClick}
-              className="px-2.5 py-0.5 rounded bg-emerald-500 text-slate-900 font-semibold disabled:opacity-50"
-            >
-              {advanceButtonLabel}
-            </button>
-            {isMultiplayer && advanceStatusText && (
-              <span className="text-[11px] italic text-emerald-200 text-right leading-tight">
-                {advanceStatusText}
-              </span>
-            )}
-          </div>
-        )}
       </div>
 
       {/* HUD */}


### PR DESCRIPTION
## Summary
- place the reference popover button inside the resolve/next controls container so it renders beside the actionable buttons
- remove the now obsolete resolve-controls placeholder comment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4479a8c708332905425b52c1cfde5