### PR TITLE
Add onboarding coach overlay and persistence

### DIFF
--- a/src/features/threeWheel/components/FirstRunCoach.tsx
+++ b/src/features/threeWheel/components/FirstRunCoach.tsx
@@ -1,0 +1,218 @@
+import React, { useLayoutEffect, useMemo, useState } from "react";
+import type { RefObject } from "react";
+import type { Card, CorePhase } from "../../../game/types";
+
+type HighlightRef = RefObject<HTMLElement | null> | RefObject<HTMLDivElement | null>;
+
+type FirstRunCoachProps = {
+  stage: number;
+  show: boolean;
+  infoPopoverRef: HighlightRef;
+  handRef: RefObject<HTMLDivElement | null>;
+  wheelRef: RefObject<HTMLDivElement | null>;
+  resolveButtonRef: RefObject<HTMLButtonElement | null>;
+  assigned: (Card | null)[];
+  handCount: number;
+  phase: CorePhase;
+  onDismiss: () => void;
+};
+
+type CoachGeometry = {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+  right: number;
+  bottom: number;
+  viewportWidth: number;
+  viewportHeight: number;
+};
+
+const getElement = (
+  stage: number,
+  refs: {
+    handRef: RefObject<HTMLDivElement | null>;
+    wheelRef: RefObject<HTMLDivElement | null>;
+    resolveButtonRef: RefObject<HTMLButtonElement | null>;
+    infoPopoverRef: HighlightRef;
+  },
+): HTMLElement | null => {
+  if (stage === 0) return refs.handRef.current;
+  if (stage === 1) return refs.wheelRef.current;
+  if (stage === 2) return refs.resolveButtonRef.current ?? refs.infoPopoverRef.current;
+  return null;
+};
+
+function toGeometry(target: HTMLElement | null): CoachGeometry | null {
+  if (typeof window === "undefined" || !target) {
+    return null;
+  }
+  const rect = target.getBoundingClientRect();
+  return {
+    top: rect.top,
+    left: rect.left,
+    width: rect.width,
+    height: rect.height,
+    right: rect.right,
+    bottom: rect.bottom,
+    viewportWidth: window.innerWidth,
+    viewportHeight: window.innerHeight,
+  };
+}
+
+const STAGE_PADDING: Record<number, number> = {
+  0: 18,
+  1: 24,
+  2: 14,
+};
+
+const FirstRunCoach: React.FC<FirstRunCoachProps> = ({
+  stage,
+  show,
+  infoPopoverRef,
+  handRef,
+  wheelRef,
+  resolveButtonRef,
+  assigned,
+  handCount,
+  phase,
+  onDismiss,
+}) => {
+  const [geometry, setGeometry] = useState<CoachGeometry | null>(null);
+
+  useLayoutEffect(() => {
+    if (!show) {
+      setGeometry(null);
+      return;
+    }
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const update = () => {
+      const target = getElement(stage, { handRef, wheelRef, resolveButtonRef, infoPopoverRef });
+      setGeometry(toGeometry(target));
+    };
+
+    update();
+
+    const handleResize = () => update();
+    const handleScroll = () => update();
+
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("scroll", handleScroll, true);
+
+    let resizeObserver: ResizeObserver | null = null;
+    const target = getElement(stage, { handRef, wheelRef, resolveButtonRef, infoPopoverRef });
+    if (typeof ResizeObserver !== "undefined" && target) {
+      resizeObserver = new ResizeObserver(() => update());
+      resizeObserver.observe(target);
+    }
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("scroll", handleScroll, true);
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+    };
+  }, [show, stage, handRef, wheelRef, resolveButtonRef, infoPopoverRef]);
+
+  const assignedCount = useMemo(
+    () => assigned.reduce((count, card) => (card ? count + 1 : count), 0),
+    [assigned],
+  );
+  const totalSlots = assigned.length;
+  const readyToResolve = stage >= 2 && phase === "choose";
+
+  const stageCopy = useMemo(() => {
+    if (stage === 0) {
+      return {
+        title: "Play a card",
+        body:
+          "Drag a card from your hand onto any wheel slot to get started. Cards you play stay until the round resolves.",
+        meta: handCount > 0 ? `${handCount} card${handCount === 1 ? "" : "s"} in hand` : undefined,
+      };
+    }
+    if (stage === 1) {
+      return {
+        title: "Fill each wheel",
+        body: `You still need to cover every wheel before resolving. Slots filled: ${assignedCount}/${totalSlots}.`,
+      };
+    }
+    if (stage === 2) {
+      return {
+        title: "Resolve the round",
+        body: readyToResolve
+          ? "Press Resolve to spin the wheels and find out which rule decides the winner."
+          : "Resolve becomes available once both sides finish assigning cards.",
+      };
+    }
+    return null;
+  }, [stage, assignedCount, totalSlots, handCount, readyToResolve]);
+
+  if (!show || stage >= 3 || !stageCopy) {
+    return null;
+  }
+
+  const padding = STAGE_PADDING[stage] ?? 16;
+  const highlightStyle: React.CSSProperties | undefined = geometry
+    ? {
+        top: Math.max(8, geometry.top - padding),
+        left: Math.max(8, geometry.left - padding),
+        width: geometry.width + padding * 2,
+        height: geometry.height + padding * 2,
+        borderRadius: stage === 1 ? 20 : 14,
+        boxShadow: "0 0 0 9999px rgba(10, 12, 22, 0.68)",
+        border: "2px solid rgba(16, 185, 129, 0.7)",
+      }
+    : undefined;
+
+  const viewportWidth = geometry?.viewportWidth ?? (typeof window !== "undefined" ? window.innerWidth : 1024);
+  const viewportHeight = geometry?.viewportHeight ?? (typeof window !== "undefined" ? window.innerHeight : 768);
+  const anchorCenter = geometry ? geometry.left + geometry.width / 2 : viewportWidth / 2;
+  const belowSpace = geometry ? geometry.viewportHeight - geometry.bottom : viewportHeight;
+  const preferBelow = belowSpace > 220;
+  const calloutTop = geometry
+    ? preferBelow
+      ? Math.min(geometry.bottom + 18, viewportHeight - 180)
+      : Math.max(16, geometry.top - 180)
+    : viewportHeight * 0.25;
+  const calloutLeft = Math.min(Math.max(anchorCenter, 160), viewportWidth - 160);
+
+  const calloutStyle: React.CSSProperties = {
+    top: calloutTop,
+    left: calloutLeft,
+    transform: "translateX(-50%)",
+  };
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-[70]" aria-hidden={!show}>
+      <div className="absolute inset-0 bg-slate-950/55" />
+      {highlightStyle ? (
+        <div
+          className="absolute transition-all duration-200 ease-out"
+          style={{ ...highlightStyle, pointerEvents: "none" }}
+        />
+      ) : null}
+      <div className="absolute w-full max-w-xs px-2" style={calloutStyle}>
+        <div className="pointer-events-auto rounded-xl border border-emerald-400/70 bg-slate-900/95 p-4 text-sm shadow-xl">
+          <div className="text-emerald-200 text-sm font-semibold">{stageCopy.title}</div>
+          <p className="mt-2 text-slate-200 text-[13px] leading-relaxed">{stageCopy.body}</p>
+          {stageCopy.meta ? (
+            <div className="mt-2 text-xs uppercase tracking-wide text-emerald-300/80">{stageCopy.meta}</div>
+          ) : null}
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="mt-3 inline-flex items-center justify-center rounded border border-emerald-400/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-emerald-200 transition hover:border-emerald-300 hover:text-emerald-100"
+          >
+            Skip tutorial
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FirstRunCoach;

