### PR TITLE
Hide round phase goal from main HUD

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -854,22 +854,7 @@ const renderWheelPanel = (i: number) => {
       )}
 
       {/* Controls */}
-      <div className="flex items-center justify-between text-[12px] min-h-[24px]">
-        <div className="flex items-center gap-3">
-          <div>
-            <span className="opacity-70">Round</span>{" "}
-            <span className="font-semibold">{round}</span>
-          </div>
-          <div>
-            <span className="opacity-70">Phase</span>{" "}
-            <span className="font-semibold">{phase}</span>
-          </div>
-          <div>
-            <span className="opacity-70">Goal</span>{" "}
-            <span className="font-semibold">First to {winGoal} wins</span>
-          </div>
-        </div>
-
+      <div className="flex items-center justify-end text-[12px] min-h-[24px]">
         <div ref={infoPopoverRootRef} className="flex items-center gap-2">
           {/* Reference button + popover */}
           <div className="relative">


### PR DESCRIPTION
## Summary
- remove the round, phase, and win goal display from the game HUD to hide that information

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d59973cf88833295db6b33211a32af