### PR TITLE
Fix hand card button nesting and add favicon link

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="/rotogo_snap_logo_2.png" />
     <title>Three Wheel Roguelike</title>
   </head>
   <body>

--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -34,6 +34,8 @@ export default memo(function StSCard({
   onPointerDown,
   className,
   spellTargetable,
+  ariaLabel,
+  ariaPressed,
 }: {
   card: Card;
   disabled?: boolean;
@@ -46,6 +48,8 @@ export default memo(function StSCard({
   onPointerDown?: React.PointerEventHandler<HTMLButtonElement>;
   className?: string;
   spellTargetable?: boolean;
+  ariaLabel?: string;
+  ariaPressed?: boolean;
 }) {
   const dims = size === "lg" ? { w: 120, h: 160 } : size === "md" ? { w: 92, h: 128 } : { w: 72, h: 96 };
   const arcana = useMemo(() => getCardArcana(card), [card]);
@@ -56,7 +60,8 @@ export default memo(function StSCard({
       disabled={disabled}
       className={`relative select-none ${disabled ? 'opacity-60' : 'hover:scale-[1.02]'} transition will-change-transform ${selected ? 'ring-2 ring-amber-400' : ''} ${className ?? ''}`.trim()}
       style={{ width: dims.w, height: dims.h }}
-      aria-label={`Card`}
+      aria-label={ariaLabel ?? `Card`}
+      aria-pressed={ariaPressed}
       draggable={draggable}
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}

--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -178,12 +178,11 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
                 transition={{ type: "spring", stiffness: 320, damping: 22 }}
                 className={`drop-shadow-xl ${isSelected ? "ring-2 ring-amber-300" : ""}`}
               >
-                <button
-                  data-hand-card
+                <StSCard
+                  card={card}
                   className="pointer-events-auto"
                   disabled={awaitingManualTarget && !cardSelectable}
-                  onClick={(e) => {
-                    e.stopPropagation();
+                  onPick={() => {
                     if (cardSelectable) {
                       const side = localLegacySide;
                       onSpellTargetSelect?.({ side, lane: null, card, location: "hand" });
@@ -223,11 +222,9 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
                     if (awaitingManualTarget) return;
                     startPointerDrag(card, e);
                   }}
-                  aria-pressed={isSelected}
-                  aria-label={`Select ${card.name}`}
-                >
-                  <StSCard card={card} />
-                </button>
+                  ariaLabel={`Select ${card.name}`}
+                  ariaPressed={isSelected}
+                />
               </motion.div>
             </div>
           );


### PR DESCRIPTION
## Summary
- allow StSCard to accept accessibility props so it can be reused directly
- replace nested hand button with StSCard usage to avoid invalid markup
- add favicon link pointing at the existing logo asset to prevent 404s

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e01866ac208332abd7fcbe426f9397