### PR TITLE
Streamline grimoire popover anchoring

### DIFF
--- a/src/features/threeWheel/components/HUDPanels.tsx
+++ b/src/features/threeWheel/components/HUDPanels.tsx
@@ -24,6 +24,7 @@ interface HUDPanelsProps {
   theme: Theme;
   onPlayerManaToggle?: () => void;
   isGrimoireOpen?: boolean;
+  playerManaButtonRef?: React.Ref<HTMLButtonElement>;
 }
 
 const HUDPanels: React.FC<HUDPanelsProps> = ({
@@ -39,6 +40,7 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
   theme,
   onPlayerManaToggle,
   isGrimoireOpen,
+  playerManaButtonRef,
 }) => {
   const rsP = reserveSums ? reserveSums.player : null;
   const rsE = reserveSums ? reserveSums.enemy : null;
@@ -76,6 +78,8 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
       </>
     );
 
+    const manaRef = isPlayer ? playerManaButtonRef : undefined;
+
     const renderManaPill = () => {
       if (!isGrimoireMode) {
         return (
@@ -101,6 +105,7 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
             title={`Mana: ${manaCount}`}
             aria-pressed={isGrimoireOpen}
             aria-label={`Mana: ${manaCount}. ${isGrimoireOpen ? "Hide" : "Show"} grimoire.`}
+            ref={manaRef}
           >
             {manaPillContent}
           </button>


### PR DESCRIPTION
## Summary
- anchor the desktop grimoire popover by directly positioning its element from the mana button ref
- remove the intermediate style state in favor of a ref-driven layout update for a smaller change set

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d53187fba083329ac2d48ae4a49b20