### PR TITLE
Allow repeated reveal intents in multiplayer

### DIFF
--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -1295,8 +1295,6 @@ export function useThreeWheelGame({
       return;
     }
 
-    if (resolveVotes[localLegacySide]) return;
-
     markResolveVote(localLegacySide);
     sendIntent({ type: "reveal", side: localLegacySide });
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- remove the early return in `handleRevealClick` so reveal intents are always sent
- ensure reconnecting players rebroadcast readiness even if their resolve vote already exists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7401ffc0483328fd56a9cf506c006