### PR TITLE
Keep unused hand cards visible until round end

### DIFF
--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -969,11 +969,12 @@ export function useThreeWheelGame({
 
   function settleFighterAfterRound(f: Fighter, played: Card[]): Fighter {
     const playedIds = new Set(played.map((c) => c.id));
+    const leftovers = f.hand.filter((c) => !playedIds.has(c.id));
     const next: Fighter = {
       name: f.name,
       deck: [...f.deck],
-      hand: f.hand.filter((c) => !playedIds.has(c.id)),
-      discard: [...f.discard, ...played],
+      hand: [],
+      discard: [...f.discard, ...played, ...leftovers],
     };
 
     const refilled = refillTo(next, 5);

--- a/src/features/threeWheel/utils/combat.ts
+++ b/src/features/threeWheel/utils/combat.ts
@@ -46,11 +46,12 @@ export function computeReserveSum(
 
 export function settleFighterAfterRound(f: Fighter, played: Card[]): Fighter {
   const playedIds = new Set(played.map((c) => c.id));
+  const leftovers = f.hand.filter((c) => !playedIds.has(c.id));
   const next: Fighter = {
     name: f.name,
     deck: [...f.deck],
-    hand: f.hand.filter((c) => !playedIds.has(c.id)),
-    discard: [...f.discard, ...played],
+    hand: [],
+    discard: [...f.discard, ...played, ...leftovers],
   };
 
   const refilled = refillTo(next, 5);


### PR DESCRIPTION
## Summary
- ensure leftover hand cards stay visible after resolving by only discarding them when the round fully resets
- update both game hook and shared combat utility to move any remaining hand cards to the discard pile before refilling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68dfbb0454f0833292b0dce4acfb9e43