### PR TITLE
Move mana pill outside wins row

### DIFF
--- a/src/features/threeWheel/components/HUDPanels.tsx
+++ b/src/features/threeWheel/components/HUDPanels.tsx
@@ -142,10 +142,13 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
               <span className="ml-2 rounded bg-white/10 px-1.5 py-0.5 text-[10px]">You</span>
             )}
           </div>
-          <div className="flex items-center gap-2 ml-1 w-full justify-between sm:w-auto sm:justify-end flex-nowrap">
-            <div className="flex items-center gap-1 flex-shrink-0">
-              <span className="opacity-80">Wins</span>
-              <span className="text-base font-extrabold tabular-nums">{win}</span>
+          <div className="flex items-start gap-2 ml-1 w-full justify-between sm:w-auto sm:justify-end flex-nowrap">
+            <div className="flex flex-col flex-shrink-0 items-start sm:items-end">
+              <div className="flex items-center gap-1">
+                <span className="opacity-80">Wins</span>
+                <span className="text-base font-extrabold tabular-nums">{win}</span>
+              </div>
+              {renderManaPill()}
             </div>
             {isReserveVisible && (
               <div
@@ -164,7 +167,6 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
                 <span className="font-bold tabular-nums">{rs ?? 0}</span>
               </div>
             )}
-            {renderManaPill()}
           </div>
           {hasInit && (
             <span


### PR DESCRIPTION
## Summary
- move the mana pill rendering next to the Wins label into its own vertical stack
- position the pill directly beneath the Wins count for both player panels while preserving existing styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5a62afbe48332a0b466e7da8d762e