### PR TITLE
Update Grimoire instructions to cover symbol loadouts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1054,16 +1054,20 @@ const renderWheelPanel = (i: number) => {
                   {isGrimoireMode && (
                     <div className="space-y-1">
                       <div>
-                        <span className="font-semibold">Grimoire - Casting Spells</span>
+                        <span className="font-semibold">Grimoire - Symbols &amp; Mana</span>
                       </div>
                       <div>
-                        Spells cost <span className="font-semibold">Mana</span> to cast. Your
-                        <span className="font-semibold"> Grimoire</span> can be accessed by pressing on your
-                        <span className="font-semibold"> 🔮 Mana</span>. After both players resolve and the wheels finish
-                        moving, you gain <span className="font-semibold">Mana equal to half your reserve sum</span>
-                        (rounded up). Some spells require you to select{" "}
-                        <span className="font-semibold">either a card or a wheel</span> before they resolve. Most spells
-                        are available after the Resolve phase, but some can be cast at any time.
+                        Each round your hand grants <span className="font-semibold">Arcana symbols</span> based on the loadout
+                        set on your profile. Spells appear in the Grimoire when their symbol requirements are met.
+                      </div>
+                      <div>
+                        Spend <span className="font-semibold">Mana</span> to cast those spells during the phases shown in the
+                        Grimoire. Mana is earned after Resolve equal to half of your remaining reserve (rounded up).
+                      </div>
+                      <div>
+                        Some spells ask you to pick a <span className="font-semibold">card</span> or{" "}
+                        <span className="font-semibold">wheel</span> before they resolve. Use <b>Cancel</b> if you change
+                        your mind mid-cast.
                       </div>
                     </div>
                   )}

--- a/ui/RogueWheelHub.tsx
+++ b/ui/RogueWheelHub.tsx
@@ -311,30 +311,37 @@ function HowToContent() {
 
       <div className="space-y-4">
         <h2 className="text-xl font-bold border-b border-white/10 pb-2">Grimoire Mode</h2>
-        <p>Use spells to bend a round in your favor by spending <b>Mana</b> and applying targeted effects.</p>
+        <p>
+          Configure your deck with arcana symbols to unlock spells, then spend <b>Mana</b> during a round to bend wheels in your
+          favor.
+        </p>
 
         <ol className="list-decimal pl-5 space-y-2">
-          <li><b>Open:</b> Tap <b>Grimoire</b> to view known spells and your current 🔹 <b>Mana</b>.</li>
           <li>
-            <b>Cast:</b> Choose a spell that’s <b>available this phase</b> and that you can <b>afford</b>.
-            If it needs a target, you’ll see <i>Select a target…</i>.
+            <b>Prepare:</b> On the Profile screen assign up to ten <b>Arcana symbols</b> (🔥, 🗡️, 👁️, 🌙, 🐍). Your opening hand
+            each round reflects that loadout and determines which spells you know.
+          </li>
+          <li><b>Open:</b> Tap <b>Grimoire</b> to view your symbols, known spells, and current 🔹 <b>Mana</b>.</li>
+          <li>
+            <b>Cast:</b> Choose a spell that matches the <b>current phase</b> and whose <b>symbol and mana costs</b> you meet. If
+            it needs a target, you’ll see <i>Select a target…</i>.
           </li>
           <li>
             <b>Target:</b> Click a valid <b>card</b> or <b>wheel</b> (some spells specify <i>Ally</i>, <i>Enemy</i>, or <i>Any</i>).
             Use <b>Cancel</b> to back out if needed.
           </li>
-          <li><b>Resolve:</b> The effect applies immediately and shows icons/tags on the affected slot or wheel.</li>
+          <li>
+            <b>Refresh:</b> Effects apply immediately and mark the affected slots. After Resolve you gain Mana equal to half of
+            your reserve (rounded up) and your next draw may unlock a different mix of spells.
+          </li>
         </ol>
 
         <div className="grid gap-3 rounded-xl bg-white/5 p-3 ring-1 ring-white/10">
           <div className="font-semibold">Tips</div>
           <ul className="list-disc pl-5 space-y-1">
-            <li>
-              After both players resolve a round, gain <b>Mana equal to half of your reserve sum</b> (rounded up);
-              save it for key moments or chain multiple small spells.
-            </li>
-            <li>Check spell <b>phase</b>, most work in <i>Choose</i>, some only after Resolve.</li>
-            <li>If a spell is disabled, you’re either short on Mana or it’s the wrong phase.</li>
+            <li>Adjust your symbol mix between runs to shift which archetype spells can appear.</li>
+            <li>Hands refresh symbols every round — reserve choices can influence what you draw next.</li>
+            <li>Disabled spells indicate you’re missing Mana, symbols, or you’re in the wrong phase.</li>
           </ul>
         </div>
 
@@ -349,8 +356,8 @@ function HowToContent() {
           <div className="rounded-xl bg-white/5 p-3 ring-1 ring-white/10">
             <div className="font-semibold">Mana & Availability</div>
             <p>
-              🔹 Mana is awarded after Resolve based on half of your remaining reserve (rounded up). Spells show cost
-              and whether they’re usable <i>now</i>.
+              🔹 Mana is awarded after Resolve based on half of your remaining reserve (rounded up). Spells list their symbol
+              badges and phases so you know when they’ll be usable.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- update the in-match reference panel so Grimoire instructions mention arcana symbols, mana gain, and targeting
- refresh the hub "How to Play" copy for Grimoire mode with the new symbol preparation step and revised tips

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dfe0ecc7008332b05bd277b6c8c99f