### PR TITLE
Implement arcana-targeted spell system and multi-target support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1233,8 +1233,11 @@ const renderWheelPanel = (i: number) => {
       </div>
     </div>
 
-    <div className="mt-1 text-[11px] leading-snug text-slate-300">
-      {spell.description}
+    <div className="mt-1 space-y-0.5 text-[11px] leading-snug text-slate-300">
+      {spell.targetSummary ? (
+        <div className="font-semibold text-slate-200">{spell.targetSummary}</div>
+      ) : null}
+      <div>{spell.description}</div>
     </div>
 
   </button>
@@ -1302,8 +1305,11 @@ const renderWheelPanel = (i: number) => {
       </div>
     </div>
 
-    <div className="mt-1 text-[11px] leading-snug text-slate-300">
-      {spell.description}
+    <div className="mt-1 space-y-0.5 text-[11px] leading-snug text-slate-300">
+      {spell.targetSummary ? (
+        <div className="font-semibold text-slate-200">{spell.targetSummary}</div>
+      ) : null}
+      <div>{spell.description}</div>
     </div>
 
   </button>

--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -1,88 +1,25 @@
 // src/components/StSCard.tsx
 import React, { memo, useMemo } from "react";
-import { Card, TagId } from "../game/types";
+import type { Arcana, Card } from "../game/types";
+import { getArcanaIcon, getCardArcana } from "../game/arcana";
 import { fmtNum, isSplit } from "../game/values";
 
-type ArcanaSymbol = "serpent" | "dagger" | "flame" | "eye";
-
-const TAG_SYMBOL_MAP: Partial<Record<TagId, ArcanaSymbol>> = {
-  oddshift: "serpent",
-  parityflip: "dagger",
-  echoreserve: "eye",
+const ARCANA_COLOR_CLASS: Record<Arcana, string> = {
+  fire: "text-orange-300",
+  blade: "text-sky-200",
+  eye: "text-violet-200",
+  moon: "text-slate-200",
+  serpent: "text-emerald-300",
 };
 
-const SYMBOL_ORDER: ArcanaSymbol[] = ["serpent", "dagger", "flame", "eye"];
-
-function symbolForCard(card: Card): ArcanaSymbol {
-  const tagged = card.tags?.find((tag) => TAG_SYMBOL_MAP[tag]);
-  if (tagged) return TAG_SYMBOL_MAP[tagged]!;
-
-  const baseValue = isSplit(card)
-    ? (card.leftValue ?? 0) + (card.rightValue ?? 0)
-    : card.number ?? 0;
-
-  const idx = Math.abs(baseValue) % SYMBOL_ORDER.length;
-  return SYMBOL_ORDER[idx];
-}
-
-function ArcanaGlyph({ symbol }: { symbol: ArcanaSymbol }) {
-  switch (symbol) {
-    case "serpent":
-      return (
-        <svg viewBox="0 0 32 32" aria-hidden className="h-6 w-6 text-emerald-300">
-          <path
-            d="M8 20c0 4 3.5 6 8 6s8-2 8-6c0-3-2.2-4.5-5.2-5.4C15.3 13.5 14 12 14 10c0-2.4 2.3-4 5-4 2.1 0 3.9.9 5 2.5"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2.2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-          <circle cx="24" cy="8" r="2" fill="currentColor" />
-        </svg>
-      );
-    case "dagger":
-      return (
-        <svg viewBox="0 0 32 32" aria-hidden className="h-6 w-6 text-sky-200">
-          <path
-            d="M16 4l-3 7 3 14 3-14-3-7z"
-            fill="currentColor"
-          />
-          <rect x="13" y="23" width="6" height="5" rx="1.5" className="fill-slate-200" />
-          <path d="M12 11h8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-        </svg>
-      );
-    case "flame":
-      return (
-        <svg viewBox="0 0 32 32" aria-hidden className="h-6 w-6 text-orange-300">
-          <path
-            d="M18 4c0 4-4 5-4 9 0 2 1.4 3.6 1 6-.4 2.6-2.5 4-4 4-2.7 0-5-2.4-5-6 0-5 3.6-7.7 7.2-10.4C15.9 4.8 17 3 17 2c1.2 1.1 1 2.6 1 2z"
-            fill="currentColor"
-          />
-          <path
-            d="M21 10c4.6 3.1 6 6.6 6 10 0 4.4-3.3 8-8.5 8-3.3 0-6.5-2.4-6.5-6 0-2.7 1.9-4.4 4.5-5 1.7-.4 3.5-1.4 4.5-3z"
-            fill="currentColor"
-            opacity="0.65"
-          />
-        </svg>
-      );
-    case "eye":
-    default:
-      return (
-        <svg viewBox="0 0 32 32" aria-hidden className="h-6 w-6 text-violet-200">
-          <path
-            d="M4 16s4.5-8 12-8 12 8 12 8-4.5 8-12 8-12-8-12-8z"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-          <circle cx="16" cy="16" r="4" fill="currentColor" />
-          <circle cx="16" cy="16" r="2" className="fill-slate-900" />
-        </svg>
-      );
-  }
+function ArcanaGlyph({ arcana }: { arcana: Arcana }) {
+  const icon = getArcanaIcon(arcana);
+  const color = ARCANA_COLOR_CLASS[arcana] ?? "text-slate-200";
+  return (
+    <span aria-hidden className={`text-2xl leading-none ${color}`}>
+      {icon}
+    </span>
+  );
 }
 
 export default memo(function StSCard({
@@ -111,7 +48,7 @@ export default memo(function StSCard({
   spellTargetable?: boolean;
 }) {
   const dims = size === "lg" ? { w: 120, h: 160 } : size === "md" ? { w: 92, h: 128 } : { w: 72, h: 96 };
-  const symbol = useMemo(() => symbolForCard(card), [card]);
+  const arcana = useMemo(() => getCardArcana(card), [card]);
 
   return (
     <button
@@ -137,7 +74,7 @@ export default memo(function StSCard({
           <div className="mt+8 text-3xl font-extrabold text-white/90">{fmtNum(card.number as number)}</div>
         )}
         <div className="pointer-events-none mt-0 flex items-center justify-center">
-          <ArcanaGlyph symbol={symbol} />
+          <ArcanaGlyph arcana={arcana} />
         </div>
       </div>
     </button>

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -3,11 +3,16 @@ import CanvasWheel, { WheelHandle } from "../../../components/CanvasWheel";
 import StSCard from "../../../components/StSCard";
 import type { Card, Fighter, Phase, Section } from "../../../game/types";
 import {
-  spellTargetRequiresManualSelection,
   type SpellDefinition,
   type SpellTargetInstance,
   type SpellTargetOwnership,
 } from "../../../game/spellEngine";
+import {
+  getSpellTargetStage,
+  spellTargetStageRequiresManualSelection,
+  type SpellTargetLocation,
+} from "../../../game/spells";
+import { getCardArcana, matchesArcana } from "../../../game/arcana";
 import {
   isChooseLikePhase,
   shouldShowSlotCard,
@@ -59,9 +64,15 @@ export interface WheelPanelProps {
   pendingSpell: {
     side: LegacySide;
     spell: SpellDefinition;
-    target: SpellTargetInstance | null;
+    targets: SpellTargetInstance[];
+    currentStage: number;
   } | null;
-  onSpellTargetSelect?: (selection: { side: LegacySide; lane: number | null; cardId: string }) => void;
+  onSpellTargetSelect?: (selection: {
+    side: LegacySide;
+    lane: number | null;
+    card: Card;
+    location: SpellTargetLocation;
+  }) => void;
   onWheelTargetSelect?: (wheelIndex: number) => void;
   isAwaitingSpellTarget: boolean;
   variant?: "standalone" | "grouped";
@@ -127,22 +138,20 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
   const playerPenalty = reservePenalties.player;
   const enemyPenalty = reservePenalties.enemy;
 
-  const awaitingManualTarget =
-    isAwaitingSpellTarget &&
-    pendingSpell &&
-    spellTargetRequiresManualSelection(pendingSpell.spell.target) &&
-    !pendingSpell.target;
+  const activeStage = pendingSpell ? getSpellTargetStage(pendingSpell.spell.target, pendingSpell.currentStage) : null;
 
-  const awaitingCardTarget =
-    awaitingManualTarget && pendingSpell?.spell.target.type === "card";
+  const awaitingManualTarget = Boolean(
+    isAwaitingSpellTarget && pendingSpell && activeStage && spellTargetStageRequiresManualSelection(activeStage),
+  );
 
-  const awaitingWheelTarget =
-    awaitingManualTarget && pendingSpell?.spell.target.type === "wheel";
+  const awaitingCardTarget = awaitingManualTarget && activeStage?.type === "card";
+
+  const awaitingWheelTarget = awaitingManualTarget && activeStage?.type === "wheel";
 
   const awaitingSpellTarget = awaitingManualTarget;
 
-  const pendingOwnership: SpellTargetOwnership | null = awaitingCardTarget
-    ? pendingSpell!.spell.target.ownership
+  const pendingOwnership: SpellTargetOwnership | null = awaitingCardTarget && activeStage?.type === "card"
+    ? activeStage.ownership
     : null;
 
   const leftSlot = { side: "player" as const, card: playerCard, name: namesByLegacy.player };
@@ -167,15 +176,35 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
       : "enemy"
     : null;
 
+  const stageLocation = activeStage?.type === "card" ? activeStage.location ?? "board" : null;
+  const stageArcana = activeStage?.type === "card" ? activeStage.arcana : undefined;
+  const previousTarget = pendingSpell?.targets[pendingSpell.targets.length - 1];
+
+  const adjacencyAllows = (slotOwnership: SpellTargetOwnership | null, laneIndex: number): boolean => {
+    if (!activeStage?.adjacentToPrevious) return true;
+    if (!previousTarget || previousTarget.type !== "card") return false;
+    if (typeof previousTarget.lane !== "number") return false;
+    if (!slotOwnership) return false;
+    if (typeof laneIndex !== "number") return false;
+    if (activeStage.ownership !== "any" && previousTarget.owner !== slotOwnership) return false;
+    return Math.abs(previousTarget.lane - laneIndex) === 1;
+  };
+
   const leftSlotTargetable =
     awaitingCardTarget &&
     !!leftSlot.card &&
-    (pendingOwnership === "any" || pendingOwnership === leftSlotOwnership);
+    (pendingOwnership === "any" || pendingOwnership === leftSlotOwnership) &&
+    (stageLocation === "any" || stageLocation === "board") &&
+    matchesArcana(getCardArcana(leftSlot.card), stageArcana) &&
+    adjacencyAllows(leftSlotOwnership, index);
 
   const rightSlotTargetable =
     awaitingCardTarget &&
     !!rightSlot.card &&
-    (pendingOwnership === "any" || pendingOwnership === rightSlotOwnership);
+    (pendingOwnership === "any" || pendingOwnership === rightSlotOwnership) &&
+    (stageLocation === "any" || stageLocation === "board") &&
+    matchesArcana(getCardArcana(rightSlot.card), stageArcana) &&
+    adjacencyAllows(rightSlotOwnership, index);
 
   const isPhaseChooseLike = isChooseLikePhase(phase);
 
@@ -201,11 +230,18 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
       slotTargetable: rightSlotTargetable,
     }) || (revealOpposingCardDuringMirror && rightSlot.side !== localLegacySide);
 
-  const wheelScope = pendingSpell?.spell.target.type === "wheel" ? pendingSpell.spell.target.scope : null;
+  const wheelScope = activeStage?.type === "wheel" ? activeStage.scope : null;
+  const wheelRequiresArcana = activeStage?.type === "wheel" ? activeStage.requiresArcana : undefined;
+  const wheelHasRequiredArcana = (): boolean => {
+    if (!wheelRequiresArcana) return true;
+    const cards = [assign.player[index], assign.enemy[index]].filter(Boolean) as Card[];
+    return cards.some((card) => matchesArcana(getCardArcana(card), wheelRequiresArcana));
+  };
   const wheelTargetable =
     awaitingWheelTarget &&
     pendingSpell?.side === localLegacySide &&
-    (wheelScope === "any" || (wheelScope === "current" && isWheelActive));
+    (wheelScope === "any" || (wheelScope === "current" && isWheelActive)) &&
+    wheelHasRequiredArcana();
 
   const renderSlotCard = (slot: typeof leftSlot, isSlotSelected: boolean) => {
     if (!slot.card) return null;
@@ -232,7 +268,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
 
     const handlePick = () => {
       if (isSlotTargetable && slot.card) {
-        onSpellTargetSelect?.({ side: slot.side, lane: index, cardId: slot.card.id });
+        onSpellTargetSelect?.({ side: slot.side, lane: index, card: slot.card, location: "board" });
         return;
       }
       if (!canInteractNormally) return;
@@ -401,7 +437,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
               (ownership === "ally" && isAlly) ||
               (ownership === "enemy" && !isAlly)
             ) {
-              onSpellTargetSelect?.({ side: leftSlot.side, lane: index, cardId: card.id });
+              onSpellTargetSelect?.({ side: leftSlot.side, lane: index, card, location: "board" });
               return;
             }
           }
@@ -512,7 +548,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
               (ownership === "ally" && isAlly) ||
               (ownership === "enemy" && !isAlly)
             ) {
-              onSpellTargetSelect?.({ side: rightSlot.side, lane: index, cardId: card.id });
+              onSpellTargetSelect?.({ side: rightSlot.side, lane: index, card, location: "board" });
               return;
             }
           }

--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -223,7 +223,15 @@ export function useThreeWheelGame({
   const chanRef = useRef<AblyChannel | null>(null);
 
   const [player, setPlayer] = useState<Fighter>(() => makeFighter("Wanderer"));
+  const playerRef = useRef(player);
+  useEffect(() => {
+    playerRef.current = player;
+  }, [player]);
   const [enemy, setEnemy] = useState<Fighter>(() => makeFighter("Shade Bandit"));
+  const enemyRef = useRef(enemy);
+  useEffect(() => {
+    enemyRef.current = enemy;
+  }, [enemy]);
   const [initiative, setInitiative] = useState<LegacySide>(() =>
     hostId ? hostLegacySide : localLegacySide
   );
@@ -930,6 +938,21 @@ export function useThreeWheelGame({
             roundStartTokensRef.current = nextTokens;
             snapshotTokens = nextTokens;
             tokensAdjusted = true;
+          },
+          updateFighter: (side, updater) => {
+            if (side === "player") {
+              setPlayer((prev) => {
+                const next = updater(prev);
+                playerRef.current = next;
+                return next;
+              });
+            } else {
+              setEnemy((prev) => {
+                const next = updater(prev);
+                enemyRef.current = next;
+                return next;
+              });
+            }
           },
         },
         options,

--- a/src/game/arcana.ts
+++ b/src/game/arcana.ts
@@ -1,0 +1,64 @@
+import type { Card, Arcana, TagId } from "./types.js";
+import { isSplit } from "./values.js";
+
+export const ARCANA_EMOJI: Record<Arcana, string> = {
+  fire: "🔥",
+  blade: "🗡️",
+  eye: "👁️",
+  moon: "🌒",
+  serpent: "🐍",
+};
+
+const TAG_TO_ARCANA: Partial<Record<TagId, Arcana>> = {
+  oddshift: "serpent",
+  parityflip: "blade",
+  echoreserve: "eye",
+};
+
+const ARCANA_ORDER: Arcana[] = ["fire", "blade", "eye", "moon", "serpent"];
+
+function inferArcanaFromValue(value: number): Arcana {
+  const normalized = Number.isFinite(value) ? Math.abs(Math.round(value)) : 0;
+  const index = normalized % ARCANA_ORDER.length;
+  return ARCANA_ORDER[index] ?? "fire";
+}
+
+export function deriveArcanaForCard(card: Card): Arcana {
+  if (card.arcana && ARCANA_ORDER.includes(card.arcana)) {
+    return card.arcana;
+  }
+
+  const tagged = card.tags?.find((tag) => TAG_TO_ARCANA[tag]);
+  if (tagged) {
+    return TAG_TO_ARCANA[tagged] ?? "fire";
+  }
+
+  const baseValue = isSplit(card)
+    ? (card.leftValue ?? 0) + (card.rightValue ?? 0)
+    : card.number ?? 0;
+
+  return inferArcanaFromValue(baseValue);
+}
+
+export function getCardArcana(card: Card): Arcana {
+  return deriveArcanaForCard(card);
+}
+
+export function getArcanaIcon(arcana: Arcana): string {
+  return ARCANA_EMOJI[arcana];
+}
+
+export function matchesArcana(arcana: Arcana | undefined, requirement?: Arcana | Arcana[]): boolean {
+  if (!requirement) return true;
+  if (!arcana) return false;
+  if (Array.isArray(requirement)) {
+    return requirement.includes(arcana);
+  }
+  return arcana === requirement;
+}
+
+export function arcanaListToIcons(requirement?: Arcana | Arcana[]): string[] {
+  if (!requirement) return [];
+  const list = Array.isArray(requirement) ? requirement : [requirement];
+  return list.map((arcana) => ARCANA_EMOJI[arcana]);
+}

--- a/src/game/archetypes.ts
+++ b/src/game/archetypes.ts
@@ -15,21 +15,21 @@ const definitions: Record<ArchetypeId, ArchetypeDefinition> = {
     name: "Shade Bandit",
     description:
       "A cunning rogue who manipulates momentum with tricks and stolen reserves.",
-    spellIds: ["hex", "mirrorImage", "iceShard"],
+    spellIds: ["hex", "mirrorImage", "iceShard", "suddenStrike", "crosscut", "leech"],
   },
   sorcerer: {
     id: "sorcerer",
     name: "Chronomancer",
     description:
       "A master of temporal magic who bends slices and values to their will.",
-    spellIds: ["fireball", "arcaneShift", "timeTwist"],
+    spellIds: ["fireball", "arcaneShift", "timeTwist", "kindle", "offering", "phantom"],
   },
   beast: {
     id: "beast",
     name: "Wildshifter",
     description:
       "A primal force that overwhelms foes with ferocity and relentless pressure.",
-    spellIds: ["fireball", "hex", "iceShard"],
+    spellIds: ["fireball", "hex", "iceShard", "kindle", "leech", "phantom"],
   },
 };
 

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -27,6 +27,8 @@ export type Players = Record<Side, PlayerCore>;
 
 export type TagId = "oddshift" | "parityflip" | "echoreserve";
 
+export type Arcana = "fire" | "blade" | "eye" | "moon" | "serpent";
+
 export type CardType = "normal" | "split";
 
 export type Card = {
@@ -37,6 +39,7 @@ export type Card = {
   leftValue?: number;   // when type === "split"
   rightValue?: number;  // when type === "split"
   tags: TagId[];
+  arcana?: Arcana;
 };
 
 export type VC =

--- a/src/player/profileStore.tsx
+++ b/src/player/profileStore.tsx
@@ -2,6 +2,7 @@
 // to match your existing game types/functions.
 
 import { shuffle } from "../game/math";
+import { deriveArcanaForCard } from "../game/arcana";
 import type { Card, Fighter } from "../game/types";
 import { uid } from "../utils/uid";
 
@@ -442,13 +443,16 @@ function cardFromId(cardId: string): Card {
   else if (mNeg) num = parseInt(mNeg[1], 10);
   else if (mNum) num = parseInt(mNum[1], 10);
 
-  return {
+  const card: Card = {
     id: nextCardId(),
     name: `${num}`,
     type: "normal",
     number: num,
     tags: [],
   };
+
+  card.arcana = deriveArcanaForCard(card);
+  return card;
 }
 
 // ====== Build a runtime deck (Card[]) from the ACTIVE profile deck ======
@@ -471,7 +475,7 @@ export function starterDeck(): Card[] {
     type: "normal",
     number: n,
     tags: [],
-  }));
+  })).map((card) => ({ ...card, arcana: deriveArcanaForCard(card) }));
   return shuffle(base);
 }
 

--- a/tests/mirrorImageResolution.test.ts
+++ b/tests/mirrorImageResolution.test.ts
@@ -64,6 +64,7 @@ const createInitialAssignments = (): AssignmentState<TestCard> => ({
       tokenVisualUpdates.push({ index, value });
     },
     startingTokens: [...tokens] as [number, number, number],
+    updateFighter: () => {},
   };
 
   applySpellEffects<TestCard>(
@@ -148,6 +149,7 @@ const createInitialAssignments = (): AssignmentState<TestCard> => ({
       }
     },
     startingTokens: [...tokens] as [number, number, number],
+    updateFighter: () => {},
   };
 
   applySpellEffects<TestCard>(

--- a/tests/preRevealStatSpellResolution.test.ts
+++ b/tests/preRevealStatSpellResolution.test.ts
@@ -58,6 +58,7 @@ const createAssignments = (): AssignmentState<TestCard> => ({
       previewUpdates.push({ index, value });
     },
     startingTokens: [...tokens] as [number, number, number],
+    updateFighter: () => {},
   };
 
   applySpellEffects<TestCard>(

--- a/tests/spellEffects.test.ts
+++ b/tests/spellEffects.test.ts
@@ -7,14 +7,24 @@ import {
   type LegacySide,
 } from "../src/features/threeWheel/utils/spellEffectTransforms.js";
 import { collectRuntimeSpellEffects } from "../src/features/threeWheel/utils/spellEffectTransforms.js";
-import type { Card } from "../src/game/types.js";
+import {
+  applySpellEffects,
+  type AssignmentState,
+  type SpellEffectPayload,
+} from "../src/game/spellEngine.js";
+import type { Card, Fighter } from "../src/game/types.js";
 
 const opponentOf = (side: LegacySide): LegacySide => (side === "player" ? "enemy" : "player");
 
 // Fireball reduces card number via payload adjustments.
 {
   const runtimeState = {
-    lastFireballTarget: { type: "card", cardId: "enemy-card", owner: "enemy" },
+    cardAdjustments: [
+      {
+        target: { type: "card", cardId: "enemy-card", owner: "enemy" },
+        numberDelta: -2,
+      },
+    ],
   } as const;
   const caster: LegacySide = "player";
   const summary = collectRuntimeSpellEffects(runtimeState, caster);
@@ -73,6 +83,110 @@ const opponentOf = (side: LegacySide): LegacySide => (side === "player" ? "enemy
   assert.equal(summary.initiative, caster);
   assert(summary.delayedEffects && summary.delayedEffects.length === 1);
   assert.equal(summary.delayedEffects![0], "Future surge charged.");
+}
+
+// applySpellEffects mutates board, hand, and initiative based on payload fields.
+{
+  const playerBoard: [Card, Card, Card] = [
+    { id: "p0", name: "Striker", number: 3, tags: [] },
+    { id: "p1", name: "Oracle", number: 4, tags: [] },
+    { id: "p2", name: "Wisp", number: 2, tags: [] },
+  ];
+  const enemyBoard: [Card, Card, Card | null] = [
+    { id: "e0", name: "Bandit", number: 5, tags: [] },
+    { id: "e1", name: "Ghoul", number: 3, tags: [] },
+    null,
+  ];
+  const assignSnapshot: AssignmentState<Card> = {
+    player: playerBoard,
+    enemy: enemyBoard,
+  };
+  let assignments: AssignmentState<Card> = {
+    player: [...playerBoard],
+    enemy: [...enemyBoard],
+  };
+  let tokens: [number, number, number] = [0, 0, 0];
+  let reserveSums: { player: number; enemy: number } | null = { player: 5, enemy: 5 };
+  let chillStacks: LaneChillStacks = { player: [0, 0, 0], enemy: [0, 0, 0] };
+  let initiative: LegacySide = "enemy";
+  const log: string[] = [];
+  let playerFighter: Fighter = {
+    name: "Caster",
+    deck: [],
+    hand: [
+      { id: "ph1", name: "Spark", number: 1, tags: [] },
+      { id: "ph2", name: "Guard", number: 5, tags: [] },
+    ],
+    discard: [],
+  };
+  let enemyFighter: Fighter = {
+    name: "Target",
+    deck: [],
+    hand: [{ id: "eh1", name: "Shade", number: 4, tags: [] }],
+    discard: [],
+  };
+
+  const payload: SpellEffectPayload = {
+    caster: "player",
+    cardAdjustments: [
+      { owner: "player", cardId: "p1", numberDelta: 2 },
+      { owner: "enemy", cardId: "e1", numberDelta: -1 },
+    ],
+    handAdjustments: [{ side: "player", cardId: "ph1", numberDelta: 2 }],
+    handDiscards: [{ side: "enemy", cardId: "eh1" }],
+    positionSwaps: [{ side: "player", laneA: 0, laneB: 2 }],
+    initiativeChallenges: [{ side: "player", lane: 1, cardId: "p1", mode: "higher" }],
+    logMessages: ["Spell resolved."],
+  };
+
+  applySpellEffects<Card>(payload, {
+    assignSnapshot,
+    updateAssignments: (updater) => {
+      assignments = updater(assignments);
+    },
+    updateReserveSums: (updater) => {
+      reserveSums = updater(reserveSums);
+    },
+    updateTokens: (updater) => {
+      tokens = updater(tokens);
+      return tokens;
+    },
+    updateLaneChillStacks: (updater) => {
+      chillStacks = updater(chillStacks);
+    },
+    setInitiative: (side) => {
+      initiative = side;
+    },
+    appendLog: (entry) => {
+      log.push(entry);
+    },
+    initiative,
+    isMultiplayer: false,
+    updateFighter: (side, updater) => {
+      if (side === "player") {
+        playerFighter = updater(playerFighter);
+      } else {
+        enemyFighter = updater(enemyFighter);
+      }
+    },
+  });
+
+  assert.notEqual(assignments, assignSnapshot);
+  assert.equal(assignments.player[0]?.id, "p2");
+  assert.equal(assignments.player[2]?.id, "p0");
+  assert.equal((assignments.player[1] as Card).number, 6);
+  assert.equal((assignments.enemy[1] as Card).number, 2);
+  const adjustedHand = playerFighter.hand.find((card) => card.id === "ph1");
+  assert(adjustedHand);
+  assert.equal(adjustedHand!.number, 3);
+  assert.equal(enemyFighter.hand.length, 0);
+  assert.equal(enemyFighter.discard.length, 1);
+  assert.equal(enemyFighter.discard[0]!.id, "eh1");
+  assert.equal(initiative, "player");
+  assert(log.includes("Spell resolved."));
+  assert.deepEqual(tokens, [0, 0, 0]);
+  assert.deepEqual(reserveSums, { player: 5, enemy: 5 });
+  assert.deepEqual(chillStacks, { player: [0, 0, 0], enemy: [0, 0, 0] });
 }
 
 console.log("spellEffects tests passed");


### PR DESCRIPTION
## Summary
- add arcana derivation utilities and surface arcana requirements across spell targeting flows in the UI
- extend the spell engine to emit and apply new hand adjustments, discards, swaps, and initiative challenges for multi-stage spells
- expand the spell roster with arcana-focused abilities and update archetype spellbooks, plus strengthen automated tests for spell effects

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfc8d3346c8332a2638ab93ea9eb78