### PR TITLE
Keep unused hand cards visible until round end

### DIFF
--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -621,6 +621,7 @@ export function useThreeWheelGame({
 
   const assignToWheelFor = useCallback(
     (side: LegacySide, laneIndex: number, card: Card) => {
+      if (phaseRef.current !== "choose") return false;
       if (!active[laneIndex]) return false;
 
       const lane = side === "player" ? assignRef.current.player : assignRef.current.enemy;
@@ -689,6 +690,7 @@ export function useThreeWheelGame({
 
   const clearAssignFor = useCallback(
     (side: LegacySide, laneIndex: number) => {
+      if (phaseRef.current !== "choose") return false;
       const lane = side === "player" ? assignRef.current.player : assignRef.current.enemy;
       const prev = lane[laneIndex];
       if (!prev) return false;
@@ -969,11 +971,12 @@ export function useThreeWheelGame({
 
   function settleFighterAfterRound(f: Fighter, played: Card[]): Fighter {
     const playedIds = new Set(played.map((c) => c.id));
+    const leftovers = f.hand.filter((c) => !playedIds.has(c.id));
     const next: Fighter = {
       name: f.name,
       deck: [...f.deck],
-      hand: f.hand.filter((c) => !playedIds.has(c.id)),
-      discard: [...f.discard, ...played],
+      hand: [],
+      discard: [...f.discard, ...played, ...leftovers],
     };
 
     const refilled = refillTo(next, 5);
@@ -1542,6 +1545,7 @@ export function useThreeWheelGame({
 
   const startPointerDrag = useCallback(
     (card: Card, e: ReactPointerEvent) => {
+      if (phaseRef.current !== "choose") return;
       if (e.pointerType === "mouse") return;
       e.currentTarget.setPointerCapture?.(e.pointerId);
       setSelectedCardId(card.id);

--- a/src/features/threeWheel/utils/combat.ts
+++ b/src/features/threeWheel/utils/combat.ts
@@ -46,11 +46,12 @@ export function computeReserveSum(
 
 export function settleFighterAfterRound(f: Fighter, played: Card[]): Fighter {
   const playedIds = new Set(played.map((c) => c.id));
+  const leftovers = f.hand.filter((c) => !playedIds.has(c.id));
   const next: Fighter = {
     name: f.name,
     deck: [...f.deck],
-    hand: f.hand.filter((c) => !playedIds.has(c.id)),
-    discard: [...f.discard, ...played],
+    hand: [],
+    discard: [...f.discard, ...played, ...leftovers],
   };
 
   const refilled = refillTo(next, 5);


### PR DESCRIPTION
## Summary
- ensure leftover hand cards stay visible after resolving by only discarding them when the round fully resets
- update both game hook and shared combat utility to move any remaining hand cards to the discard pile before refilling
- prevent hand cards from being reassigned once resolving has begun by ignoring assign/clear attempts outside the choose phase

## Testing
- `npm test -- --watch=false`


------
https://chatgpt.com/codex/tasks/task_e_68dfbb0454f0833292b0dce4acfb9e43