### PR TITLE
Scope in-game Grimoire to profile unlocks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -360,8 +360,8 @@ export default function ThreeWheel_WinsOnly({
   const localSpellIds = useMemo(() => {
     if (!isGrimoireMode) return [] as string[];
     if (phase === "roundEnd" || phase === "ended") return [] as string[];
-    return getVisibleSpellsForHand(localHandSymbols);
-  }, [isGrimoireMode, phase, localHandSymbols]);
+    return getVisibleSpellsForHand(localHandSymbols, localGrimoireSpellIds);
+  }, [isGrimoireMode, phase, localHandSymbols, localGrimoireSpellIds]);
 
   const localSpellDefinitions = useMemo<SpellDefinition[]>(
     () => getSpellDefinitions(localSpellIds),

--- a/src/game/grimoire.ts
+++ b/src/game/grimoire.ts
@@ -152,9 +152,29 @@ export function handMeetsVisibilityRequirement(
   return false;
 }
 
-export function getVisibleSpellsForHand(handSymbols: GrimoireSymbols): SpellId[] {
+export function getVisibleSpellsForHand(
+  handSymbols: GrimoireSymbols,
+  availableSpellIds?: SpellId[],
+): SpellId[] {
+  const allowedPriority = (() => {
+    if (!availableSpellIds || availableSpellIds.length === 0) {
+      return SPELL_PRIORITY;
+    }
+
+    const allowed = new Set<SpellId>(availableSpellIds);
+    const prioritized = SPELL_PRIORITY.filter((id) => allowed.has(id));
+
+    if (prioritized.length === allowed.size) {
+      return prioritized;
+    }
+
+    const extras = availableSpellIds.filter((id) => !SPELL_PRIORITY.includes(id));
+
+    return [...prioritized, ...extras];
+  })();
+
   const visible: SpellId[] = [];
-  for (const id of SPELL_PRIORITY) {
+  for (const id of allowedPriority) {
     if (handMeetsVisibilityRequirement(handSymbols, GRIMOIRE_SPELL_REQUIREMENTS[id])) {
       visible.push(id);
     }

--- a/tests/grimoireVisibility.test.ts
+++ b/tests/grimoireVisibility.test.ts
@@ -95,4 +95,15 @@ const makeHand = (values: Partial<GrimoireSymbols>): GrimoireSymbols => {
   );
 }
 
+// When a profile only knows certain spells, only those spells should populate the Grimoire.
+{
+  const unlocked = ["fireball", "hex"] as const;
+  const fullHand = makeHand({ fire: 3, serpent: 3, moon: 2 });
+  assert.deepEqual(
+    getVisibleSpellsForHand(fullHand, [...unlocked]),
+    ["fireball", "hex"],
+    "grimoire should only show spells unlocked by the profile even if others meet visibility rules",
+  );
+}
+
 console.log("grimoire visibility tests passed");


### PR DESCRIPTION
## Summary
- limit the in-game Grimoire to spells unlocked on the player profile while preserving round visibility rules
- add an optional profile-aware filter to `getVisibleSpellsForHand`
- cover the profile filtering behavior with an updated grimoire visibility test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dff6a93d04833285facee80c8c1317