### PR TITLE
Center hand dock overlay with wheel panels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -393,7 +393,6 @@ export default function ThreeWheel_WinsOnly({
   const wheelPanelContainerStyle = useMemo(
     () => ({
       width: wheelPanelLayout.panelWidth,
-      margin: "0 auto",
       background: "transparent",
       borderColor: "transparent",
       borderWidth: 2,
@@ -1145,7 +1144,7 @@ const renderWheelPanel = (i: number) => {
       >
         <div
           ref={wheelPanelContainerRef}
-          className="flex h-full flex-col items-stretch justify-center gap-0 rounded-xl border border-transparent p-2 shadow"
+          className="mx-auto flex h-full flex-col items-center justify-center gap-0 rounded-xl border border-transparent p-2 shadow"
           style={wheelPanelContainerStyle}
         >
           {[0, 1, 2].map((i) => (

--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -104,8 +104,14 @@ const HandDock: React.FC<HandDockProps> = ({
     if (typeof measuredWidth === "number") {
       style.width = measuredWidth;
     }
-    
+
+    if (wheelPanelBounds) {
+      const centerX = wheelPanelBounds.left + wheelPanelBounds.width / 2;
+      style.left = `${centerX}px`;
+    }
+
     return style;
+  }, [wheelPanelBounds, wheelPanelWidth]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- align the fixed hand dock overlay to the measured center of the wheel panel container so it shares the same screen centerline as the wheels
- center the wheel panel stack itself on the screen vertical centerline for consistent alignment with the dock

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d57c878e488332ae83a5ba46a37604