### PR TITLE
Remove pill backdrop from StS card glyph

### DIFF
--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -136,7 +136,7 @@ export default memo(function StSCard({
         ) : (
           <div className="mt-1 text-3xl font-extrabold text-white/90">{fmtNum(card.number as number)}</div>
         )}
-        <div className="pointer-events-none mt-2 flex h-8 w-12 items-center justify-center rounded-full border border-slate-700/80 bg-transparent shadow-inner">
+        <div className="pointer-events-none mt-2 flex items-center justify-center">
           <ArcanaGlyph symbol={symbol} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove the rounded pill container surrounding the primary glyph on the StS card so the SVG rests on the card background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfc401c6308332b0d2a6cbdae92bb9