### PR TITLE
Center wheel panel and tighten layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -396,7 +396,8 @@ export default function ThreeWheel_WinsOnly({
   const wheelPanelContainerStyle = useMemo(
     () => ({
       width: wheelPanelLayout.panelWidth,
-      background: `linear-gradient(180deg, rgba(255,255,255,.04) 0%, rgba(0,0,0,.14) 100%), ${THEME.panelBg}`,
+      margin: "0 auto",
+      background: "transparent",
       borderColor: THEME.panelBorder,
       borderWidth: 2,
       boxShadow: wheelPanelShadow,

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -68,7 +68,7 @@ export interface WheelPanelProps {
 }
 
 const slotWidthPx = 80;
-const gapXPx = 16;
+const gapXPx = 4;
 const paddingXPx = 16;
 const borderXPx = 4;
 const extraHeightPx = 16;
@@ -381,7 +381,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
     );
 
   const content = (
-    <div className="flex items-center justify-center gap-1" style={{ height: panelHeight }}>
+    <div className="flex items-center justify-center gap-[2px]" style={{ height: panelHeight }}>
       <div
         data-drop="slot"
         data-idx={index}


### PR DESCRIPTION
## Summary
- center the grouped wheel panel within the play area and remove its opaque background
- tighten wheel spacing constants so the card slots sit closer to their wheels while keeping drop zones aligned

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5508f9a3c83328555f99d151d6bce