### PR TITLE
Add branded loading screen with centered logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,48 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Three Wheel Roguelike</title>
+    <style>
+      .rw-loading-screen {
+        min-height: 100vh;
+        width: 100%;
+        background: #000;
+        color: #fff;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        padding: 2.5rem 1.5rem;
+        box-sizing: border-box;
+        gap: 1.5rem;
+      }
+
+      .rw-loading-screen__logo {
+        width: min(60vw, 320px);
+        max-width: 100%;
+        height: auto;
+        filter: drop-shadow(0 18px 32px rgba(0, 0, 0, 0.6));
+      }
+
+      .rw-loading-screen__message {
+        font-size: 1.05rem;
+        font-weight: 600;
+        color: rgba(255, 255, 255, 0.85);
+      }
+
+      .rw-loading-screen__extra {
+        font-size: 0.85rem;
+        color: rgba(255, 255, 255, 0.7);
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div class="rw-loading-screen" role="status" aria-live="polite" aria-busy="true" aria-label="Loading">
+        <img class="rw-loading-screen__logo" src="/assets/rogue-wheel-logo.png" alt="Rogue Wheel logo" />
+        <div class="rw-loading-screen__message">Loading…</div>
+      </div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/ProfilePage.tsx
+++ b/src/ProfilePage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import LoadingScreen from "./components/LoadingScreen";
 import {
   getProfileBundle,
   expRequiredForLevel,
@@ -16,6 +17,12 @@ export default function ProfilePage() {
     bundle?.profile.displayName ?? "Local Player"
   );
   const nameInputRef = useRef<HTMLInputElement | null>(null);
+  const handleHardReset = useCallback(() => {
+    try {
+      localStorage.removeItem("rw:single:state");
+    } catch {}
+    location.reload();
+  }, []);
 
   // Refresh once on mount (covers first-run seed or any changes)
   useEffect(() => {
@@ -63,15 +70,15 @@ export default function ProfilePage() {
 
   if (!bundle) {
     return (
-      <div className="p-4">
-        Loading profile…
+      <LoadingScreen message="Loading profile…">
         <button
-          className="ml-3 underline text-xs"
-          onClick={() => { try { localStorage.removeItem("rw:single:state"); } catch {}; location.reload(); }}
+          type="button"
+          onClick={handleHardReset}
+          className="rounded-full border border-white/30 px-3 py-1 text-xs font-semibold text-white/80 transition hover:border-white/60 hover:text-white"
         >
-          reset
+          Reset local data
         </button>
-      </div>
+      </LoadingScreen>
     );
   }
 

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+
+const LOGO_SRC = "/assets/rogue-wheel-logo.png";
+
+type LoadingScreenProps = {
+  /** Optional message rendered under the logo. */
+  message?: ReactNode;
+  /** Additional content rendered below the message (e.g. retry buttons). */
+  children?: ReactNode;
+  /** Extra class names appended to the root element. */
+  className?: string;
+  /** Override the alt text used for the logo image. */
+  logoAlt?: string;
+};
+
+export default function LoadingScreen({
+  message,
+  children,
+  className = "",
+  logoAlt = "Rogue Wheel logo",
+}: LoadingScreenProps) {
+  const classes = ["rw-loading-screen", className].filter(Boolean).join(" ");
+  const ariaLabel = typeof message === "string" ? message : undefined;
+
+  return (
+    <div
+      className={classes}
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label={ariaLabel ?? "Loading"}
+    >
+      <img
+        src={LOGO_SRC}
+        alt={logoAlt}
+        className="rw-loading-screen__logo"
+        draggable={false}
+      />
+      {message ? <div className="rw-loading-screen__message">{message}</div> : null}
+      {children ? <div className="rw-loading-screen__extra">{children}</div> : null}
+      {!message && <span className="sr-only">Loading</span>}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,43 @@
  * tailwind.config.js.  It also includes typographic rules for headings.
  */
 
+.rw-loading-screen {
+  min-height: 100vh;
+  width: 100%;
+  background-color: #000;
+  color: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2.5rem 1.5rem;
+  box-sizing: border-box;
+  gap: 1.5rem;
+}
+
+.rw-loading-screen__logo {
+  width: min(60vw, 320px);
+  max-width: 100%;
+  height: auto;
+  filter: drop-shadow(0 18px 32px rgba(0, 0, 0, 0.6));
+}
+
+.rw-loading-screen__message {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.rw-loading-screen__extra {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
 body {
   /* Apply a warm wood background texture across the entire game.  The dark
    * slate fallback ensures the UI remains legible if the image fails to


### PR DESCRIPTION
## Summary
- render a branded loading screen with the game logo while the app bundle initializes
- add shared styles and a reusable `LoadingScreen` component for consistent loading layouts
- update the profile route to reuse the branded loading screen and keep the reset control accessible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5d71f696083329e7742a6aebd3ecc