### PR TITLE
Move mana pill below HUD panels

### DIFF
--- a/src/features/threeWheel/components/HUDPanels.tsx
+++ b/src/features/threeWheel/components/HUDPanels.tsx
@@ -125,7 +125,7 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
     };
 
     return (
-      <div className="flex h-full flex-col items-center w-full">
+      <div className="flex h-full flex-col items-start w-full">
         <div
           className="relative flex min-w-0 items-start sm:items-center gap-2 rounded-lg border px-0.5 py-0.5 sm:py-1 text-[12px] shadow w-full flex-wrap sm:flex-nowrap min-h-[40px] sm:min-h-0"
           style={{
@@ -148,7 +148,6 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
                 <span className="opacity-80">Wins</span>
                 <span className="text-base font-extrabold tabular-nums">{win}</span>
               </div>
-              {renderManaPill()}
             </div>
             {isReserveVisible && (
               <div
@@ -181,7 +180,9 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
             </span>
           )}
         </div>
-
+        <div className="mt-1 self-start">
+          {renderManaPill()}
+        </div>
       </div>
     );
   };


### PR DESCRIPTION
## Summary
- position the mana pill beneath each player HUD panel and align it with the panel's left edge

## Testing
- npm run lint *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b020c9408332ba0b164f4eff7aeb