### PR TITLE
Simplify reference popover adjustments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -888,7 +888,7 @@ const renderWheelPanel = (i: number) => {
 
             {showRef && (
               <div
-                className="absolute top-[110%] right-0 w-[calc(100vw-2rem)] max-w-xs sm:w-80 sm:max-w-none rounded-lg border border-slate-700 bg-slate-800/95 shadow-xl p-3 z-50"
+                className="absolute top-[110%] right-0 w-72 max-w-[calc(100vw-2rem)] sm:w-80 rounded-lg border border-slate-700 bg-slate-800/95 shadow-xl p-3 z-50"
               >
                 <div className="flex items-center justify-between mb-1">
                   <div className="font-semibold">Reference</div>
@@ -915,13 +915,21 @@ const renderWheelPanel = (i: number) => {
                     <li>⚑ Initiative — initiative holder wins</li>
                     <li><span className="font-semibold">0 Start</span> — no one wins</li>
                   </ul>
-                  <div><span className="font-semibold">Grimoire - Casting Spells</span></div>
-                    <div> Spells cost <span className="font-semibold">Mana</span> to cast. 
-                      Your <span className="font-semibold">Grimoire</span> can be acceessed by pressing on your <span className="font-semibold">Mana. </span>
-                      You gain <span className="font-semibold">+1 Mana</span> for each wheel you win. 
-                      Some spells require you to select<span className="font-semibold"> either a card or a wheel</span> before they resolve. 
-                      Most spells are available after the Resolve phase, but some can be cast at any time.
-                  </div>
+                  {isGrimoireMode && (
+                    <div className="space-y-1">
+                      <div>
+                        <span className="font-semibold">Grimoire - Casting Spells</span>
+                      </div>
+                      <div>
+                        Spells cost <span className="font-semibold">Mana</span> to cast. Your
+                        <span className="font-semibold"> Grimoire</span> can be accessed by pressing on your
+                        <span className="font-semibold"> Mana</span>. You gain
+                        <span className="font-semibold"> +1 Mana</span> for each wheel you win. Some spells require you to
+                        select <span className="font-semibold">either a card or a wheel</span> before they resolve. Most
+                        spells are available after the Resolve phase, but some can be cast at any time.
+                      </div>
+                    </div>
+                  )}
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Summary
- remove the bespoke resize listeners for the reference popover and rely on static positioning
- anchor the reference popover to the trigger's right edge on small screens while preserving the desktop layout
- gate the Grimoire casting guidance behind the Grimoire game mode flag

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d59a0bb2348332a3023c280019e9cf