### PR TITLE
Avoid Ably channel resubscribe churn

### DIFF
--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -1285,7 +1285,8 @@ export function useThreeWheelGame({
         ablyRef.current = null;
       }
     };
-  }, [roomCode, localPlayerId, handleMPIntent]);
+    // handleMPIntent is intentionally omitted: handleMPIntentRef keeps the latest callback.
+  }, [roomCode, localPlayerId]);
 
   const handleRevealClick = useCallback(() => {
     if (phase !== "choose" || !canReveal) return;


### PR DESCRIPTION
## Summary
- stop re-creating the Ably connection effect when the multiplayer intent handler ref changes
- add a clarifying comment about the omitted dependency

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d74d9cd7dc83329d6dc51873adca14