### PR TITLE
Allow rendering StSCard as a div to avoid nested buttons

### DIFF
--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -22,7 +22,22 @@ function ArcanaGlyph({ arcana }: { arcana: Arcana }) {
   );
 }
 
-export default memo(function StSCard({
+type StSCardProps = {
+  card: Card;
+  disabled?: boolean;
+  size?: "sm" | "md" | "lg";
+  selected?: boolean;
+  onPick?: () => void;
+  draggable?: boolean;
+  onDragStart?: React.DragEventHandler<HTMLDivElement | HTMLButtonElement>;
+  onDragEnd?: React.DragEventHandler<HTMLDivElement | HTMLButtonElement>;
+  onPointerDown?: React.PointerEventHandler<HTMLDivElement | HTMLButtonElement>;
+  className?: string;
+  spellTargetable?: boolean;
+  as?: "button" | "div";
+};
+
+function StSCardBase({
   card,
   disabled,
   size = "sm",
@@ -34,41 +49,27 @@ export default memo(function StSCard({
   onPointerDown,
   className,
   spellTargetable,
-}: {
-  card: Card;
-  disabled?: boolean;
-  size?: "sm" | "md" | "lg";
-  selected?: boolean;
-  onPick?: () => void;
-  draggable?: boolean;
-  onDragStart?: React.DragEventHandler<HTMLButtonElement>;
-  onDragEnd?: React.DragEventHandler<HTMLButtonElement>;
-  onPointerDown?: React.PointerEventHandler<HTMLButtonElement>;
-  className?: string;
-  spellTargetable?: boolean;
-}) {
+  as = "button",
+}: StSCardProps) {
   const dims = size === "lg" ? { w: 120, h: 160 } : size === "md" ? { w: 92, h: 128 } : { w: 72, h: 96 };
   const arcana = useMemo(() => getCardArcana(card), [card]);
 
-  return (
-    <button
-      onClick={(e) => { e.stopPropagation(); onPick?.(); }}
-      disabled={disabled}
-      className={`relative select-none ${disabled ? 'opacity-60' : 'hover:scale-[1.02]'} transition will-change-transform ${selected ? 'ring-2 ring-amber-400' : ''} ${className ?? ''}`.trim()}
-      style={{ width: dims.w, height: dims.h }}
-      aria-label={`Card`}
-      draggable={draggable}
-      onDragStart={onDragStart}
-      onDragEnd={onDragEnd}
-      onPointerDown={onPointerDown}
-      data-spell-targetable={spellTargetable ? "true" : undefined}
-    >
+  const rootClassName = `relative select-none ${
+    disabled ? "opacity-60" : "hover:scale-[1.02]"
+  } transition will-change-transform ${selected ? "ring-2 ring-amber-400" : ""} ${className ?? ""}`.trim();
+
+  const content = (
+    <>
       <div className="absolute inset-0 rounded-xl border bg-gradient-to-br from-slate-600 to-slate-800 border-slate-400"></div>
       <div className="absolute inset-px rounded-[10px] bg-slate-900/85 backdrop-blur-[1px] border border-slate-700/70" />
       <div className="absolute inset-0 flex flex-col items-center justify-center">
         {isSplit(card) ? (
           <div className="mt-1 text-xl font-extrabold text-white/90 leading-none text-center">
-            <div>{fmtNum(card.leftValue!)}<span className="opacity-60">|</span>{fmtNum(card.rightValue!)}</div>
+            <div>
+              {fmtNum(card.leftValue!)}
+              <span className="opacity-60">|</span>
+              {fmtNum(card.rightValue!)}
+            </div>
           </div>
         ) : (
           <div className="mt+10 text-3xl font-extrabold text-white/90">{fmtNum(card.number as number)}</div>
@@ -77,6 +78,43 @@ export default memo(function StSCard({
           <ArcanaGlyph arcana={arcana} />
         </div>
       </div>
+    </>
+  );
+
+  if (as === "div") {
+    return (
+      <div
+        className={rootClassName}
+        style={{ width: dims.w, height: dims.h }}
+        draggable={draggable}
+        onDragStart={onDragStart as React.DragEventHandler<HTMLDivElement>}
+        onDragEnd={onDragEnd as React.DragEventHandler<HTMLDivElement>}
+        onPointerDown={onPointerDown as React.PointerEventHandler<HTMLDivElement>}
+        data-spell-targetable={spellTargetable ? "true" : undefined}
+        role="presentation"
+      >
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={(e) => { e.stopPropagation(); onPick?.(); }}
+      disabled={disabled}
+      className={rootClassName}
+      style={{ width: dims.w, height: dims.h }}
+      aria-label={`Card`}
+      draggable={draggable}
+      onDragStart={onDragStart as React.DragEventHandler<HTMLButtonElement>}
+      onDragEnd={onDragEnd as React.DragEventHandler<HTMLButtonElement>}
+      onPointerDown={onPointerDown as React.PointerEventHandler<HTMLButtonElement>}
+      data-spell-targetable={spellTargetable ? "true" : undefined}
+      type="button"
+    >
+      {content}
     </button>
   );
-});
+}
+
+export default memo(StSCardBase);

--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -226,7 +226,7 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
                   aria-pressed={isSelected}
                   aria-label={`Select ${card.name}`}
                 >
-                  <StSCard card={card} />
+                  <StSCard as="div" card={card} />
                 </button>
               </motion.div>
             </div>
@@ -246,7 +246,7 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
           aria-hidden
         >
           <div style={{ transform: "scale(0.9)", filter: "drop-shadow(0 6px 8px rgba(0,0,0,.35))" }}>
-            <StSCard card={ptrDragCard} />
+            <StSCard as="div" card={ptrDragCard} />
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- add an optional `as` prop to `StSCard` so it can render as either a button or div while keeping visuals the same
- use the div variant in the hand dock to prevent nested button markup during hand interactions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e01c3991a88332b6653a986addf162