### PR TITLE
Prioritize round start tokens in analyzeRound snapshot

### DIFF
--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -797,7 +797,8 @@ export function useThreeWheelGame({
     const eReserve = localLegacySide === "enemy" ? localReserve : remoteReserve;
 
     const outcomes: WheelOutcome[] = [];
-    const tokensSnapshot = tokensRef.current ?? tokens;
+    const tokensSnapshot =
+      roundStartTokensRef.current ?? tokensRef.current ?? tokens;
 
     for (let w = 0; w < 3; w++) {
       const secList = wheelSections[w];


### PR DESCRIPTION
## Summary
- prioritize the round-start token snapshot when analyzing round outcomes so spell effects use the correct token baseline

## Testing
- npm test -- preRevealStatSpellResolution

------
https://chatgpt.com/codex/tasks/task_e_68d97fb9ac6883329639e481cddef2c7