### PR TITLE
Hide card arcana glyphs outside grimoire mode

### DIFF
--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -73,7 +73,7 @@ export default memo(function StSCard({
         ) : (
           <div className="mt+10 text-3xl font-extrabold text-white/90">{fmtNum(card.number as number)}</div>
         )}
-        <div className="pointer-events-none mt-1 flex items-center justify-center">
+        <div className="pointer-events-none mt-1 flex items-center justify-center card-arcana">
           <ArcanaGlyph arcana={arcana} />
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -99,6 +99,10 @@ button[aria-label^="Card"] .text-3xl {
   color: #f5e7c4;
 }
 
+[data-spells-enabled="false"] .card-arcana {
+  display: none;
+}
+
 /* Add margin below the last wheel to prevent overlap with the player's hand */
 div.relative[aria-label^="Wheel"]:last-of-type {
   margin-bottom: 1rem;


### PR DESCRIPTION
## Summary
- add a targeted class for the card arcana glyph
- hide card symbols whenever the game indicates spells are disabled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfe0d053fc83329d42ddefdca9429d