### PR TITLE
Add Next button to tutorial overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -625,6 +625,11 @@ export default function ThreeWheel_WinsOnly({
     phase !== "ended" &&
     phase !== "spellTargeting";
 
+  const handleCoachAdvance = useCallback(() => {
+    const nextStage = Math.min(onboardingStage + 1, 3);
+    persistStage(nextStage);
+  }, [onboardingStage, persistStage]);
+
   const handleCoachDismiss = useCallback(() => {
     const staged = persistStage(3);
     const updated = dismissOnboardingHint("firstRunCoach");
@@ -1427,6 +1432,7 @@ const renderWheelPanel = (i: number) => {
         handCount={player.hand.length}
         phase={phaseForLogic}
         onDismiss={handleCoachDismiss}
+        onAdvance={handleCoachAdvance}
       />
 
       {/* Ended overlay (banner + modal) */}

--- a/src/features/threeWheel/components/FirstRunCoach.tsx
+++ b/src/features/threeWheel/components/FirstRunCoach.tsx
@@ -15,6 +15,7 @@ type FirstRunCoachProps = {
   handCount: number;
   phase: CorePhase;
   onDismiss: () => void;
+  onAdvance: () => void;
 };
 
 type CoachGeometry = {
@@ -77,6 +78,7 @@ const FirstRunCoach: React.FC<FirstRunCoachProps> = ({
   handCount,
   phase,
   onDismiss,
+  onAdvance,
 }) => {
   const [geometry, setGeometry] = useState<CoachGeometry | null>(null);
 
@@ -202,13 +204,22 @@ const FirstRunCoach: React.FC<FirstRunCoachProps> = ({
           {stageCopy.meta ? (
             <div className="mt-2 text-xs uppercase tracking-wide text-emerald-300/80">{stageCopy.meta}</div>
           ) : null}
-          <button
-            type="button"
-            onClick={onDismiss}
-            className="mt-3 inline-flex items-center justify-center rounded border border-emerald-400/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-emerald-200 transition hover:border-emerald-300 hover:text-emerald-100"
-          >
-            Skip tutorial
-          </button>
+          <div className="mt-3 flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="inline-flex items-center justify-center rounded border border-emerald-400/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-emerald-200 transition hover:border-emerald-300 hover:text-emerald-100"
+            >
+              Skip tutorial
+            </button>
+            <button
+              type="button"
+              onClick={onAdvance}
+              className="inline-flex items-center justify-center rounded bg-emerald-400/90 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-950 transition hover:bg-emerald-300"
+            >
+              Next
+            </button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a Next button alongside Skip tutorial in the first run coach overlay
- allow advancing the onboarding stage manually when the new button is pressed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d80e8dfdbc83328eb756bcdb4ca764