### PR TITLE
Fix multiplayer resolve synchronization and bypass MP mode select

### DIFF
--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -44,13 +44,11 @@ export default function AppShell() {
       <MultiplayerRoute
         onBack={() => setView({ key: "hub" })}
         onStart={(payload) => {
-          setGameMode(normalizeGameMode(payload.gameMode));
-          setMpPayload(payload);
-          setView({
-            key: "modeSelect",
-            from: "mp",
-            next: { key: "game", mode: "mp", mpPayload: payload },
-          });
+          const normalizedMode = normalizeGameMode(payload.gameMode);
+          const nextPayload = { ...payload, gameMode: normalizedMode };
+          setGameMode(normalizedMode);
+          setMpPayload(nextPayload);
+          setView({ key: "game", mode: "mp", mpPayload: nextPayload });
         }}
       />
     );


### PR DESCRIPTION
## Summary
- ensure multiplayer resolve votes immediately trigger the reveal once both players are ready
- skip the singleplayer mode selection screen when launching a multiplayer match from the lobby

## Testing
- npm test *(fails: TypeScript expects explicit .js extension in src/game/types.ts under node16 resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68d72cd7ea2c8332b86d20f335bebdad