### PR TITLE
Adjust card number positioning and symbol panel styling

### DIFF
--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -130,13 +130,13 @@ export default memo(function StSCard({
       <div className="absolute inset-px rounded-[10px] bg-slate-900/85 backdrop-blur-[1px] border border-slate-700/70" />
       <div className="absolute inset-0 flex flex-col items-center justify-center">
         {isSplit(card) ? (
-          <div className="text-xl font-extrabold text-white/90 leading-none text-center">
+          <div className="mt-1 text-xl font-extrabold text-white/90 leading-none text-center">
             <div>{fmtNum(card.leftValue!)}<span className="opacity-60">|</span>{fmtNum(card.rightValue!)}</div>
           </div>
         ) : (
-          <div className="text-3xl font-extrabold text-white/90">{fmtNum(card.number as number)}</div>
+          <div className="mt-1 text-3xl font-extrabold text-white/90">{fmtNum(card.number as number)}</div>
         )}
-        <div className="pointer-events-none mt-2 flex h-8 w-12 items-center justify-center rounded-full border border-slate-700/80 bg-slate-900/70 shadow-inner">
+        <div className="pointer-events-none mt-2 flex h-8 w-12 items-center justify-center rounded-full border border-slate-700/80 bg-transparent shadow-inner">
           <ArcanaGlyph symbol={symbol} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- nudge the displayed card numbers slightly downward for both split and single-value cards
- make the oval panel behind the arcana glyph transparent while keeping the border styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfbf805abc8332b18f02a49841f2a3