### PR TITLE
Fix resolve button readiness resetting prematurely

### DIFF
--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -811,8 +811,6 @@ export function useThreeWheelGame({
     (opts?: { force?: boolean }) => {
       if (!opts?.force && !canReveal) return false;
 
-      clearResolveVotes();
-
       if (isMultiplayer) {
         broadcastLocalReserve();
       }
@@ -845,7 +843,7 @@ export function useThreeWheelGame({
 
       return true;
     },
-    [broadcastLocalReserve, canReveal, clearResolveVotes, isMultiplayer, wheelSize]
+    [broadcastLocalReserve, canReveal, isMultiplayer, wheelSize]
   );
 
   const onReveal = useCallback(() => {


### PR DESCRIPTION
## Summary
- keep resolve votes marked ready until the round reveal begins so readiness is not cleared when the second player resolves

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d731eab2408332a60bdee74c01a639