### PR TITLE
Respect resolve votes per side

### DIFF
--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -302,8 +302,12 @@ export function useThreeWheelGame({
     });
   }, []);
 
-  const clearResolveVotes = useCallback(() => {
+  const clearResolveVotes = useCallback((side?: LegacySide) => {
     setResolveVotes((prev) => {
+      if (side) {
+        if (!prev[side]) return prev;
+        return { ...prev, [side]: false };
+      }
       if (!prev.player && !prev.enemy) return prev;
       return { player: false, enemy: false };
     });
@@ -639,7 +643,7 @@ export function useThreeWheelGame({
         }
       });
 
-      clearResolveVotes();
+      clearResolveVotes(side);
 
       return true;
     },
@@ -681,7 +685,7 @@ export function useThreeWheelGame({
         }
       });
 
-      clearResolveVotes();
+      clearResolveVotes(side);
 
       return true;
     },


### PR DESCRIPTION
## Summary
- allow resolve vote clearing to target a specific side so reassignment only affects the acting player
- update assignment helpers to clear only that side's resolve vote while keeping round/reset flows clearing both

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d82091bbb0833292a4ac2deef1ea5b