### PR TITLE
Add accessible wheel visuals with palette toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,15 @@ import {
   LEGACY_FROM_SIDE,
 } from "./game/types";
 import { easeInOutCubic, inSection, createSeededRng } from "./game/math";
-import { VC_META, genWheelSections } from "./game/wheel";
+import {
+  VC_META,
+  VC_ORDER,
+  WHEEL_PALETTES,
+  WHEEL_SHAPE_PATHS,
+  type WheelPaletteMode,
+  type WheelShape,
+  genWheelSections,
+} from "./game/wheel";
 import {
   ARCHETYPE_DEFINITIONS,
   ARCHETYPE_IDS,
@@ -123,6 +131,30 @@ const laneSpellStatesEqual = (a: LaneSpellState, b: LaneSpellState) =>
   a.damageModifier === b.damageModifier &&
   a.mirrorTargetCardId === b.mirrorTargetCardId &&
   a.occupantCardId === b.occupantCardId;
+
+const WheelLegendIcon = ({
+  shape,
+  color,
+}: {
+  shape: WheelShape;
+  color: string;
+}) => {
+  const path = WHEEL_SHAPE_PATHS[shape];
+  if (!path) return null;
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 100 100"
+      className="h-6 w-6 shrink-0"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <circle cx={50} cy={50} r={46} fill={color} stroke="#0f172a" strokeWidth={6} />
+      <path d={path} fill="#0f172a" stroke="#f8fafc" strokeWidth={8} strokeLinejoin="round" />
+    </svg>
+  );
+};
 
 // Multiplayer intents
 type SpellTargetIntentPayload = {
@@ -388,6 +420,12 @@ export default function ThreeWheel_WinsOnly({
   const infoPopoverRootRef = useRef<HTMLDivElement | null>(null);
   const [showRef, setShowRef] = useState(false);
 
+  const [wheelPaletteMode, setWheelPaletteMode] = useState<WheelPaletteMode>("default");
+  const toggleWheelPalette = useCallback(() => {
+    setWheelPaletteMode((prev) => (prev === "default" ? "colorblind" : "default"));
+  }, []);
+  const activeWheelPalette = WHEEL_PALETTES[wheelPaletteMode];
+
   const handlePlayerManaToggle = useCallback(() => {
     if (!isGrimoireMode) return;
     setShowGrimoire((prev) => {
@@ -566,7 +604,12 @@ const renderWheelPanel = (i: number) => {
           }}
           aria-label={`Wheel ${i + 1}`}
         >
-          <CanvasWheel ref={wheelRefs[i]} sections={wheelSections[i]} size={ws} />
+          <CanvasWheel
+            ref={wheelRefs[i]}
+            sections={wheelSections[i]}
+            size={ws}
+            paletteMode={wheelPaletteMode}
+          />
           <div
             aria-hidden
             className="pointer-events-none absolute inset-0 rounded-full"
@@ -837,6 +880,23 @@ const renderWheelPanel = (i: number) => {
         </div>
 
         <div ref={infoPopoverRootRef} className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={toggleWheelPalette}
+            aria-pressed={wheelPaletteMode === "colorblind"}
+            className={`px-2.5 py-0.5 rounded border transition focus:outline-none focus:ring-2 focus:ring-amber-300 focus:ring-offset-1 focus:ring-offset-slate-900 ${
+              wheelPaletteMode === "colorblind"
+                ? "border-sky-300 bg-sky-500 text-slate-900 hover:bg-sky-400"
+                : "border-slate-600 bg-slate-700 text-white hover:bg-slate-600"
+            }`}
+            title={
+              wheelPaletteMode === "colorblind"
+                ? "Color-blind safe palette enabled"
+                : "Switch to color-blind safe palette"
+            }
+          >
+            {wheelPaletteMode === "colorblind" ? "Color-blind palette" : "Standard palette"}
+          </button>
           {/* Reference button + popover */}
           <div className="relative">
             <button
@@ -871,13 +931,36 @@ const renderWheelPanel = (i: number) => {
                     the player who matches it gets <span className="font-semibold">1 win</span>.
                     First to <span className="font-semibold">{winGoal}</span> wins takes the match.
                   </div>
-                  <ul className="list-disc pl-5 space-y-1">
-                    <li>💥 Strongest — higher value wins</li>
-                    <li>🦊 Weakest — lower value wins</li>
-                    <li>🗃️ Reserve — compare the two cards left in hand</li>
-                    <li>🎯 Closest — value closest to target wins</li>
-                    <li>⚑ Initiative — initiative holder wins</li>
-                    <li><span className="font-semibold">0 Start</span> — no one wins</li>
+                  <p className="text-[11px] text-slate-300">
+                    Colors and bold shapes on the wheel match each rule, and you can
+                    switch to a color-blind safe palette at any time.
+                  </p>
+                  <ul className="space-y-1">
+                    {VC_ORDER.map((id) => {
+                      const meta = VC_META[id];
+                      const color = activeWheelPalette[id];
+                      return (
+                        <li key={id} className="flex items-center gap-2">
+                          <WheelLegendIcon shape={meta.shape} color={color} />
+                          <div>
+                            <span className="font-semibold">{meta.label}</span>
+                            <span className="opacity-80"> — {meta.explain}</span>
+                          </div>
+                        </li>
+                      );
+                    })}
+                    <li className="flex items-center gap-2">
+                      <span
+                        className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-500 bg-slate-600 text-[11px] font-semibold text-white"
+                        aria-hidden
+                      >
+                        0
+                      </span>
+                      <div>
+                        <span className="font-semibold">Start</span>
+                        <span className="opacity-80"> — no one wins this slice</span>
+                      </div>
+                    </li>
                   </ul>
                   <div><span className="font-semibold">Grimoire - Casting Spells</span></div>
                     <div> Spells cost <span className="font-semibold">Mana</span> to cast. 
@@ -1039,6 +1122,7 @@ const renderWheelPanel = (i: number) => {
                 onSpellTargetSelect={handleSpellTargetSelect}
                 onWheelTargetSelect={handleWheelTargetSelect}
                 isAwaitingSpellTarget={isAwaitingSpellTarget}
+                wheelPaletteMode={wheelPaletteMode}
               />
             </div>
           ))}

--- a/src/components/CanvasWheel.tsx
+++ b/src/components/CanvasWheel.tsx
@@ -2,13 +2,106 @@
 import React, { forwardRef, memo, useEffect, useImperativeHandle, useRef } from "react";
 import { SLICES, Section } from "../game/types";
 import { inSection, polar } from "../game/math";
-import { VC_META } from "../game/wheel";
+import {
+  VC_META,
+  WHEEL_PALETTES,
+  WHEEL_SHAPE_POINTS,
+  type WheelPaletteMode,
+  type WheelShape,
+} from "../game/wheel";
 
 export type WheelHandle = { setVisualToken: (slice: number) => void };
-type CanvasWheelProps = { sections: Section[]; size: number; onTapAssign?: () => void; };
+type CanvasWheelProps = {
+  sections: Section[];
+  size: number;
+  onTapAssign?: () => void;
+  paletteMode?: WheelPaletteMode;
+};
+
+const START_SLICE_COLOR = "#6b7280";
+const DEFAULT_SLICE_FALLBACK = "#334155";
+const TEXT_LIGHT = "#f8fafc";
+const TEXT_DARK = "#020617";
+
+const parseHexColor = (hex: string): [number, number, number] | null => {
+  const normalized = hex.trim().replace("#", "");
+  if (normalized.length === 3) {
+    const r = parseInt(normalized[0] + normalized[0], 16);
+    const g = parseInt(normalized[1] + normalized[1], 16);
+    const b = parseInt(normalized[2] + normalized[2], 16);
+    if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+    return [r, g, b];
+  }
+  if (normalized.length === 6) {
+    const r = parseInt(normalized.slice(0, 2), 16);
+    const g = parseInt(normalized.slice(2, 4), 16);
+    const b = parseInt(normalized.slice(4, 6), 16);
+    if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+    return [r, g, b];
+  }
+  return null;
+};
+
+const srgbToLinear = (value: number): number => {
+  const c = value / 255;
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+};
+
+const getLuminance = ([r, g, b]: [number, number, number]): number =>
+  0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b);
+
+const getContrastRatio = (lumA: number, lumB: number): number =>
+  (Math.max(lumA, lumB) + 0.05) / (Math.min(lumA, lumB) + 0.05);
+
+const WHITE_LUMINANCE = 1; // luminance of pure white
+const DARK_RGB = parseHexColor(TEXT_DARK);
+const DARK_LUMINANCE = DARK_RGB ? getLuminance(DARK_RGB) : 0;
+
+const chooseTextColor = (hexColor: string): string => {
+  const rgb = parseHexColor(hexColor);
+  if (!rgb) return TEXT_DARK;
+  const luminance = getLuminance(rgb);
+  const contrastLight = getContrastRatio(luminance, WHITE_LUMINANCE);
+  const contrastDark = getContrastRatio(luminance, DARK_LUMINANCE);
+  if (contrastLight >= contrastDark) return TEXT_LIGHT;
+  return TEXT_DARK;
+};
+
+const drawShape = (
+  ctx: CanvasRenderingContext2D,
+  shape: WheelShape,
+  x: number,
+  y: number,
+  size: number
+) => {
+  const pts = WHEEL_SHAPE_POINTS[shape];
+  if (!pts) return;
+  ctx.save();
+  ctx.translate(x, y);
+  const scale = size / 100;
+  ctx.scale(scale, scale);
+  const strokePx = Math.max(2.2, size * 0.18);
+  ctx.lineWidth = strokePx / scale;
+  ctx.lineJoin = "round";
+  ctx.fillStyle = "rgba(15,23,42,0.88)";
+  ctx.strokeStyle = "rgba(248,250,252,0.94)";
+  ctx.shadowColor = "rgba(15,23,42,0.35)";
+  ctx.shadowBlur = size * 0.08;
+  ctx.beginPath();
+  pts.forEach(([px, py], idx) => {
+    const nx = px - 50;
+    const ny = py - 50;
+    if (idx === 0) ctx.moveTo(nx, ny);
+    else ctx.lineTo(nx, ny);
+  });
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+  ctx.restore();
+};
 
 const CanvasWheel = memo(forwardRef<WheelHandle, CanvasWheelProps>(
-  ({ sections, size, onTapAssign }, ref) => {
+  ({ sections, size, onTapAssign, paletteMode = "default" }, ref) => {
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
     const tokenElRef = useRef<HTMLDivElement | null>(null);
     const tokenSliceRef = useRef<number>(0);
@@ -40,8 +133,12 @@ const CanvasWheel = memo(forwardRef<WheelHandle, CanvasWheelProps>(
       const wheelR = cssW / 2 - (16 + CLIP_PAD);
 
       const angPer = 360 / SLICES;
-      const sliceFill = (i: number) =>
-        sections.find((s) => inSection(i, s))?.color ?? "#334155";
+      const palette = WHEEL_PALETTES[paletteMode] ?? WHEEL_PALETTES.default;
+      const sliceFill = (i: number) => {
+        const sec = sections.find((s) => inSection(i, s));
+        if (!sec) return DEFAULT_SLICE_FALLBACK;
+        return palette[sec.id] ?? sec.color ?? DEFAULT_SLICE_FALLBACK;
+      };
 
       ctx.clearRect(0, 0, cssW, cssH);
 
@@ -54,16 +151,26 @@ const CanvasWheel = memo(forwardRef<WheelHandle, CanvasWheelProps>(
         ctx.moveTo(centerX, centerY);
         ctx.arc(centerX, centerY, wheelR, startAng, endAng, false);
         ctx.closePath();
-        ctx.fillStyle = i === 0 ? "#6b7280" : sliceFill(i);
+        const fillColor = i === 0 ? START_SLICE_COLOR : sliceFill(i);
+        ctx.fillStyle = fillColor;
         (ctx as any).globalAlpha = 0.9; ctx.fill(); (ctx as any).globalAlpha = 1;
         ctx.strokeStyle = "#0f172a"; ctx.lineWidth = 1; ctx.stroke();
 
         // numbers
         const midAng = (i + 0.5) * angPer;
         const numPos = polar(centerX, centerY, wheelR * 0.6, midAng);
-        ctx.fillStyle = i === 0 ? "#ffffff" : "#0f172a";
-        ctx.font = "700 11px system-ui, -apple-system, Segoe UI, Roboto";
+        const textColor = chooseTextColor(fillColor);
+        const fontPx = Math.max(12, Math.round(size * 0.09));
+        const font = `600 ${fontPx}px "Roboto Flex", "Inter var", "Inter", "system-ui", -apple-system`;
+        ctx.font = font;
         ctx.textAlign = "center"; ctx.textBaseline = "middle";
+        const outlineColor = textColor === TEXT_LIGHT ? "rgba(15,23,42,0.7)" : "rgba(248,250,252,0.85)";
+        const outlineWidth = Math.max(0.75, fontPx * 0.1);
+        ctx.lineJoin = "round";
+        ctx.strokeStyle = outlineColor;
+        ctx.lineWidth = outlineWidth;
+        ctx.strokeText(String(i), numPos.x, numPos.y);
+        ctx.fillStyle = textColor;
         ctx.fillText(String(i), numPos.x, numPos.y);
 
         // icons
@@ -71,9 +178,11 @@ const CanvasWheel = memo(forwardRef<WheelHandle, CanvasWheelProps>(
           const sec = sections.find((s) => inSection(i, s));
           if (sec) {
             const iconPos = polar(centerX, centerY, wheelR * 0.86, midAng);
-            ctx.font = "12px system-ui, Apple Color Emoji, Segoe UI Emoji";
-            ctx.fillStyle = "#ffffff";
-            ctx.fillText(VC_META[sec.id].icon, iconPos.x, iconPos.y);
+            const shape = VC_META[sec.id]?.shape;
+            if (shape) {
+              const iconSize = Math.min(32, Math.max(18, wheelR * 0.32));
+              drawShape(ctx, shape, iconPos.x, iconPos.y, iconSize);
+            }
           }
         }
       }
@@ -99,7 +208,23 @@ const CanvasWheel = memo(forwardRef<WheelHandle, CanvasWheelProps>(
     };
 
     // redraw base when size/sections change
-    useEffect(() => { drawBase(); /* eslint-disable-line react-hooks/exhaustive-deps */ }, [size, sections]);
+    useEffect(() => {
+      drawBase();
+      if (typeof document !== "undefined" && "fonts" in document) {
+        let cancelled = false;
+        void (document.fonts as FontFaceSet)
+          .load('600 16px "Roboto Flex"')
+          .then(() => {
+            if (!cancelled) drawBase();
+          })
+          .catch(() => {});
+        return () => {
+          cancelled = true;
+        };
+      }
+      return undefined;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [size, sections, paletteMode]);
 
     // expose imperative API
     useImperativeHandle(ref, () => ({

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import CanvasWheel, { WheelHandle } from "../../../components/CanvasWheel";
 import StSCard from "../../../components/StSCard";
 import type { Card, Fighter, Phase, Section } from "../../../game/types";
+import type { WheelPaletteMode } from "../../../game/wheel";
 import {
   spellTargetRequiresManualSelection,
   type SpellDefinition,
@@ -64,6 +65,7 @@ export interface WheelPanelProps {
   onSpellTargetSelect?: (selection: { side: LegacySide; lane: number | null; cardId: string }) => void;
   onWheelTargetSelect?: (wheelIndex: number) => void;
   isAwaitingSpellTarget: boolean;
+  wheelPaletteMode: WheelPaletteMode;
 }
 
 const slotWidthPx = 80;
@@ -107,6 +109,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
   onSpellTargetSelect,
   onWheelTargetSelect,
   isAwaitingSpellTarget,
+  wheelPaletteMode,
 }) => {
   const playerCard = assign.player[index];
   const enemyCard = assign.enemy[index];
@@ -451,7 +454,12 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
           }}
           aria-label={`Wheel ${index + 1}`}
         >
-          <CanvasWheel ref={wheelRef as React.RefObject<WheelHandle>} sections={wheelSection} size={ws} />
+          <CanvasWheel
+            ref={wheelRef as React.RefObject<WheelHandle>}
+            sections={wheelSection}
+            size={ws}
+            paletteMode={wheelPaletteMode}
+          />
           <div
             aria-hidden
             className="pointer-events-none absolute inset-0 rounded-full"

--- a/src/game/wheel.ts
+++ b/src/game/wheel.ts
@@ -1,15 +1,129 @@
 // src/game/wheel.ts
 import { SLICES, VC, Section } from "./types";
 
+export type WheelShape = "burst" | "triangle" | "square" | "diamond" | "hex";
+
+export type WheelPaletteMode = "default" | "colorblind";
+
+export const VC_ORDER: readonly VC[] = [
+  "Strongest",
+  "Weakest",
+  "ReserveSum",
+  "ClosestToTarget",
+  "Initiative",
+] as const;
+
+const createRegularPolygonPoints = (
+  sides: number,
+  radius: number,
+  rotationDeg: number
+): readonly [number, number][] => {
+  const rotation = (rotationDeg * Math.PI) / 180;
+  const center = 50;
+  const pts: [number, number][] = [];
+  for (let i = 0; i < sides; i++) {
+    const angle = rotation + (i * 2 * Math.PI) / sides;
+    const x = center + Math.cos(angle) * radius;
+    const y = center + Math.sin(angle) * radius;
+    pts.push([parseFloat(x.toFixed(3)), parseFloat(y.toFixed(3))]);
+  }
+  return pts;
+};
+
+const createStarPoints = (
+  points: number,
+  outerRadius: number,
+  innerRadius: number,
+  rotationDeg: number
+): readonly [number, number][] => {
+  const rotation = (rotationDeg * Math.PI) / 180;
+  const center = 50;
+  const pts: [number, number][] = [];
+  for (let i = 0; i < points * 2; i++) {
+    const isOuter = i % 2 === 0;
+    const radius = isOuter ? outerRadius : innerRadius;
+    const angle = rotation + (i * Math.PI) / points;
+    const x = center + Math.cos(angle) * radius;
+    const y = center + Math.sin(angle) * radius;
+    pts.push([parseFloat(x.toFixed(3)), parseFloat(y.toFixed(3))]);
+  }
+  return pts;
+};
+
+const pointsToPath = (pts: readonly [number, number][]): string =>
+  pts.reduce((acc, [x, y], idx) => `${acc}${idx === 0 ? "M" : "L"}${x} ${y} `, "").trimEnd() + " Z";
+
+export const WHEEL_SHAPE_POINTS: Record<WheelShape, readonly [number, number][]> = {
+  burst: createStarPoints(5, 44, 20, -90),
+  triangle: createRegularPolygonPoints(3, 42, -90),
+  square: [
+    [18, 18],
+    [82, 18],
+    [82, 82],
+    [18, 82],
+  ],
+  diamond: createRegularPolygonPoints(4, 44, -45),
+  hex: createRegularPolygonPoints(6, 40, -90),
+};
+
+export const WHEEL_SHAPE_PATHS: Record<WheelShape, string> = Object.fromEntries(
+  (Object.entries(WHEEL_SHAPE_POINTS) as [WheelShape, readonly [number, number][]][]).map(([shape, pts]) => [
+    shape,
+    pointsToPath(pts),
+  ])
+) as Record<WheelShape, string>;
+
+export const WHEEL_PALETTES: Record<WheelPaletteMode, Record<VC, string>> = {
+  default: {
+    Strongest: "#c2410c",
+    Weakest: "#0f766e",
+    ReserveSum: "#1d4ed8",
+    ClosestToTarget: "#9333ea",
+    Initiative: "#b91c1c",
+  },
+  colorblind: {
+    Strongest: "#d55e00",
+    Weakest: "#0072b2",
+    ReserveSum: "#009e73",
+    ClosestToTarget: "#e69f00",
+    Initiative: "#cc79a7",
+  },
+};
+
 export const VC_META: Record<
   VC,
-  { icon: string; color: string; short: string; explain: string }
+  { short: string; explain: string; shape: WheelShape; label: string }
 > = {
-  Strongest: { icon: "💥", color: "#f43f5e", short: "STR", explain: "Higher value wins." },
-  Weakest: { icon: "🦊", color: "#10b981", short: "WEAK", explain: "Lower value wins." },
-  ReserveSum: { icon: "🗃️", color: "#0ea5e9", short: "RES", explain: "Compare sums of the two cards left in hand." },
-  ClosestToTarget: { icon: "🎯", color: "#f59e0b", short: "CL", explain: "Value closest to target wins." },
-  Initiative: { icon: "⚑", color: "#a78bfa", short: "INIT", explain: "Initiative holder wins." },
+  Strongest: {
+    short: "STR",
+    explain: "Higher value wins.",
+    shape: "burst",
+    label: "Strongest",
+  },
+  Weakest: {
+    short: "WEAK",
+    explain: "Lower value wins.",
+    shape: "triangle",
+    label: "Weakest",
+  },
+  ReserveSum: {
+    short: "RES",
+    explain: "Compare sums of the two cards left in hand.",
+    shape: "square",
+    label: "Reserve",
+  },
+  ClosestToTarget: {
+    short: "CL",
+    explain: "Value closest to target wins.",
+    shape: "diamond",
+    label: "Closest",
+  },
+  Initiative: {
+    short: "INIT",
+    explain: "Initiative holder wins.",
+    shape: "hex",
+    label: "Initiative",
+  },
 };
 
 import { shuffle } from "./math";
@@ -36,9 +150,10 @@ export function genWheelSections(
     const id = kinds[i];
     const len = lens[i];
     const end = (start + len - 1) % SLICES;
+    const defaultColor = WHEEL_PALETTES.default[id];
     sections.push({
       id,
-      color: VC_META[id].color,
+      color: defaultColor,
       start,
       end,
       target: id === "ClosestToTarget" ? Math.floor(rng() * 16) : undefined,

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wght@8..144,600&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- add shared wheel metadata for shape paths and accessible palette modes
- render wheel slices with contrast-aware numbers, bold vector shapes, and a variable font
- expose a color-blind safe palette toggle with updated legend entries and shape icons

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d530dbc61c8332a38cb03f9ca458fb