### PR TITLE
Lock grimoire spells per round

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -282,7 +282,7 @@ export default function ThreeWheel_WinsOnly({
     startPointerDrag,
     assignToWheelLocal,
     handleRevealClick,
-    handleNextClick,
+    handleNextClick: handleNextClickBase,
     handleRematchClick,
     handleExitClick,
     applySpellEffects,
@@ -357,7 +357,18 @@ export default function ThreeWheel_WinsOnly({
 
   const localHandCards = localLegacySide === "player" ? player.hand : enemy.hand;
   const localHandSymbols = useMemo(() => countSymbolsFromCards(localHandCards), [localHandCards]);
-  const lastChooseVisibleSpellIdsRef = useRef<SpellId[]>([]);
+  const [spellLock, setSpellLock] = useState<{ round: number | null; ids: SpellId[] }>({
+    round: null,
+    ids: [],
+  });
+  const clearSpellLock = useCallback(() => {
+    setSpellLock((prev) => {
+      if (prev.round === null && prev.ids.length === 0) {
+        return prev;
+      }
+      return { round: null, ids: [] };
+    });
+  }, []);
 
   const casterFighter = localLegacySide === "player" ? player : enemy;
   const opponentFighter = localLegacySide === "player" ? enemy : player;
@@ -582,44 +593,65 @@ export default function ThreeWheel_WinsOnly({
 
   useEffect(() => {
     if (!isGrimoireMode) {
-      lastChooseVisibleSpellIdsRef.current = [];
+      clearSpellLock();
       return;
     }
 
     if (phaseForLogic === "ended") {
-      lastChooseVisibleSpellIdsRef.current = [];
+      clearSpellLock();
       return;
     }
 
-    if (liveVisibleSpellIds !== null) {
-      lastChooseVisibleSpellIdsRef.current = liveVisibleSpellIds;
+    if (phaseForLogic !== "choose") {
+      return;
     }
-  }, [isGrimoireMode, phaseForLogic, liveVisibleSpellIds]);
+
+    setSpellLock((prev) => {
+      if (prev.round === round) {
+        return prev;
+      }
+      const nextIds = getVisibleSpellsForHand(localHandSymbols, localGrimoireSpellIds);
+      return { round, ids: nextIds };
+    });
+  }, [
+    clearSpellLock,
+    isGrimoireMode,
+    phaseForLogic,
+    round,
+    localHandSymbols,
+    localGrimoireSpellIds,
+  ]);
 
   const localSpellIds = useMemo(() => {
     if (!isGrimoireMode) return [] as SpellId[];
     if (phaseForLogic === "ended") return [] as SpellId[];
 
+    if (spellLock.round !== null) {
+      return spellLock.ids;
+    }
+
     if (phase === "choose" || phaseForLogic === "choose") {
-      return liveVisibleSpellIds ?? lastChooseVisibleSpellIdsRef.current;
+      return liveVisibleSpellIds ?? spellLock.ids;
     }
 
-    if (phase === "roundEnd") {
-      return lastChooseVisibleSpellIdsRef.current;
-    }
-
-    return lastChooseVisibleSpellIdsRef.current;
+    return spellLock.ids;
   }, [
     isGrimoireMode,
     phase,
     phaseForLogic,
     liveVisibleSpellIds,
+    spellLock,
   ]);
 
   const localSpellDefinitions = useMemo<SpellDefinition[]>(
     () => getSpellDefinitions(localSpellIds),
     [localSpellIds]
   );
+
+  const handleNextClick = useCallback(() => {
+    clearSpellLock();
+    handleNextClickBase();
+  }, [clearSpellLock, handleNextClickBase]);
 
   const getSpellCost = useCallback(
     (spell: SpellDefinition): number =>


### PR DESCRIPTION
## Summary
- capture the visible grimoire spell list when a new round enters the choose phase
- keep the locked spell list through resolve and clear it when the round ends or the game exits grimoire mode
- reset the spell lock when advancing to the next round so the grimoire refreshes with the new hand

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0154ae9dc8332ba42d3676fee303a