### PR TITLE
Remove arcana requirements from spell targeting

### DIFF
--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -17,7 +17,6 @@ import {
   spellTargetStageRequiresManualSelection,
   type SpellTargetLocation,
 } from "../../../game/spells";
-import { getCardArcana, matchesArcana } from "../../../game/arcana";
 
 interface HandDockProps {
   localLegacySide: LegacySide;
@@ -141,7 +140,6 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
   }, [wheelPanelBounds, wheelPanelWidth]);
 
   const stageLocation = activeStage?.type === "card" ? activeStage.location ?? "board" : null;
-  const stageArcana = activeStage?.type === "card" ? activeStage.arcana : undefined;
 
   return (
     <div
@@ -159,11 +157,7 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
       >
         {localFighter.hand.map((card, idx) => {
           const isSelected = selectedCardId === card.id;
-          const cardArcana = getCardArcana(card);
-          const cardSelectable =
-            awaitingCardTarget &&
-            (stageLocation === "any" || stageLocation === "hand") &&
-            matchesArcana(cardArcana, stageArcana);
+          const cardSelectable = awaitingCardTarget && (stageLocation === "any" || stageLocation === "hand");
           return (
             <div key={card.id} className="group relative pointer-events-auto" style={{ zIndex: 10 + idx }}>
               <motion.div

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -12,7 +12,6 @@ import {
   spellTargetStageRequiresManualSelection,
   type SpellTargetLocation,
 } from "../../../game/spells";
-import { getCardArcana, matchesArcana } from "../../../game/arcana";
 import {
   isChooseLikePhase,
   shouldShowSlotCard,
@@ -175,7 +174,6 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
     : null;
 
   const stageLocation = activeStage?.type === "card" ? activeStage.location ?? "board" : null;
-  const stageArcana = activeStage?.type === "card" ? activeStage.arcana : undefined;
   const previousTarget = pendingSpell?.targets[pendingSpell.targets.length - 1];
 
   const adjacencyAllows = (slotOwnership: SpellTargetOwnership | null, laneIndex: number): boolean => {
@@ -193,7 +191,6 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
     !!leftSlot.card &&
     (pendingOwnership === "any" || pendingOwnership === leftSlotOwnership) &&
     (stageLocation === "any" || stageLocation === "board") &&
-    matchesArcana(getCardArcana(leftSlot.card), stageArcana) &&
     adjacencyAllows(leftSlotOwnership, index);
 
   const rightSlotTargetable =
@@ -201,7 +198,6 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
     !!rightSlot.card &&
     (pendingOwnership === "any" || pendingOwnership === rightSlotOwnership) &&
     (stageLocation === "any" || stageLocation === "board") &&
-    matchesArcana(getCardArcana(rightSlot.card), stageArcana) &&
     adjacencyAllows(rightSlotOwnership, index);
 
   const isPhaseChooseLike = isChooseLikePhase(phase);
@@ -229,12 +225,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
     }) || (revealOpposingCardDuringMirror && rightSlot.side !== localLegacySide);
 
   const wheelScope = activeStage?.type === "wheel" ? activeStage.scope : null;
-  const wheelRequiresArcana = activeStage?.type === "wheel" ? activeStage.requiresArcana : undefined;
-  const wheelHasRequiredArcana = (): boolean => {
-    if (!wheelRequiresArcana) return true;
-    const cards = [assign.player[index], assign.enemy[index]].filter(Boolean) as Card[];
-    return cards.some((card) => matchesArcana(getCardArcana(card), wheelRequiresArcana));
-  };
+  const wheelHasRequiredArcana = (): boolean => true;
   const wheelTargetable =
     awaitingWheelTarget &&
     pendingSpell?.side === localLegacySide &&

--- a/src/game/hooks/useSpellCasting.ts
+++ b/src/game/hooks/useSpellCasting.ts
@@ -12,7 +12,7 @@ import {
 } from "../spellEngine";
 import { getSpellTargetStage, spellTargetStageRequiresManualSelection } from "../spells";
 import type { SpellTargetLocation } from "../spells";
-import { getCardArcana, matchesArcana } from "../arcana";
+import { getCardArcana } from "../arcana";
 import type { LegacySide } from "../../features/threeWheel/utils/spellEffectTransforms";
 
 type SideState<T> = Record<LegacySide, T>;
@@ -267,9 +267,6 @@ export function useSpellCasting(options: UseSpellCastingOptions): UseSpellCastin
       }
 
       const cardArcana = getCardArcana(selection.card);
-      if (!matchesArcana(cardArcana, stage.arcana)) {
-        return;
-      }
 
       if (stage.adjacentToPrevious) {
         const previous = pendingSpell.targets[pendingSpell.targets.length - 1];


### PR DESCRIPTION
## Summary
- allow spell targeting logic to skip arcana matching checks so any card can be selected
- update hand and wheel UI to no longer gate spell targeting by arcana requirements

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e029d952b48332a9c862476c2e27e3