### PR TITLE
Add CPU spell response AI for Grimoire mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,13 @@ import {
   computeReserveSum,
   settleFighterAfterRound,
 } from "./features/threeWheel/utils/combat";
-import { computeSpellCost, type SpellEffectPayload } from "./game/spellEngine";
+import {
+  computeSpellCost,
+  resolvePendingSpell,
+  type PendingSpellDescriptor,
+  type SpellEffectPayload,
+  type SpellTargetInstance,
+} from "./game/spellEngine";
 import { useSpellCasting } from "./game/hooks/useSpellCasting";
 
 // components
@@ -75,9 +81,16 @@ import HandDock from "./features/threeWheel/components/HandDock";
 import FirstRunCoach from "./features/threeWheel/components/FirstRunCoach";
 import HUDPanels from "./features/threeWheel/components/HUDPanels";
 import VictoryOverlay from "./features/threeWheel/components/VictoryOverlay";
-import { getSpellDefinitions, type SpellDefinition, type SpellRuntimeState } from "./game/spells";
+import {
+  getLearnedSpellsForFighter,
+  getSpellDefinitions,
+  type SpellDefinition,
+  type SpellId,
+  type SpellRuntimeState,
+} from "./game/spells";
 import { countSymbolsFromCards, getVisibleSpellsForHand } from "./game/grimoire";
 import StSCard from "./components/StSCard";
+import { chooseCpuSpellResponse, type CpuSpellDecision } from "./game/ai/grimoireCpu";
 
 // ---- Local aliases/types/state helpers
 type AblyRealtime = InstanceType<typeof Realtime>;
