### PR TITLE
Adjust grimoire spell visibility logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "tsc --project tsconfig.tests.json && node dist-tests/tests/slotVisibility.test.js && node dist-tests/tests/spellEffects.test.js && node dist-tests/tests/mirrorImageResolution.test.js && node dist-tests/tests/resolveRoundSkipAnimation.test.js && node dist-tests/tests/preRevealStatSpellResolution.test.js"
+    "test": "tsc --project tsconfig.tests.json && node --experimental-specifier-resolution=node dist-tests/tests/slotVisibility.test.js && node --experimental-specifier-resolution=node dist-tests/tests/spellEffects.test.js && node --experimental-specifier-resolution=node dist-tests/tests/mirrorImageResolution.test.js && node --experimental-specifier-resolution=node dist-tests/tests/resolveRoundSkipAnimation.test.js && node --experimental-specifier-resolution=node dist-tests/tests/preRevealStatSpellResolution.test.js && node --experimental-specifier-resolution=node dist-tests/tests/grimoireVisibility.test.js"
   },
   "dependencies": {
     "ably": "^2.12.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ import FirstRunCoach from "./features/threeWheel/components/FirstRunCoach";
 import HUDPanels from "./features/threeWheel/components/HUDPanels";
 import VictoryOverlay from "./features/threeWheel/components/VictoryOverlay";
 import { getSpellDefinitions, type SpellDefinition, type SpellRuntimeState } from "./game/spells";
-import { countSymbolsFromCards, getSpellsForSymbols } from "./game/grimoire";
+import { countSymbolsFromCards, getVisibleSpellsForHand } from "./game/grimoire";
 import StSCard from "./components/StSCard";
 
 // ---- Local aliases/types/state helpers
@@ -351,7 +351,7 @@ export default function ThreeWheel_WinsOnly({
   const localSpellIds = useMemo(() => {
     if (!isGrimoireMode) return [] as string[];
     if (phase === "roundEnd" || phase === "ended") return [] as string[];
-    return getSpellsForSymbols(localHandSymbols);
+    return getVisibleSpellsForHand(localHandSymbols);
   }, [isGrimoireMode, phase, localHandSymbols]);
 
   const localSpellDefinitions = useMemo<SpellDefinition[]>(
@@ -1058,7 +1058,8 @@ const renderWheelPanel = (i: number) => {
                       </div>
                       <div>
                         Each round your hand grants <span className="font-semibold">Arcana symbols</span> based on the loadout
-                        set on your profile. Spells appear in the Grimoire when their symbol requirements are met.
+                        set on your profile. Spells appear in the Grimoire when your hand shows at least two of their required
+                        symbols (single-symbol spells only need that matching symbol).
                       </div>
                       <div>
                         Spend <span className="font-semibold">Mana</span> to cast those spells during the phases shown in the

--- a/src/game/grimoire.ts
+++ b/src/game/grimoire.ts
@@ -1,6 +1,6 @@
-import { getCardArcana } from "./arcana";
-import type { Card, Arcana } from "./types";
-import type { SpellId } from "./spells";
+import { getCardArcana } from "./arcana.js";
+import type { Card, Arcana } from "./types.js";
+import type { SpellId } from "./spells.js";
 
 export const GRIMOIRE_SYMBOL_ORDER: Arcana[] = [
   "fire",
@@ -122,6 +122,44 @@ export function getSpellsForSymbols(symbols: GrimoireSymbols): SpellId[] {
     }
   }
   return available;
+}
+
+export function handMeetsVisibilityRequirement(
+  handSymbols: GrimoireSymbols,
+  requirement: GrimoireRequirement | undefined,
+): boolean {
+  if (!requirement) return true;
+  const entries = Object.entries(requirement).filter(([, needed]) => typeof needed === "number" && needed > 0);
+  if (entries.length === 0) return true;
+
+  if (entries.length === 1) {
+    const [arcana] = entries[0];
+    const key = arcana as Arcana;
+    return (handSymbols[key] ?? 0) > 0;
+  }
+
+  let typesPresent = 0;
+  for (const [arcana] of entries) {
+    const key = arcana as Arcana;
+    if ((handSymbols[key] ?? 0) > 0) {
+      typesPresent += 1;
+      if (typesPresent >= 2) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+export function getVisibleSpellsForHand(handSymbols: GrimoireSymbols): SpellId[] {
+  const visible: SpellId[] = [];
+  for (const id of SPELL_PRIORITY) {
+    if (handMeetsVisibilityRequirement(handSymbols, GRIMOIRE_SPELL_REQUIREMENTS[id])) {
+      visible.push(id);
+    }
+  }
+  return visible;
 }
 
 export function symbolsTotal(symbols: GrimoireSymbols): number {

--- a/tests/grimoireVisibility.test.ts
+++ b/tests/grimoireVisibility.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+
+import {
+  GRIMOIRE_SPELL_REQUIREMENTS,
+  createEmptySymbolMap,
+  getVisibleSpellsForHand,
+  handMeetsVisibilityRequirement,
+} from "../src/game/grimoire.js";
+import type { GrimoireSymbols } from "../src/game/grimoire.js";
+
+const makeHand = (values: Partial<GrimoireSymbols>): GrimoireSymbols => {
+  const base = createEmptySymbolMap();
+  for (const [arcana, amount] of Object.entries(values)) {
+    if (!arcana || typeof amount !== "number") continue;
+    const key = arcana as keyof GrimoireSymbols;
+    base[key] = amount;
+  }
+  return base;
+};
+
+// Single-symbol spells only require that symbol to appear in hand.
+{
+  const fireOnly = makeHand({ fire: 1 });
+  assert.equal(
+    handMeetsVisibilityRequirement(fireOnly, GRIMOIRE_SPELL_REQUIREMENTS.fireball),
+    true,
+    "fireball should appear when a fire symbol is present",
+  );
+
+  const noFire = makeHand({ fire: 0 });
+  assert.equal(
+    handMeetsVisibilityRequirement(noFire, GRIMOIRE_SPELL_REQUIREMENTS.fireball),
+    false,
+    "fireball should not appear without any fire symbols",
+  );
+}
+
+// Multi-symbol spells require at least two of their required symbol types to appear.
+{
+  const fireAndMoon = makeHand({ fire: 1, moon: 1 });
+  assert.equal(
+    handMeetsVisibilityRequirement(fireAndMoon, GRIMOIRE_SPELL_REQUIREMENTS.kindle),
+    true,
+    "kindle should appear when both fire and moon symbols are present",
+  );
+
+  const fireOnly = makeHand({ fire: 1 });
+  assert.equal(
+    handMeetsVisibilityRequirement(fireOnly, GRIMOIRE_SPELL_REQUIREMENTS.kindle),
+    false,
+    "kindle should not appear when only one of its symbol types is present",
+  );
+
+  const moonOnly = makeHand({ moon: 1 });
+  assert.equal(
+    handMeetsVisibilityRequirement(moonOnly, GRIMOIRE_SPELL_REQUIREMENTS.kindle),
+    false,
+    "kindle should not appear when only moon symbols are present",
+  );
+}
+
+// Spells that require three symbol types still only need any two of those types in hand.
+{
+  const moonAndEye = makeHand({ moon: 1, eye: 1 });
+  assert.equal(
+    handMeetsVisibilityRequirement(moonAndEye, GRIMOIRE_SPELL_REQUIREMENTS.timeTwist),
+    true,
+    "timeTwist should appear with any two of its required symbol types",
+  );
+
+  const moonOnly = makeHand({ moon: 1 });
+  assert.equal(
+    handMeetsVisibilityRequirement(moonOnly, GRIMOIRE_SPELL_REQUIREMENTS.timeTwist),
+    false,
+    "timeTwist should not appear with only one of its required symbol types",
+  );
+}
+
+// getVisibleSpellsForHand should respect the visibility rules while keeping spell priority.
+{
+  const hand = makeHand({ fire: 1, moon: 1 });
+  assert.deepEqual(
+    getVisibleSpellsForHand(hand),
+    ["fireball", "kindle", "iceShard"],
+    "fire + moon hand should reveal matching single- and dual-symbol spells",
+  );
+}
+
+{
+  const eyeOnly = makeHand({ eye: 1 });
+  assert.deepEqual(
+    getVisibleSpellsForHand(eyeOnly),
+    ["arcaneShift"],
+    "single eye symbol should only reveal arcaneShift",
+  );
+}
+
+console.log("grimoire visibility tests passed");

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -10,6 +10,7 @@
   },
   "include": [
     "tests/**/*.ts",
+    "src/game/**/*.ts",
     "src/features/threeWheel/utils/slotVisibility.ts",
     "src/features/threeWheel/hooks/roundOutcomeSummary.ts",
     "src/vite-env.d.ts"


### PR DESCRIPTION
## Summary
- add runtime visibility checks so spells appear when a hand contains two required symbol types (or the lone required type)
- use the new visibility helper when populating the in-game grimoire and update its descriptive text
- extend the test suite and configuration to cover the new visibility rules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfe4d2bed48332801c9b44e1fe2df9