### PR TITLE
Adjust glyph offset on StSCard

### DIFF
--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -140,7 +140,7 @@ export default memo(function StSCard({
           <ArcanaGlyph symbol={symbol} />
         </div>
       </div>
-      <div className="pointer-events-none absolute inset-x-0 bottom-2 flex justify-center">
+      <div className="pointer-events-none absolute inset-x-0 bottom-4 flex justify-center">
         <ArcanaGlyph symbol={symbol} />
       </div>
     </button>


### PR DESCRIPTION
## Summary
- raise the bottom arcana glyph on StSCard so it no longer overlaps the border

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfc49b67f08332b2dc936d9d2a5c3e