--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -1,4 +1,12 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  forwardRef,
+  type MutableRefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { motion } from "framer-motion";
 import StSCard from "../../../components/StSCard";
 import type { Card, Fighter } from "../../../game/types";
@@ -34,27 +42,39 @@ interface HandDockProps {
   onSpellTargetSelect?: (selection: { side: LegacySide; lane: number | null; cardId: string }) => void;
 }
 
-const HandDock: React.FC<HandDockProps> = ({
-  localLegacySide,
-  player,
-  enemy,
-  wheelPanelWidth,
-  wheelPanelBounds,
-  selectedCardId,
-  setSelectedCardId,
-  assign,
-  assignToWheelLocal,
-  setDragCardId,
-  startPointerDrag,
-  isPtrDragging,
-  ptrDragCard,
-  ptrPos,
-  onMeasure,
-  pendingSpell,
-  isAwaitingSpellTarget,
-  onSpellTargetSelect,
-}) => {
-  const dockRef = useRef<HTMLDivElement | null>(null);
+const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
+  ({
+    localLegacySide,
+    player,
+    enemy,
+    wheelPanelWidth,
+    wheelPanelBounds,
+    selectedCardId,
+    setSelectedCardId,
+    assign,
+    assignToWheelLocal,
+    setDragCardId,
+    startPointerDrag,
+    isPtrDragging,
+    ptrDragCard,
+    ptrPos,
+    onMeasure,
+    pendingSpell,
+    isAwaitingSpellTarget,
+    onSpellTargetSelect,
+  }, forwardedRef) => {
+    const dockRef = useRef<HTMLDivElement | null>(null);
+    const handleDockRef = useCallback(
+      (node: HTMLDivElement | null) => {
+        dockRef.current = node;
+        if (typeof forwardedRef === "function") {
+          forwardedRef(node);
+        } else if (forwardedRef) {
+          (forwardedRef as MutableRefObject<HTMLDivElement | null>).current = node;
+        }
+      },
+      [forwardedRef],
+    );
   const [liftPx, setLiftPx] = useState<number>(18);
 
   useEffect(() => {
@@ -115,7 +135,7 @@ const HandDock: React.FC<HandDockProps> = ({
 
   return (
     <div
-      ref={dockRef}
+      ref={handleDockRef}
       className="fixed bottom-0 z-40 pointer-events-none select-none"
       style={overlayStyle}
       data-awaiting-spell-target={awaitingCardTarget ? "true" : "false"}
@@ -217,6 +237,8 @@ const HandDock: React.FC<HandDockProps> = ({
       )}
     </div>
   );
-};
+});
+
+HandDock.displayName = "HandDock";
 
 export default HandDock;


### PR DESCRIPTION
## Summary
- persist an onboarding progress object in the profile store and upgrade old saves
- expose helper functions and integrate the onboarding coach flow into the main app
- add a FirstRunCoach overlay component and forward HandDock refs for highlighting

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7f137446c8332b84e04bcd075d9dc