### PR TITLE
Enable optional game mode combinations

### DIFF
--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -6,7 +6,7 @@ import MultiplayerRoute from "./MultiplayerRoute";
 import { TARGET_WINS, type Players, type Side } from "./game/types";
 import ProfilePage from "./ProfilePage";
 import ModeSelect from "./ModeSelect";
-import { DEFAULT_GAME_MODE, type GameMode } from "./gameModes";
+import { DEFAULT_GAME_MODE, normalizeGameMode, type GameMode } from "./gameModes";
 
 type MPStartPayload = Parameters<
   NonNullable<React.ComponentProps<typeof MultiplayerRoute>["onStart"]>
@@ -24,7 +24,7 @@ type View =
 export default function AppShell() {
   const [view, setView] = useState<View>({ key: "hub" });
   const [mpPayload, setMpPayload] = useState<MPStartPayload | null>(null);
-  const [gameMode, setGameMode] = useState<GameMode>(DEFAULT_GAME_MODE);
+  const [gameMode, setGameMode] = useState<GameMode>(() => [...DEFAULT_GAME_MODE]);
   const [soloTargetWins, setSoloTargetWins] = useState<number>(TARGET_WINS);
 
   if (view.key === "hub") {
@@ -44,7 +44,7 @@ export default function AppShell() {
       <MultiplayerRoute
         onBack={() => setView({ key: "hub" })}
         onStart={(payload) => {
-          setGameMode(payload.gameMode);
+          setGameMode(normalizeGameMode(payload.gameMode));
           setMpPayload(payload);
           setView({
             key: "modeSelect",
@@ -89,7 +89,7 @@ export default function AppShell() {
           setMpPayload(null);
         }}
         onConfirm={(mode, winsGoal) => {
-          setGameMode(mode);
+          setGameMode(normalizeGameMode(mode));
 
           if (view.next.mode === "mp") {
             const payload = view.next.mpPayload ?? mpPayload;
@@ -97,7 +97,11 @@ export default function AppShell() {
               setView({ key: "mp" });
               return;
             }
-            const nextPayload = { ...payload, targetWins: winsGoal, gameMode: mode };
+            const nextPayload = {
+              ...payload,
+              targetWins: winsGoal,
+              gameMode: normalizeGameMode(mode),
+            };
             setMpPayload(nextPayload);
             setView({ key: "game", mode: "mp", mpPayload: nextPayload });
             return;

--- a/src/ModeSelect.tsx
+++ b/src/ModeSelect.tsx
@@ -1,7 +1,14 @@
 import React, { useEffect, useMemo, useState } from "react";
 
 import { TARGET_WINS } from "./game/types";
-import { DEFAULT_GAME_MODE, GAME_MODE_DETAILS, type GameMode } from "./gameModes";
+import {
+  DEFAULT_GAME_MODE,
+  GAME_MODE_DETAILS,
+  normalizeGameMode,
+  toggleGameMode,
+  type GameMode,
+  type GameModeOption,
+} from "./gameModes";
 
 type ModeSelectProps = {
   initialMode?: GameMode;
@@ -22,12 +29,16 @@ export default function ModeSelect({
   backLabel = "← Back",
   confirmLabel = "Confirm Mode",
 }: ModeSelectProps) {
-  const [selectedMode, setSelectedMode] = useState<GameMode>(initialMode);
+  const [selectedModes, setSelectedModes] = useState<GameMode>(() => normalizeGameMode(initialMode));
   const [targetWins, setTargetWins] = useState<number>(() => clampTargetWins(initialTargetWins));
   const [targetWinsInput, setTargetWinsInput] = useState<string>(String(clampTargetWins(initialTargetWins)));
 
   const detailEntries = useMemo(
-    () => Object.entries(GAME_MODE_DETAILS) as [GameMode, (typeof GAME_MODE_DETAILS)[GameMode]][],
+    () =>
+      Object.entries(GAME_MODE_DETAILS) as [
+        GameModeOption,
+        (typeof GAME_MODE_DETAILS)[GameModeOption],
+      ][],
     [],
   );
 
@@ -36,6 +47,10 @@ export default function ModeSelect({
     setTargetWins(next);
     setTargetWinsInput(String(next));
   }, [initialTargetWins]);
+
+  useEffect(() => {
+    setSelectedModes(normalizeGameMode(initialMode));
+  }, [initialMode]);
 
   const handleWinsChange = (value: string) => {
     if (!/^\d*$/.test(value)) return;
@@ -77,17 +92,20 @@ export default function ModeSelect({
         </div>
 
         <div className="mt-6 flex flex-col gap-3 text-left">
-          <h1 className="text-3xl font-bold sm:text-4xl">Choose a Mode</h1>
+          <h1 className="text-3xl font-bold sm:text-4xl">Choose Game Modes</h1>
+          <p className="text-sm text-slate-300 sm:text-base">
+            Classic rules are always on. Toggle any additional modes you want to include.
+          </p>
         </div>
 
         <div className="mt-8 grid gap-4 sm:grid-cols-2">
           {detailEntries.map(([mode, info]) => {
-            const isSelected = selectedMode === mode;
+            const isSelected = selectedModes.includes(mode);
             return (
               <button
                 key={mode}
                 type="button"
-                onClick={() => setSelectedMode(mode)}
+                onClick={() => setSelectedModes((prev) => toggleGameMode(prev, mode))}
                 className={[
                   "rounded-2xl border p-5 text-left transition focus:outline-none",
                   "bg-slate-900/60 hover:bg-slate-900/80",
@@ -102,7 +120,7 @@ export default function ModeSelect({
                   </div>
                   {isSelected && (
                     <span className="rounded-full bg-emerald-500/20 px-2 py-0.5 text-xs font-semibold text-emerald-200">
-                      Selected
+                      Enabled
                     </span>
                   )}
                 </div>
@@ -140,7 +158,7 @@ export default function ModeSelect({
           )}
           <button
             type="button"
-            onClick={() => onConfirm(selectedMode, targetWins)}
+            onClick={() => onConfirm(normalizeGameMode(selectedModes), targetWins)}
             className="inline-flex items-center justify-center rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300"
           >
             {confirmLabel}

--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -21,7 +21,7 @@ import {
   type CorePhase,
   LEGACY_FROM_SIDE,
 } from "../../../game/types";
-import type { GameMode } from "../../../gameModes";
+import { DEFAULT_GAME_MODE, normalizeGameMode, type GameMode } from "../../../gameModes";
 import { easeInOutCubic, inSection, createSeededRng } from "../../../game/math";
 import { genWheelSections } from "../../../game/wheel";
 import {
@@ -199,8 +199,8 @@ export function useThreeWheelGame({
       ? Math.max(1, Math.min(25, Math.round(targetWins)))
       : TARGET_WINS;
 
-  const currentGameMode: GameMode = gameMode ?? "classic";
-  const isAnteMode = currentGameMode === "ante";
+  const currentGameMode = normalizeGameMode(gameMode ?? DEFAULT_GAME_MODE);
+  const isAnteMode = currentGameMode.includes("ante");
 
   const hostLegacySide: LegacySide = (() => {
     if (!hostId) return "player";

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -71,7 +71,7 @@ export type Phase =
 
 export type CorePhase = Exclude<Phase, "spellTargeting">;
 
-export type GameMode = "classic" | "grimoire";
+export type { GameMode, GameModeOption } from "../gameModes";
 
 /** Helpful 2P maps (optional, but convenient) */
 export type HandMap = Record<Side, Card[]>;

--- a/src/gameModes.ts
+++ b/src/gameModes.ts
@@ -1,23 +1,24 @@
-export type GameMode = "classic" | "grimoire" | "ante";
+export const GAME_MODE_OPTIONS = ["grimoire", "ante"] as const;
 
-export const DEFAULT_GAME_MODE: GameMode = "classic";
+export type GameModeOption = (typeof GAME_MODE_OPTIONS)[number];
+
+export type GameMode = GameModeOption[];
+
+export const DEFAULT_GAME_MODE: GameMode = [];
+
+export const GAME_MODE_LABELS: Record<GameModeOption, string> = {
+  grimoire: "Grimoire",
+  ante: "Ante",
+};
 
 export const GAME_MODE_DETAILS: Record<
-  GameMode,
+  GameModeOption,
   {
     title: string;
     subtitle: string;
     highlights: string[];
   }
 > = {
-  classic: {
-    title: "Classic",
-    subtitle: "Pure spins and tactical cardplay.",
-    highlights: [
-      "Original ruleset with straightforward drafting",
-      "Great for quick matches and onboarding",
-    ],
-  },
   grimoire: {
     title: "Grimoire",
     subtitle: "Experimental systems and power-ups.",
@@ -35,3 +36,47 @@ export const GAME_MODE_DETAILS: Record<
     ],
   },
 };
+
+export function normalizeGameMode(modes: readonly GameModeOption[]): GameMode {
+  const set = new Set<GameModeOption>();
+  for (const option of GAME_MODE_OPTIONS) {
+    if (modes.includes(option)) {
+      set.add(option);
+    }
+  }
+  return Array.from(set);
+}
+
+export function toggleGameMode(current: readonly GameModeOption[], option: GameModeOption): GameMode {
+  if (current.includes(option)) {
+    return current.filter((mode) => mode !== option);
+  }
+  return normalizeGameMode([...current, option]);
+}
+
+export function gameModeDisplayName(modes: readonly GameModeOption[]): string {
+  if (modes.length === 0) return "Classic";
+  return normalizeGameMode(modes).map((mode) => GAME_MODE_LABELS[mode]).join(" + ");
+}
+
+export function coerceGameMode(value: unknown): GameMode | null {
+  if (Array.isArray(value)) {
+    const filtered = value.filter((item): item is GameModeOption =>
+      GAME_MODE_OPTIONS.includes(item as GameModeOption),
+    );
+    return normalizeGameMode(filtered);
+  }
+  if (typeof value === "string") {
+    if (value === "classic" || value.trim() === "") {
+      return DEFAULT_GAME_MODE;
+    }
+    if (GAME_MODE_OPTIONS.includes(value as GameModeOption)) {
+      return [value as GameModeOption];
+    }
+  }
+  return null;
+}
+
+export function isGameMode(value: unknown): value is GameMode {
+  return coerceGameMode(value) !== null;
+}


### PR DESCRIPTION
## Summary
- change multiplayer lobby to toggle optional game modes with Classic implied when none are selected
- update single-player mode select screen to share the same multi-select toggle experience
- adapt shared game logic to accept combined game modes for ante and grimoire features

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6c03699548332ac12e8169b684ca7