### PR TITLE
Revamp grimoire configuration and spell flow

### DIFF
--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -45,7 +45,6 @@ export interface WheelPanelProps {
   setSelectedCardId: (value: string | null) => void;
   localLegacySide: LegacySide;
   phase: Phase;
-  archetypeGateOpen: boolean;
   setDragCardId: (value: string | null) => void;
   dragCardId: string | null;
   setDragOverWheel: (value: number | null) => void;
@@ -107,7 +106,6 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
   setSelectedCardId,
   localLegacySide,
   phase,
-  archetypeGateOpen,
   setDragCardId,
   dragCardId,
   setDragOverWheel,
@@ -258,11 +256,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
       (pendingOwnership === "any" || pendingOwnership === slotOwnership);
 
     const canInteractNormally =
-      !awaitingSpellTarget &&
-      slot.side === localLegacySide &&
-      phase === "choose" &&
-      archetypeGateOpen &&
-      isWheelActive;
+      !awaitingSpellTarget && slot.side === localLegacySide && phase === "choose" && isWheelActive;
 
     const cardInteractable = canInteractNormally || isSlotTargetable;
 

--- a/src/game/grimoire.ts
+++ b/src/game/grimoire.ts
@@ -1,0 +1,129 @@
+import { getCardArcana } from "./arcana";
+import type { Card, Arcana } from "./types";
+import type { SpellId } from "./spells";
+
+export const GRIMOIRE_SYMBOL_ORDER: Arcana[] = [
+  "fire",
+  "blade",
+  "eye",
+  "moon",
+  "serpent",
+];
+
+export type GrimoireSymbols = Record<Arcana, number>;
+
+export const MAX_GRIMOIRE_SYMBOLS = 10;
+
+export const DEFAULT_GRIMOIRE_SYMBOLS: GrimoireSymbols = {
+  fire: 2,
+  blade: 2,
+  eye: 2,
+  moon: 2,
+  serpent: 2,
+};
+
+export type GrimoireRequirement = Partial<Record<Arcana, number>>;
+
+export const GRIMOIRE_SPELL_REQUIREMENTS: Record<SpellId, GrimoireRequirement> = {
+  fireball: { fire: 3 },
+  kindle: { fire: 2, moon: 1 },
+  hex: { serpent: 2 },
+  mirrorImage: { eye: 2, moon: 1 },
+  iceShard: { moon: 2 },
+  suddenStrike: { blade: 2 },
+  crosscut: { blade: 1, fire: 1 },
+  leech: { serpent: 1, eye: 1 },
+  arcaneShift: { eye: 3 },
+  timeTwist: { moon: 1, eye: 1, serpent: 1 },
+  offering: { fire: 1, serpent: 2 },
+  phantom: { moon: 1, blade: 1, eye: 1 },
+};
+
+const SPELL_PRIORITY: SpellId[] = [
+  "fireball",
+  "kindle",
+  "hex",
+  "mirrorImage",
+  "iceShard",
+  "suddenStrike",
+  "crosscut",
+  "leech",
+  "arcaneShift",
+  "timeTwist",
+  "offering",
+  "phantom",
+];
+
+export function createEmptySymbolMap(): GrimoireSymbols {
+  return GRIMOIRE_SYMBOL_ORDER.reduce<GrimoireSymbols>((acc, arcana) => {
+    acc[arcana] = 0;
+    return acc;
+  }, {} as GrimoireSymbols);
+}
+
+export function clampSymbols(raw: Partial<Record<Arcana, number>> | null | undefined): GrimoireSymbols {
+  const base = createEmptySymbolMap();
+  if (raw) {
+    for (const arcana of GRIMOIRE_SYMBOL_ORDER) {
+      const incoming = raw[arcana];
+      if (typeof incoming === "number" && Number.isFinite(incoming)) {
+        base[arcana] = Math.max(0, Math.floor(incoming));
+      }
+    }
+  }
+
+  let total = GRIMOIRE_SYMBOL_ORDER.reduce((sum, arcana) => sum + base[arcana], 0);
+  if (total <= MAX_GRIMOIRE_SYMBOLS) {
+    return base;
+  }
+
+  let overflow = total - MAX_GRIMOIRE_SYMBOLS;
+  for (const arcana of [...GRIMOIRE_SYMBOL_ORDER].reverse()) {
+    if (overflow <= 0) break;
+    const available = base[arcana];
+    if (available <= 0) continue;
+    const deduct = Math.min(available, overflow);
+    base[arcana] = available - deduct;
+    overflow -= deduct;
+  }
+
+  return base;
+}
+
+export function countSymbolsFromCards(cards: Card[]): GrimoireSymbols {
+  const counts = createEmptySymbolMap();
+  for (const card of cards) {
+    if (card.tags?.includes("grimoireFiller")) continue;
+    const arcana = getCardArcana(card);
+    if (arcana && arcana in counts) {
+      counts[arcana as Arcana] += 1;
+    }
+  }
+  return counts;
+}
+
+export function requirementSatisfied(symbols: GrimoireSymbols, requirement: GrimoireRequirement | undefined): boolean {
+  if (!requirement) return true;
+  for (const [arcana, needed] of Object.entries(requirement)) {
+    if (!arcana || typeof needed !== "number") continue;
+    const key = arcana as Arcana;
+    if ((symbols[key] ?? 0) < needed) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function getSpellsForSymbols(symbols: GrimoireSymbols): SpellId[] {
+  const available: SpellId[] = [];
+  for (const id of SPELL_PRIORITY) {
+    if (requirementSatisfied(symbols, GRIMOIRE_SPELL_REQUIREMENTS[id])) {
+      available.push(id);
+    }
+  }
+  return available;
+}
+
+export function symbolsTotal(symbols: GrimoireSymbols): number {
+  return GRIMOIRE_SYMBOL_ORDER.reduce((sum, arcana) => sum + (symbols[arcana] ?? 0), 0);
+}

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -25,7 +25,7 @@ export type PlayerCore = {
 };
 export type Players = Record<Side, PlayerCore>;
 
-export type TagId = "oddshift" | "parityflip" | "echoreserve";
+export type TagId = "oddshift" | "parityflip" | "echoreserve" | "grimoireFiller";
 
 export type Arcana = "fire" | "blade" | "eye" | "moon" | "serpent";
 

--- a/src/player/profileStore.tsx
+++ b/src/player/profileStore.tsx
@@ -3,7 +3,17 @@
 
 import { shuffle } from "../game/math";
 import { deriveArcanaForCard } from "../game/arcana";
-import type { Card, Fighter } from "../game/types";
+import type { Arcana, Card, Fighter } from "../game/types";
+import {
+  DEFAULT_GRIMOIRE_SYMBOLS,
+  GRIMOIRE_SYMBOL_ORDER,
+  MAX_GRIMOIRE_SYMBOLS,
+  clampSymbols as clampGrimoireSymbols,
+  getSpellsForSymbols,
+  symbolsTotal,
+  type GrimoireSymbols,
+} from "../game/grimoire";
+import type { SpellId } from "../game/spells";
 import { uid } from "../utils/uid";
 
 // ===== Local persistence types (module-scoped) =====
@@ -21,17 +31,20 @@ export type Profile = {
   winStreak: number;
 };
 export type OnboardingState = { stage: number; dismissed: string[] };
+type GrimoireState = { symbols: GrimoireSymbols };
+
 type LocalState = {
   version: number;
   profile: Profile;
   inventory: InventoryItem[];
   decks: Deck[];
   onboarding: OnboardingState;
+  grimoire: GrimoireState;
 };
 
 // ===== Storage/config =====
 const KEY = "rw:single:state";
-const VERSION = 3;
+const VERSION = 4;
 const MAX_DECK_SIZE = 10;
 const MAX_COPIES_PER_DECK = 2;
 const MAX_PROFILE_NAME_LENGTH = 24;
@@ -54,6 +67,7 @@ let memoryState: LocalState | null = null;
 // ===== Seed data (keep numbers only to match Card { type:'normal', number:n }) =====
 const SEED_INVENTORY: InventoryItem[] = [];
 const SEED_ONBOARDING: OnboardingState = { stage: 0, dismissed: [] };
+const GRIMOIRE_SEED: GrimoireState = { symbols: { ...DEFAULT_GRIMOIRE_SYMBOLS } };
 
 const SEED_DECK: Deck = {
   id: uid("deck"),
@@ -77,6 +91,7 @@ function seed(): LocalState {
     inventory: SEED_INVENTORY,
     decks: [SEED_DECK],
     onboarding: { ...SEED_ONBOARDING },
+    grimoire: { symbols: { ...GRIMOIRE_SEED.symbols } },
   };
 }
 
@@ -98,6 +113,12 @@ function ensureOnboarding(state: LocalState): OnboardingState {
   const uniqueDismissed = Array.from(new Set(normalized.dismissed));
   state.onboarding = { stage: normalized.stage, dismissed: uniqueDismissed };
   return state.onboarding;
+}
+
+function ensureGrimoire(state: LocalState): GrimoireState {
+  const symbols = clampGrimoireSymbols(state.grimoire?.symbols ?? DEFAULT_GRIMOIRE_SYMBOLS);
+  state.grimoire = { symbols };
+  return state.grimoire;
 }
 
 function normalizeDisplayName(name: string): string {
@@ -158,13 +179,28 @@ function loadStateRaw(): LocalState {
     if (onboardingBefore !== onboardingAfter) {
       didUpgrade = true;
     }
+    const grimoireBefore = JSON.stringify(s.grimoire ?? null);
+    if (!s.grimoire) {
+      s.grimoire = { symbols: { ...DEFAULT_GRIMOIRE_SYMBOLS } };
+      didUpgrade = true;
+    }
+    ensureGrimoire(s);
+    const grimoireAfter = JSON.stringify(s.grimoire);
+    if (grimoireBefore !== grimoireAfter) {
+      didUpgrade = true;
+    }
     if (s.version < 3) {
       s.version = 3;
+      didUpgrade = true;
+    }
+    if (s.version < 4) {
+      s.version = 4;
       didUpgrade = true;
     }
     if (didUpgrade) {
       saveState(s);
     }
+    ensureGrimoire(s);
     return s;
   } catch {
     const s = seed();
@@ -208,6 +244,33 @@ export function setOnboardingStage(stage: number): OnboardingState {
     saveState(state);
   }
   return { stage: onboarding.stage, dismissed: [...onboarding.dismissed] };
+}
+
+export type GrimoireProfile = {
+  symbols: GrimoireSymbols;
+  spellIds: SpellId[];
+  total: number;
+};
+
+function getGrimoireProfileFromState(state: LocalState): GrimoireProfile {
+  const grimoire = ensureGrimoire(state);
+  const symbols = { ...grimoire.symbols };
+  const spellIds = getSpellsForSymbols(symbols);
+  return { symbols, spellIds, total: symbolsTotal(symbols) };
+}
+
+export function getGrimoireSymbols(): GrimoireSymbols {
+  const state = loadStateRaw();
+  const grimoire = ensureGrimoire(state);
+  return { ...grimoire.symbols };
+}
+
+export function setGrimoireSymbols(next: GrimoireSymbols): GrimoireProfile {
+  const state = loadStateRaw();
+  const normalized = clampGrimoireSymbols(next);
+  state.grimoire = { symbols: normalized };
+  saveState(state);
+  return getGrimoireProfileFromState(state);
 }
 
 export function dismissOnboardingHint(id: string): OnboardingState {
@@ -346,11 +409,23 @@ export function recordMatchResult({ didWin }: { didWin: boolean }): MatchResultS
 }
 
 // ===== Public profile/deck management API (used by UI) =====
-export type ProfileBundle = { profile: Profile; inventory: InventoryItem[]; decks: Deck[]; active: Deck | undefined };
+export type ProfileBundle = {
+  profile: Profile;
+  inventory: InventoryItem[];
+  decks: Deck[];
+  active: Deck | undefined;
+  grimoire: GrimoireProfile;
+};
 
 export function getProfileBundle(): ProfileBundle {
   const s = loadStateRaw();
-  return { profile: s.profile, inventory: s.inventory, decks: s.decks, active: findActive(s) };
+  return {
+    profile: s.profile,
+    inventory: s.inventory,
+    decks: s.decks,
+    active: findActive(s),
+    grimoire: getGrimoireProfileFromState(s),
+  };
 }
 
 export function updateProfileDisplayName(name: string): Profile {
@@ -455,9 +530,56 @@ function cardFromId(cardId: string): Card {
   return card;
 }
 
+function buildGrimoireDeck(symbols: GrimoireSymbols): Card[] {
+  const queue: Arcana[] = [];
+  for (const arcana of GRIMOIRE_SYMBOL_ORDER) {
+    const count = symbols[arcana] ?? 0;
+    for (let i = 0; i < count; i++) {
+      queue.push(arcana);
+    }
+  }
+
+  const cards: Card[] = [];
+  const baseNumbers = Array.from({ length: MAX_DECK_SIZE }, (_, n) => n);
+  let index = 0;
+
+  for (const arcana of queue) {
+    const number = baseNumbers[index % baseNumbers.length];
+    const card: Card = {
+      id: nextCardId(),
+      name: `${number}`,
+      type: "normal",
+      number,
+      tags: [],
+      arcana,
+    };
+    cards.push(card);
+    index += 1;
+  }
+
+  while (cards.length < MAX_DECK_SIZE) {
+    const number = baseNumbers[index % baseNumbers.length];
+    const filler: Card = {
+      id: nextCardId(),
+      name: `${number}`,
+      type: "normal",
+      number,
+      tags: ["grimoireFiller"],
+    };
+    cards.push(filler);
+    index += 1;
+  }
+
+  return cards;
+}
+
 // ====== Build a runtime deck (Card[]) from the ACTIVE profile deck ======
 export function buildActiveDeckAsCards(): Card[] {
-  const { active } = getProfileBundle();
+  const { active, grimoire } = getProfileBundle();
+  const symbolDeck = grimoire?.symbols ?? DEFAULT_GRIMOIRE_SYMBOLS;
+  if (symbolsTotal(symbolDeck) > 0) {
+    return shuffle(buildGrimoireDeck(symbolDeck));
+  }
   if (!active || !active.cards?.length) return starterDeck(); // fallback
 
   const pool: Card[] = [];
@@ -469,14 +591,7 @@ export function buildActiveDeckAsCards(): Card[] {
 
 // ====== Runtime helpers (folded from your src/game/decks.ts) ======
 export function starterDeck(): Card[] {
-  const base: Card[] = Array.from({ length: 10 }, (_, n) => ({
-    id: nextCardId(),
-    name: `${n}`,
-    type: "normal",
-    number: n,
-    tags: [],
-  })).map((card) => ({ ...card, arcana: deriveArcanaForCard(card) }));
-  return shuffle(base);
+  return shuffle(buildGrimoireDeck(DEFAULT_GRIMOIRE_SYMBOLS));
 }
 
 export function drawOne(f: Fighter): Fighter {


### PR DESCRIPTION
## Summary
- add a persistent grimoire configuration with per-symbol spell requirements
- expose symbol controls and automatic spell previews on the profile page
- draw spells dynamically from the active hand during grimoire matches and remove the archetype gate

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfda4e4eb88332ba0a3050af6d6cc3