### PR TITLE
Refactor UID usage to share helper

### DIFF
--- a/src/MultiplayerRoute.tsx
+++ b/src/MultiplayerRoute.tsx
@@ -13,6 +13,7 @@ import {
   type GameModeOption,
 } from "./gameModes";
 import LoadingScreen from "./components/LoadingScreen";
+import { uidShort } from "./utils/uid";
 
 // ----- Start payload now includes targetWins (wins goal) -----
 type StartMessagePayload = {
@@ -71,7 +72,7 @@ export default function MultiplayerRoute({
   const [members, setMembers] = useState<
     { clientId: string; name: string; targetWins?: number; gameMode?: GameMode }[]
   >([]);
-  const clientId = useMemo(() => uid4(), []);
+  const clientId = useMemo(() => uidShort(), []);
 
   type MemberEntry = {
     clientId: string;
@@ -774,11 +775,6 @@ function makeRoomCode() {
     s += alphabet[Math.floor(Math.random() * alphabet.length)];
   }
   return s;
-}
-
-function uid4() {
-  // short client id
-  return Math.random().toString(36).slice(2, 6) + Math.random().toString(36).slice(2, 6);
 }
 
 function defaultName() {

--- a/src/player/profileStore.tsx
+++ b/src/player/profileStore.tsx
@@ -3,6 +3,7 @@
 
 import { shuffle } from "../game/math";
 import type { Card, Fighter } from "../game/types";
+import { uid } from "../utils/uid";
 
 // ===== Local persistence types (module-scoped) =====
 type CardId = string;
@@ -41,15 +42,6 @@ function resolveStorage(): SafeStorage {
 
 const storage: SafeStorage = resolveStorage();
 let memoryState: LocalState | null = null;
-
-// Node/browser-safe UID (no imports)
-function uid(prefix = "id") {
-  if (typeof globalThis.crypto !== "undefined" && "randomUUID" in globalThis.crypto) {
-    // @ts-ignore
-    return `${prefix}_${globalThis.crypto.randomUUID()}`;
-  }
-  return `${prefix}_${Math.random().toString(36).slice(2, 8)}${Date.now().toString(36).slice(-4)}`;
-}
 
 // ===== Seed data (keep numbers only to match Card { type:'normal', number:n }) =====
 const SEED_INVENTORY: InventoryItem[] = [];

--- a/src/utils/uid.ts
+++ b/src/utils/uid.ts
@@ -1,9 +1,37 @@
+const hasRandomUUID =
+  typeof globalThis.crypto !== "undefined" && "randomUUID" in globalThis.crypto;
+
+function formatId(prefix: string | undefined, value: string) {
+  if (prefix && prefix.length > 0) {
+    return `${prefix}_${value}`;
+  }
+  return value;
+}
+
+function randomString(length: number) {
+  const target = Number.isFinite(length) ? Math.max(1, Math.floor(length)) : 1;
+  let result = "";
+
+  while (result.length < target) {
+    result += Math.random().toString(36).slice(2);
+  }
+
+  return result.slice(0, target);
+}
+
 export function uid(prefix = "id") {
   // Browser has Web Crypto; modern Node 20/22 also has crypto.randomUUID
-  if (typeof globalThis.crypto !== "undefined" && "randomUUID" in globalThis.crypto) {
-    // @ts-ignore
-    return `${prefix}_${globalThis.crypto.randomUUID()}`;
+  if (hasRandomUUID) {
+    return formatId(prefix, (globalThis.crypto as Crypto).randomUUID());
   }
-  // Safe fallback for any environment (no imports)
-  return `${prefix}_${Math.random().toString(36).slice(2, 8)}${Date.now().toString(36).slice(-4)}`;
+
+  const randomPart = randomString(6);
+  const timestampPart = Date.now().toString(36).slice(-4);
+  return formatId(prefix, `${randomPart}${timestampPart}`);
+}
+
+export function uidShort(options: { prefix?: string; length?: number } = {}) {
+  const { prefix, length = 8 } = options;
+  const randomPart = randomString(length);
+  return formatId(prefix, randomPart);
 }


### PR DESCRIPTION
## Summary
- extend the uid helper with shared formatting and a short-id option
- update the multiplayer route to use the helper instead of an inline generator
- reuse the uid helper for local profile and deck identifiers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7e45f6e648332a7975fafd34e2a36