### PR TITLE
Fix token previews for pre-reveal spells

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "tsc --project tsconfig.tests.json && node dist-tests/tests/slotVisibility.test.js && node dist-tests/tests/spellEffects.test.js && node dist-tests/tests/mirrorImageResolution.test.js && node dist-tests/tests/resolveRoundSkipAnimation.test.js"
+    "test": "tsc --project tsconfig.tests.json && node dist-tests/tests/slotVisibility.test.js && node dist-tests/tests/spellEffects.test.js && node dist-tests/tests/mirrorImageResolution.test.js && node dist-tests/tests/resolveRoundSkipAnimation.test.js && node dist-tests/tests/preRevealStatSpellResolution.test.js"
   },
   "dependencies": {
     "ably": "^2.12.0",

--- a/tests/mirrorImageResolution.test.ts
+++ b/tests/mirrorImageResolution.test.ts
@@ -26,15 +26,9 @@ const createInitialAssignments = (): AssignmentState<TestCard> => ({
   ],
 });
 
-const computeInitialTokens = (assignments: AssignmentState<TestCard>): [number, number, number] => {
-  const playerValue = assignments.player[0]?.number ?? 0;
-  const enemyValue = assignments.enemy[0]?.number ?? 0;
-  return [((playerValue + enemyValue) % SLICES + SLICES) % SLICES, 0, 0];
-};
-
 {
   let assignments = createInitialAssignments();
-  let tokens = computeInitialTokens(assignments);
+  let tokens: [number, number, number] = [0, 0, 0];
   let reserveState: ReserveState | null = { player: 0, enemy: 0 };
   let laneChillStacks: LaneChillStacks = { player: [0, 0, 0], enemy: [0, 0, 0] };
   let initiative: LegacySide = initialInitiative;
@@ -69,6 +63,7 @@ const computeInitialTokens = (assignments: AssignmentState<TestCard>): [number, 
     updateTokenVisual: (index, value) => {
       tokenVisualUpdates.push({ index, value });
     },
+    startingTokens: [...tokens] as [number, number, number],
   };
 
   applySpellEffects<TestCard>(
@@ -87,10 +82,15 @@ const computeInitialTokens = (assignments: AssignmentState<TestCard>): [number, 
   assert.equal(assignments.player[0]?.number, assignments.enemy[0]?.number);
   assert.equal(assignments.player[0]?.number, 7);
 
-  const expectedTokenValue = (7 + 7) % SLICES;
-  assert.equal(tokens[0], expectedTokenValue);
-  assert.equal(tokenUpdateCallCount, 1);
-  assert.deepEqual(tokenVisualUpdates, [{ index: 0, value: expectedTokenValue }]);
+  const expectedStep = ((assignments.player[0]?.number ?? 0) + (assignments.enemy[0]?.number ?? 0)) % SLICES;
+  const expectedTokenValue = (tokens[0] + expectedStep) % SLICES;
+  assert.equal(tokens[0], 0);
+  assert.equal(tokenUpdateCallCount, 0);
+  assert.deepEqual(tokenVisualUpdates, [
+    { index: 0, value: expectedTokenValue },
+    { index: 1, value: tokens[1] },
+    { index: 2, value: tokens[2] },
+  ]);
 
   assert.equal(reserveState?.player, 0);
   assert.equal(laneChillStacks.player[0], 0);
@@ -101,7 +101,7 @@ const computeInitialTokens = (assignments: AssignmentState<TestCard>): [number, 
 // Hex drains the opponent's reserve before reveal, flipping the ReserveSum outcome.
 {
   let assignments = createInitialAssignments();
-  let tokens: [number, number, number] = computeInitialTokens(assignments);
+  let tokens: [number, number, number] = [0, 0, 0];
   let reserveState: ReserveState | null = null;
   let laneChillStacks: LaneChillStacks = { player: [0, 0, 0], enemy: [0, 0, 0] };
   let initiative: LegacySide = initialInitiative;
@@ -147,6 +147,7 @@ const computeInitialTokens = (assignments: AssignmentState<TestCard>): [number, 
         };
       }
     },
+    startingTokens: [...tokens] as [number, number, number],
   };
 
   applySpellEffects<TestCard>(

--- a/tests/preRevealStatSpellResolution.test.ts
+++ b/tests/preRevealStatSpellResolution.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+
+import { SLICES } from "../src/game/types.js";
+import {
+  applySpellEffects,
+  type AssignmentState,
+  type ReserveState,
+  type SpellEffectApplicationContext,
+} from "../src/game/spellEngine.js";
+import type { LaneChillStacks, LegacySide } from "../src/features/threeWheel/utils/spellEffectTransforms.js";
+
+type TestCard = { id: string; name: string; number: number; tags?: string[] };
+
+const PLAYER: LegacySide = "player";
+
+const createAssignments = (): AssignmentState<TestCard> => ({
+  player: [
+    { id: "player-card", name: "Heroic", number: 5, tags: [] },
+    null,
+    null,
+  ],
+  enemy: [
+    { id: "enemy-card", name: "Brute", number: 6, tags: [] },
+    null,
+    null,
+  ],
+});
+
+{
+  let assignments = createAssignments();
+  let tokens: [number, number, number] = [3, 0, 0];
+  let reserveState: ReserveState | null = { player: 0, enemy: 0 };
+  let laneChillStacks: LaneChillStacks = { player: [0, 0, 0], enemy: [0, 0, 0] };
+  const previewUpdates: Array<{ index: number; value: number }> = [];
+  let tokenUpdateCallCount = 0;
+
+  const context: SpellEffectApplicationContext<TestCard> = {
+    assignSnapshot: assignments,
+    updateAssignments: (updater) => {
+      assignments = updater(assignments);
+    },
+    updateReserveSums: (updater) => {
+      reserveState = updater(reserveState);
+    },
+    updateTokens: (updater) => {
+      tokenUpdateCallCount += 1;
+      tokens = updater(tokens);
+    },
+    updateLaneChillStacks: (updater) => {
+      laneChillStacks = updater(laneChillStacks);
+    },
+    setInitiative: () => {},
+    appendLog: () => {},
+    initiative: PLAYER,
+    isMultiplayer: false,
+    broadcastEffects: undefined,
+    updateTokenVisual: (index, value) => {
+      previewUpdates.push({ index, value });
+    },
+    startingTokens: [...tokens] as [number, number, number],
+  };
+
+  applySpellEffects<TestCard>(
+    {
+      caster: PLAYER,
+      cardAdjustments: [
+        {
+          owner: PLAYER,
+          cardId: "player-card",
+          numberDelta: 4,
+        },
+      ],
+    },
+    context,
+  );
+
+  assert.equal(assignments.player[0]?.number, 9);
+  assert.equal(assignments.enemy[0]?.number, 6);
+  assert.equal(tokenUpdateCallCount, 0, "pre-reveal stat changes should not persist tokens");
+  assert.deepEqual(tokens, [3, 0, 0], "starting tokens remain unchanged before reveal");
+
+  const updatedPlayer = assignments.player[0]?.number ?? 0;
+  const updatedEnemy = assignments.enemy[0]?.number ?? 0;
+  const spinSteps = (updatedPlayer + updatedEnemy) % SLICES;
+  const expectedLanding = (tokens[0] + spinSteps) % SLICES;
+
+  assert.deepEqual(previewUpdates, [
+    { index: 0, value: expectedLanding },
+    { index: 1, value: tokens[1] },
+    { index: 2, value: tokens[2] },
+  ]);
+
+  const simulatedFinalTokens = [...tokens] as [number, number, number];
+  simulatedFinalTokens[0] = (simulatedFinalTokens[0] + spinSteps) % SLICES;
+  assert.equal(
+    simulatedFinalTokens[0],
+    expectedLanding,
+    "resolveRound should land on the spell-adjusted slice",
+  );
+  assert.equal(
+    simulatedFinalTokens[0],
+    previewUpdates[0]?.value ?? -1,
+    "preview matches resolved landing",
+  );
+}
+
+console.log("preReveal stat spell resolution test passed");


### PR DESCRIPTION
## Summary
- stop card and mirror spells from mutating stored wheel tokens before reveal while keeping visual previews accurate
- capture round-start tokens for re-resolve flows so post-reveal snapshots reuse the correct starting positions
- add and wire a regression test that exercises a pre-reveal stat spell to ensure the wheel lands on the expected slice

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9299be3c88332876ffee78cbc75bc