### PR TITLE
Fix ante mode selection in multiplayer host room

### DIFF
--- a/src/MultiplayerRoute.tsx
+++ b/src/MultiplayerRoute.tsx
@@ -778,7 +778,7 @@ function clampTargetWins(value: number) {
 }
 
 function isGameMode(value: unknown): value is GameMode {
-  return value === "classic" || value === "grimoire";
+  return value === "classic" || value === "grimoire" || value === "ante";
 }
 
 // Assign sides from presence order (host=left, first joiner=right)


### PR DESCRIPTION
## Summary
- allow the ante option to be treated as a valid game mode in the lobby

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6a249d5a48332a768bb0062617400