### PR TITLE
Fix multiplayer resolve flow and bypass MP mode select

### DIFF
--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -44,13 +44,11 @@ export default function AppShell() {
       <MultiplayerRoute
         onBack={() => setView({ key: "hub" })}
         onStart={(payload) => {
-          setGameMode(normalizeGameMode(payload.gameMode));
-          setMpPayload(payload);
-          setView({
-            key: "modeSelect",
-            from: "mp",
-            next: { key: "game", mode: "mp", mpPayload: payload },
-          });
+          const normalizedMode = normalizeGameMode(payload.gameMode);
+          const nextPayload = { ...payload, gameMode: normalizedMode };
+          setGameMode(normalizedMode);
+          setMpPayload(nextPayload);
+          setView({ key: "game", mode: "mp", mpPayload: nextPayload });
         }}
       />
     );


### PR DESCRIPTION
## Summary
- ensure multiplayer resolve votes immediately trigger a reveal once both sides are ready by tracking votes and phase with refs
- skip the singleplayer mode selection screen when launching a multiplayer match so players load straight into the battle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d72cd7ea2c8332b86d20f335bebdad