### PR TITLE
Add Ante mode with betting flow and lobby selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -208,6 +208,7 @@ export default function ThreeWheel_WinsOnly({
     roomCode,
     hostId,
     targetWins,
+    gameMode,
     onExit,
   });
   // --- from hook
@@ -217,6 +218,7 @@ export default function ThreeWheel_WinsOnly({
     initiative,
     wins,
     round,
+    ante,
     phase: basePhase,
     resolveVotes,
     advanceVotes,
@@ -270,10 +272,12 @@ export default function ThreeWheel_WinsOnly({
     handleRematchClick,
     handleExitClick,
     applySpellEffects,
+    setAnteBet,
   } = actions;
 
   // --- local UI/Grimoire state (from Spells branch) ---
   const isGrimoireMode = gameMode === "grimoire";
+  const isAnteMode = gameMode === "ante";
   const effectiveGameMode = gameMode as GameMode;
   const spellRuntimeStateRef = useRef<SpellRuntimeState>({});
 
@@ -321,6 +325,9 @@ export default function ThreeWheel_WinsOnly({
   const casterFighter = localLegacySide === "player" ? player : enemy;
   const opponentFighter = localLegacySide === "player" ? enemy : player;
   const readyButtonDisabled = localReady;
+
+  const localAnteValue = ante?.bets?.[localLegacySide] ?? 0;
+  const remoteAnteValue = ante?.bets?.[remoteLegacySide] ?? 0;
 
   const isWheelActive = useCallback((wheelIndex: number) => Boolean(active[wheelIndex]), [active]);
 
@@ -473,6 +480,7 @@ export default function ThreeWheel_WinsOnly({
 
   const infoPopoverRootRef = useRef<HTMLDivElement | null>(null);
   const [showRef, setShowRef] = useState(false);
+  const [showAnte, setShowAnte] = useState(false);
 
   const handlePlayerManaToggle = useCallback(() => {
     if (!isGrimoireMode) return;
@@ -480,6 +488,7 @@ export default function ThreeWheel_WinsOnly({
       const next = !prev;
       if (next) {
         setShowRef(false);
+        setShowAnte(false);
       }
       return next;
     });
@@ -519,6 +528,16 @@ export default function ThreeWheel_WinsOnly({
     }
     prevWinsRef.current = wins;
   }, [wins]);
+
+  useEffect(() => {
+    if (!isAnteMode) {
+      setShowAnte(false);
+      return;
+    }
+    if (phase !== "choose") {
+      setShowAnte(false);
+    }
+  }, [isAnteMode, phase]);
 
   // --- render helpers ---
 type SlotView = { side: LegacySide; card: Card | null; name: string };
@@ -863,6 +882,83 @@ const renderWheelPanel = (i: number) => {
         </div>
 
         <div ref={infoPopoverRootRef} className="flex items-center gap-2">
+          {isAnteMode && (
+            <div className="relative">
+              <button
+                onClick={() =>
+                  setShowAnte((prev) => {
+                    const next = !prev;
+                    if (next) {
+                      setShowRef(false);
+                      setShowGrimoire(false);
+                    }
+                    return next;
+                  })
+                }
+                disabled={phase !== "choose"}
+                className="px-2.5 py-0.5 rounded bg-slate-700 text-white border border-slate-600 hover:bg-slate-600 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Ante
+              </button>
+
+              {showAnte && (
+                <div className="absolute top-[110%] right-0 w-72 max-w-[calc(100vw-2rem)] sm:w-80 rounded-lg border border-slate-700 bg-slate-800/95 shadow-xl p-3 z-50">
+                  <div className="flex items-center justify-between mb-1">
+                    <div className="font-semibold">Ante</div>
+                    <button
+                      onClick={() => setShowAnte(false)}
+                      className="text-xl leading-none text-slate-300 hover:text-white"
+                    >
+                      ×
+                    </button>
+                  </div>
+                  <div className="text-[12px] space-y-3">
+                    <div className="space-y-1">
+                      <div className="font-semibold text-slate-200">Round odds</div>
+                      <div className="flex justify-between text-xs text-slate-300">
+                        <span>
+                          {namesByLegacy.player}: {(ante?.odds?.player ?? 1.1).toFixed(2)}×
+                        </span>
+                        <span>
+                          {namesByLegacy.enemy}: {(ante?.odds?.enemy ?? 1.1).toFixed(2)}×
+                        </span>
+                      </div>
+                    </div>
+                    <div className="space-y-1">
+                      <label className="font-semibold text-slate-200" htmlFor="ante-input">
+                        Your ante (wins)
+                      </label>
+                      <input
+                        id="ante-input"
+                        type="number"
+                        min={0}
+                        max={wins[localLegacySide]}
+                        value={localAnteValue}
+                        onChange={(event) => {
+                          const parsed = Number.parseInt(event.target.value, 10);
+                          setAnteBet(Number.isFinite(parsed) ? parsed : 0);
+                        }}
+                        disabled={phase !== "choose"}
+                        className="w-full rounded border border-slate-700 bg-slate-900/60 px-3 py-1.5 text-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40 disabled:opacity-60"
+                      />
+                      <div className="text-xs text-slate-400">
+                        Available wins: {wins[localLegacySide]}
+                      </div>
+                    </div>
+                    {isMultiplayer && (
+                      <div className="text-xs text-slate-300">
+                        Opponent ante: {remoteAnteValue}
+                      </div>
+                    )}
+                    <div className="text-xs text-slate-400">
+                      Ante can only be changed before resolving the round.
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
           {/* Reference button + popover */}
           <div className="relative">
             <button
@@ -870,6 +966,7 @@ const renderWheelPanel = (i: number) => {
                 setShowRef((prev) => {
                   const next = !prev;
                   if (next) setShowGrimoire(false);
+                  if (next) setShowAnte(false);
                   return next;
                 })
               }

--- a/src/MultiplayerRoute.tsx
+++ b/src/MultiplayerRoute.tsx
@@ -28,10 +28,11 @@ type ConnectOptions = {
   requireExistingMembers?: boolean;
 };
 
-const LOBBY_MODE_OPTIONS: GameMode[] = ["classic", "grimoire"];
+const LOBBY_MODE_OPTIONS: GameMode[] = ["classic", "grimoire", "ante"];
 const MODE_LABELS: Record<GameMode, string> = {
   classic: "Classic",
   grimoire: "Grimoire",
+  ante: "Ante",
 };
 
 export default function MultiplayerRoute({

--- a/src/gameModes.ts
+++ b/src/gameModes.ts
@@ -1,4 +1,4 @@
-export type GameMode = "classic" | "grimoire";
+export type GameMode = "classic" | "grimoire" | "ante";
 
 export const DEFAULT_GAME_MODE: GameMode = "classic";
 
@@ -24,6 +24,14 @@ export const GAME_MODE_DETAILS: Record<
     highlights: [
       "Adds spells, which can alter match outcomes",
       "Best for advanced players seeking depth",
+    ],
+  },
+  ante: {
+    title: "Ante",
+    subtitle: "Risk wins each round for boosted payouts.",
+    highlights: [
+      "Wager existing wins at the start of every round",
+      "Win the round to multiply your ante by dynamic odds",
     ],
   },
 };


### PR DESCRIPTION
## Summary
- add Ante mode metadata and expose the option in single- and multiplayer selectors
- implement ante betting state, odds calculation, and resolution handling in the three-wheel game hook
- surface an Ante HUD popover so players can review odds and place or clear wagers before resolving a round

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d69b1808948332b354061345f36946