### PR TITLE
Add lobby mode selector and editable profile name

### DIFF
--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -44,6 +44,7 @@ export default function AppShell() {
       <MultiplayerRoute
         onBack={() => setView({ key: "hub" })}
         onStart={(payload) => {
+          setGameMode(payload.gameMode);
           setMpPayload(payload);
           setView({
             key: "modeSelect",
@@ -96,7 +97,7 @@ export default function AppShell() {
               setView({ key: "mp" });
               return;
             }
-            const nextPayload = { ...payload, targetWins: winsGoal };
+            const nextPayload = { ...payload, targetWins: winsGoal, gameMode: mode };
             setMpPayload(nextPayload);
             setView({ key: "game", mode: "mp", mpPayload: nextPayload });
             return;


### PR DESCRIPTION
## Summary
- add a classic/grimoire selector to the multiplayer lobby and sync it through presence and start payloads
- carry the lobby's chosen mode into the mode select flow before launching a match
- allow editing the local profile display name with validation and storage updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d458c6a4e083328253d4a95ac2601a