@@ -286,6 +299,36 @@ export default function ThreeWheel_WinsOnly({
   const effectiveGameMode = activeGameModes.length > 0 ? activeGameModes.join("+") : "classic";
   const spellRuntimeStateRef = useRef<SpellRuntimeState>({});
 
+  const [cpuResponseTick, setCpuResponseTick] = useState(0);
+
+  const applySpellEffectsWithAi = useCallback(
+    (payload: SpellEffectPayload, options?: { broadcast?: boolean }) => {
+      applySpellEffects(payload, options);
+      if (
+        !isMultiplayer &&
+        isGrimoireMode &&
+        payload.caster === localLegacySide &&
+        remoteLegacySide !== localLegacySide
+      ) {
+        setCpuResponseTick((tick) => tick + 1);
+      }
+    },
+    [
+      applySpellEffects,
+      isGrimoireMode,
+      isMultiplayer,
+      localLegacySide,
+      remoteLegacySide,
+    ],
+  );
+
+  const handleApplySpellEffects = useCallback(
+    (payload: SpellEffectPayload) => {
+      applySpellEffectsWithAi(payload);
+    },
+    [applySpellEffectsWithAi],
+  );
+
   const localGrimoireSpellIds = useMemo<SpellId[]>(() => {
     try {
       return getProfileBundle().grimoire?.spellIds ?? [];
@@ -337,7 +380,7 @@ export default function ThreeWheel_WinsOnly({
     phase: basePhase,
     localSide: localLegacySide,
     localMana,
-    applySpellEffects,
+    applySpellEffects: handleApplySpellEffects,
     setManaPools,
     runtimeStateRef: spellRuntimeStateRef,
     closeGrimoire,
@@ -356,6 +399,179 @@ export default function ThreeWheel_WinsOnly({
 
   const phaseForLogic: CorePhase = phaseBeforeSpell ?? basePhase;
   const phase: Phase = spellTargetingSide ? "spellTargeting" : basePhase;
+
+  const castCpuSpell = useCallback(
+    (decision: CpuSpellDecision) => {
+      if (isMultiplayer) return;
+      const cpuSide = remoteLegacySide;
+      if (cpuSide === localLegacySide) return;
+
+      const caster = cpuSide === "player" ? player : enemy;
+      const opponent = cpuSide === "player" ? enemy : player;
+
+      const availableMana = manaPools[cpuSide];
+      if (availableMana < decision.cost) return;
+
+      setManaPools((current) => {
+        const currentMana = current[cpuSide];
+        if (currentMana < decision.cost) return current;
+        const next = { ...current } as SideState<number>;
+        next[cpuSide] = currentMana - decision.cost;
+        return next;
+      });
+
+      let pending: PendingSpellDescriptor | null = {
+        side: cpuSide,
+        spell: decision.spell,
+        targets: [],
+        currentStage: 0,
+        spentMana: decision.cost,
+      };
+
+      let targetIndex = 0;
+
+      while (pending) {
+        const overrideTarget: SpellTargetInstance | undefined =
+          targetIndex < decision.targets.length
+            ? { ...decision.targets[targetIndex], stageIndex: pending.currentStage }
+            : undefined;
+
+        const result = resolvePendingSpell({
+          descriptor: pending,
+          caster,
+          opponent,
+          phase: phaseForLogic,
+          runtimeState: spellRuntimeStateRef.current,
+          targetOverride: overrideTarget,
+        });
+
+        if (result.outcome === "requiresTarget") {
+          if (overrideTarget) {
+            targetIndex += 1;
+            pending = result.pendingSpell;
+            continue;
+          }
+
+          setManaPools((current) => {
+            const next = { ...current } as SideState<number>;
+            next[cpuSide] = current[cpuSide] + decision.cost;
+            return next;
+          });
+          return;
+        }
+
+        if (result.outcome === "error") {
+          console.error("CPU spell failed", result.error);
+          setManaPools((current) => {
+            const next = { ...current } as SideState<number>;
+            next[cpuSide] = current[cpuSide] + decision.cost;
+            return next;
+          });
+          return;
+        }
+
+        if (result.manaRefund && result.manaRefund > 0) {
+          setManaPools((current) => {
+            const next = { ...current } as SideState<number>;
+            next[cpuSide] = current[cpuSide] + result.manaRefund!;
+            return next;
+          });
+        }
+
+        if (result.payload) {
+          applySpellEffectsWithAi(result.payload, { broadcast: false });
+        }
+
+        pending = null;
+      }
+    },
+    [
+      applySpellEffectsWithAi,
+      enemy,
+      isMultiplayer,
+      localLegacySide,
+      manaPools,
+      phaseForLogic,
+      player,
+      remoteLegacySide,
+      setManaPools,
+      spellRuntimeStateRef,
+    ],
+  );
+
+  const attemptCpuSpell = useCallback(() => {
+    if (isMultiplayer || !isGrimoireMode) return;
+    const cpuSide = remoteLegacySide;
+    if (cpuSide === localLegacySide) return;
+    if (phaseForLogic === "ended") return;
+
+    const caster = cpuSide === "player" ? player : enemy;
+    const opponent = cpuSide === "player" ? enemy : player;
+    const mana = manaPools[cpuSide];
+    if (mana <= 0) return;
+
+    const learned = getLearnedSpellsForFighter(caster);
+    if (!learned || learned.length === 0) return;
+
+    const spellbook: SpellId[] = learned.map((spell) => spell.id as SpellId);
+    if (spellbook.length === 0) return;
+
+    const handSymbols = countSymbolsFromCards(caster.hand);
+    const visibleSpellIds = getVisibleSpellsForHand(handSymbols, spellbook);
+    if (visibleSpellIds.length === 0) return;
+
+    const visibleSpells = getSpellDefinitions(visibleSpellIds);
+
+    const candidates = visibleSpells
+      .map((spell) => {
+        const allowedPhases = spell.allowedPhases ?? ["choose"];
+        if (!allowedPhases.includes(phaseForLogic)) return null;
+        const cost = computeSpellCost(spell, {
+          caster,
+          opponent,
+          phase: phaseForLogic,
+          runtimeState: spellRuntimeStateRef.current,
+        });
+        if (cost > mana) return null;
+        return { spell, cost };
+      })
+      .filter((candidate): candidate is { spell: SpellDefinition; cost: number } => Boolean(candidate));
+
+    if (candidates.length === 0) return;
+
+    const decision = chooseCpuSpellResponse({
+      casterSide: cpuSide,
+      caster,
+      opponent,
+      board: assign,
+      reserveSums,
+      initiative,
+      availableSpells: candidates,
+    });
+
+    if (!decision) return;
+
+    castCpuSpell(decision);
+  }, [
+    assign,
+    castCpuSpell,
+    enemy,
+    initiative,
+    isGrimoireMode,
+    isMultiplayer,
+    localLegacySide,
+    manaPools,
+    phaseForLogic,
+    player,
+    remoteLegacySide,
+    reserveSums,
+    spellRuntimeStateRef,
+  ]);
+
+  useEffect(() => {
+    if (cpuResponseTick === 0) return;
+    attemptCpuSpell();
+  }, [attemptCpuSpell, cpuResponseTick]);
 
   const localSpellIds = useMemo(() => {
     if (!isGrimoireMode) return [] as string[];

--- a/src/game/ai/grimoireCpu.ts
+++ b/src/game/ai/grimoireCpu.ts
@@ -1,0 +1,271 @@
+import type { Card, Fighter, LegacySide } from "../../game/types";
+import type {
+  SpellDefinition,
+  SpellTargetInstance,
+} from "../spells";
+import type { AssignmentState } from "../spellEngine";
+
+export type CpuSpellCandidate = {
+  spell: SpellDefinition;
+  cost: number;
+};
+
+export type CpuSpellDecision = CpuSpellCandidate & {
+  targets: SpellTargetInstance[];
+};
+
+type ReserveSums = { player: number; enemy: number } | null;
+
+type CpuSpellContext = {
+  casterSide: LegacySide;
+  caster: Fighter;
+  opponent: Fighter;
+  board: AssignmentState<Card>;
+  reserveSums: ReserveSums;
+  initiative: LegacySide;
+  availableSpells: CpuSpellCandidate[];
+};
+
+const opponentOf = (side: LegacySide): LegacySide =>
+  side === "player" ? "enemy" : "player";
+
+const getCardValue = (card: Card | null | undefined): number => {
+  if (!card) return 0;
+  if (typeof card.number === "number") return card.number;
+  if (typeof card.leftValue === "number") return card.leftValue;
+  if (typeof card.rightValue === "number") return card.rightValue;
+  return 0;
+};
+
+const makeBoardTarget = (
+  context: CpuSpellContext,
+  side: LegacySide,
+  lane: number,
+  card: Card,
+): SpellTargetInstance => ({
+  type: "card",
+  cardId: card.id,
+  cardName: card.name,
+  arcana: card.arcana,
+  owner: side === context.casterSide ? "ally" : "enemy",
+  lane,
+  location: "board",
+  cardValue: getCardValue(card),
+});
+
+const makeHandTarget = (
+  context: CpuSpellContext,
+  side: LegacySide,
+  card: Card,
+): SpellTargetInstance => ({
+  type: "card",
+  cardId: card.id,
+  cardName: card.name,
+  arcana: card.arcana,
+  owner: side === context.casterSide ? "ally" : "enemy",
+  lane: null,
+  location: "hand",
+  cardValue: getCardValue(card),
+});
+
+type SpellEvaluation = {
+  score: number;
+  targets: SpellTargetInstance[];
+};
+
+const evaluateFireball = (context: CpuSpellContext): SpellEvaluation | null => {
+  const foeSide = opponentOf(context.casterSide);
+  let best: SpellEvaluation | null = null;
+  context.board[foeSide].forEach((card, lane) => {
+    if (!card || card.arcana !== "fire") return;
+    const value = getCardValue(card);
+    const score = value > 0 ? value + 1.5 : 0.5;
+    if (!best || score > best.score) {
+      best = {
+        score,
+        targets: [makeBoardTarget(context, foeSide, lane, card)],
+      };
+    }
+  });
+  return best;
+};
+
+const evaluateIceShard = (context: CpuSpellContext): SpellEvaluation | null => {
+  const foeSide = opponentOf(context.casterSide);
+  let best: SpellEvaluation | null = null;
+  context.board[foeSide].forEach((card, lane) => {
+    if (!card || card.arcana !== "blade") return;
+    const value = getCardValue(card);
+    const score = value > 0 ? value + 1 : 0.75;
+    if (!best || score > best.score) {
+      best = {
+        score,
+        targets: [makeBoardTarget(context, foeSide, lane, card)],
+      };
+    }
+  });
+  return best;
+};
+
+const evaluateHex = (context: CpuSpellContext): SpellEvaluation | null => {
+  const foeSide = opponentOf(context.casterSide);
+  const reserve = context.reserveSums?.[foeSide] ?? 0;
+  let best: SpellEvaluation | null = null;
+  context.board[foeSide].forEach((card, lane) => {
+    if (!card || card.arcana !== "serpent") return;
+    const value = getCardValue(card);
+    const score = 2 + reserve * 0.5 + Math.max(0, value * 0.4);
+    if (!best || score > best.score) {
+      best = {
+        score,
+        targets: [makeBoardTarget(context, foeSide, lane, card)],
+      };
+    }
+  });
+  return best;
+};
+
+const evaluateKindle = (context: CpuSpellContext): SpellEvaluation | null => {
+  const selfSide = context.casterSide;
+  let best: SpellEvaluation | null = null;
+
+  context.board[selfSide].forEach((card, lane) => {
+    if (!card || card.arcana !== "fire") return;
+    const value = getCardValue(card);
+    const score = value + 2.5;
+    if (!best || score > best.score) {
+      best = {
+        score,
+        targets: [makeBoardTarget(context, selfSide, lane, card)],
+      };
+    }
+  });
+
+  context.caster.hand.forEach((card) => {
+    if (!card || card.arcana !== "fire") return;
+    const value = getCardValue(card);
+    const score = value + 4;
+    if (!best || score > best.score) {
+      best = {
+        score,
+        targets: [makeHandTarget(context, selfSide, card)],
+      };
+    }
+  });
+
+  return best;
+};
+
+const evaluateMirrorImage = (
+  context: CpuSpellContext,
+): SpellEvaluation | null => {
+  const selfSide = context.casterSide;
+  const foeSide = opponentOf(selfSide);
+  let best: SpellEvaluation | null = null;
+
+  context.board[selfSide].forEach((card, lane) => {
+    if (!card || card.arcana !== "eye") return;
+    const foeCard = context.board[foeSide][lane];
+    const foeValue = getCardValue(foeCard);
+    const selfValue = getCardValue(card);
+    const improvement = foeValue - selfValue;
+    if (improvement <= 0) return;
+    const score = improvement + Math.max(0, foeValue * 0.5);
+    if (!best || score > best.score) {
+      best = {
+        score,
+        targets: [makeBoardTarget(context, selfSide, lane, card)],
+      };
+    }
+  });
+
+  return best;
+};
+
+const evaluateSuddenStrike = (
+  context: CpuSpellContext,
+): SpellEvaluation | null => {
+  if (context.initiative === context.casterSide) return null;
+  const selfSide = context.casterSide;
+  const foeSide = opponentOf(selfSide);
+  let best: SpellEvaluation | null = null;
+
+  context.board[selfSide].forEach((card, lane) => {
+    if (!card || card.arcana !== "blade") return;
+    const foeCard = context.board[foeSide][lane];
+    const diff = getCardValue(card) - getCardValue(foeCard);
+    if (diff <= 0) return;
+    const score = diff + 5;
+    if (!best || score > best.score) {
+      best = {
+        score,
+        targets: [makeBoardTarget(context, selfSide, lane, card)],
+      };
+    }
+  });
+
+  return best;
+};
+
+const evaluateTimeTwist = (
+  context: CpuSpellContext,
+): SpellEvaluation | null => {
+  if (context.initiative === context.casterSide) return null;
+  const selfSide = context.casterSide;
+  let best: SpellEvaluation | null = null;
+
+  context.caster.hand.forEach((card) => {
+    if (!card) return;
+    const arcana = card.arcana;
+    if (arcana !== "eye" && arcana !== "moon") return;
+    const value = getCardValue(card);
+    const score = 8 - Math.max(0, value);
+    if (!best || score > best.score) {
+      best = {
+        score,
+        targets: [makeHandTarget(context, selfSide, card)],
+      };
+    }
+  });
+
+  return best;
+};
+
+const EVALUATORS: Record<
+  string,
+  (context: CpuSpellContext) => SpellEvaluation | null
+> = {
+  fireball: evaluateFireball,
+  iceShard: evaluateIceShard,
+  hex: evaluateHex,
+  kindle: evaluateKindle,
+  mirrorImage: evaluateMirrorImage,
+  suddenStrike: evaluateSuddenStrike,
+  timeTwist: evaluateTimeTwist,
+};
+
+export function chooseCpuSpellResponse(
+  context: CpuSpellContext,
+): CpuSpellDecision | null {
+  let bestDecision: { score: number; decision: CpuSpellDecision } | null = null;
+
+  for (const candidate of context.availableSpells) {
+    const evaluator = EVALUATORS[candidate.spell.id];
+    if (!evaluator) continue;
+    const result = evaluator(context);
+    if (!result) continue;
+    const score = result.score - candidate.cost * 0.25;
+    if (!bestDecision || score > bestDecision.score) {
+      bestDecision = {
+        score,
+        decision: {
+          spell: candidate.spell,
+          cost: candidate.cost,
+          targets: result.targets,
+        },
+      };
+    }
+  }
+
+  return bestDecision?.decision ?? null;
+}


### PR DESCRIPTION
## Summary
- add a heuristic Grimoire spell selector for the CPU in a dedicated module
- hook solo Grimoire games so the CPU spends mana to cast a response spell after the player acts

## Testing
- npm test -- --runTestsByPath tests/grimoireVisibility.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e001699d608332a9ec90c90c3eee9e