### PR TITLE
Add reusable loading screen overlay

### DIFF
--- a/src/MultiplayerRoute.tsx
+++ b/src/MultiplayerRoute.tsx
@@ -3,6 +3,7 @@ import { Realtime } from "ably";
 import type { PresenceMessage } from "ably";
 import { TARGET_WINS, type Players, type Side } from "./game/types";
 import { DEFAULT_GAME_MODE, type GameMode } from "./gameModes";
+import LoadingScreen from "./components/LoadingScreen";
 
 // ----- Start payload now includes targetWins (wins goal) -----
 type StartMessagePayload = {
@@ -53,6 +54,8 @@ export default function MultiplayerRoute({
 
   // Game mode (host controls)
   const [gameMode, setGameMode] = useState<GameMode>(DEFAULT_GAME_MODE);
+
+  const showLoadingScreen = mode === "creating" || mode === "joining";
 
   // ---- Ably core refs ----
   const ablyRef = useRef<Realtime | null>(null);
@@ -574,6 +577,11 @@ export default function MultiplayerRoute({
 
   return (
     <div className="min-h-screen grid place-items-center bg-slate-950 text-slate-100 p-4">
+      {showLoadingScreen && (
+        <LoadingScreen>
+          <div>{mode === "creating" ? "Creating room…" : "Joining room…"}</div>
+        </LoadingScreen>
+      )}
       <div className="w-full max-w-md rounded-2xl bg-slate-900/70 p-4 ring-1 ring-white/10">
         <h1 className="text-xl font-bold mb-3">Multiplayer</h1>
 

--- a/src/ProfilePage.tsx
+++ b/src/ProfilePage.tsx
@@ -5,6 +5,7 @@ import {
   type ProfileBundle,
   updateProfileDisplayName,
 } from "./player/profileStore";
+import LoadingScreen from "./components/LoadingScreen";
 
 export default function ProfilePage() {
   // Initialize immediately so we can render without waiting for an effect
@@ -63,15 +64,20 @@ export default function ProfilePage() {
 
   if (!bundle) {
     return (
-      <div className="p-4">
-        Loading profile…
+      <LoadingScreen>
+        <div>Loading profile…</div>
         <button
-          className="ml-3 underline text-xs"
-          onClick={() => { try { localStorage.removeItem("rw:single:state"); } catch {}; location.reload(); }}
+          className="inline-flex items-center justify-center rounded bg-white/10 px-3 py-1 text-xs font-medium text-white/80 ring-1 ring-white/20 transition hover:bg-white/15 hover:text-white"
+          onClick={() => {
+            try {
+              localStorage.removeItem("rw:single:state");
+            } catch {}
+            location.reload();
+          }}
         >
-          reset
+          Reset profile
         </button>
-      </div>
+      </LoadingScreen>
     );
   }
 

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+
+interface LoadingScreenProps {
+  children?: ReactNode;
+}
+
+export default function LoadingScreen({ children }: LoadingScreenProps) {
+  return (
+    <div className="fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-black text-white p-6 text-center">
+      <img
+        src="/rotogo_snap_logo_2.png"
+        alt="RotoGo Snap logo"
+        className="w-48 max-w-[60vw] h-auto"
+      />
+      {children ? <div className="mt-6 space-y-3 text-sm text-white/80">{children}</div> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a shared loading screen component that centers the RotoGo Snap logo on a black backdrop
- display the loading screen while the profile data initializes
- show the loading screen when creating or joining multiplayer rooms

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5dc8fef988332a370b98cad7c067a