### PR TITLE
Format all spell descriptions for multi-line rendering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,6 +74,7 @@ import { useSpellCasting } from "./game/hooks/useSpellCasting";
 
 // components
 import CanvasWheel, { type WheelHandle } from "./components/CanvasWheel";
+import { SpellDescription } from "./components/SpellDescription";
 
 import WheelPanel, { getWheelPanelLayout } from "./features/threeWheel/components/WheelPanel";
 
@@ -1249,7 +1250,7 @@ export default function ThreeWheel_WinsOnly({
     </div>
 
     <div className="mt-1 space-y-0.5 text-[11px] leading-snug text-slate-300">
-      <div>{spell.description}</div>
+      <SpellDescription description={spell.description} />
     </div>
 
   </button>
@@ -1321,7 +1322,7 @@ export default function ThreeWheel_WinsOnly({
       {spell.targetSummary ? (
         <div className="font-semibold text-slate-200">{spell.targetSummary}</div>
       ) : null}
-      <div>{spell.description}</div>
+      <SpellDescription description={spell.description} />
     </div>
 
   </button>

--- a/src/ProfilePage.tsx
+++ b/src/ProfilePage.tsx
@@ -18,6 +18,7 @@ import {
   setGrimoireSymbols,
 } from "./player/profileStore";
 import LoadingScreen from "./components/LoadingScreen";
+import { SpellDescription } from "./components/SpellDescription";
 import { ARCANA_EMOJI } from "./game/arcana";
 import { GRIMOIRE_SYMBOL_ORDER, MAX_GRIMOIRE_SYMBOLS, symbolsTotal, GRIMOIRE_SPELL_REQUIREMENTS } from "./game/grimoire";
 import type { Arcana } from "./game/types";
@@ -406,7 +407,10 @@ function renderSpellListItem(spell: SpellDefinition) {
           {spell.targetSummary}
         </div>
       ) : null}
-      <div className="mt-2 text-xs leading-relaxed text-white/70">{spell.description}</div>
+      <SpellDescription
+        className="mt-2 text-xs leading-relaxed text-white/70"
+        description={spell.description}
+      />
     </li>
   );
 }

--- a/src/components/SpellDescription.tsx
+++ b/src/components/SpellDescription.tsx
@@ -1,0 +1,23 @@
+import { forwardRef } from "react";
+import type { HTMLAttributes } from "react";
+
+export type SpellDescriptionProps = HTMLAttributes<HTMLDivElement> & {
+  description: string;
+};
+
+export const SpellDescription = forwardRef<HTMLDivElement, SpellDescriptionProps>(
+  ({ description, className, ...rest }, ref) => {
+    const lines = description.split(/\r?\n/);
+    return (
+      <div ref={ref} className={className} {...rest}>
+        {lines.map((line, index) => (
+          <span key={index} className="block">
+            {line === "" ? "\u00a0" : line}
+          </span>
+        ))}
+      </div>
+    );
+  },
+);
+
+SpellDescription.displayName = "SpellDescription";

--- a/src/features/threeWheel/components/ArchetypeModal.tsx
+++ b/src/features/threeWheel/components/ArchetypeModal.tsx
@@ -5,6 +5,7 @@ import {
   type ArchetypeId,
 } from "../../../game/archetypes";
 import { getSpellDefinitions, type SpellDefinition } from "../../../game/spells";
+import { SpellDescription } from "../../../components/SpellDescription";
 
 export type LegacySide = "player" | "enemy";
 
@@ -122,15 +123,14 @@ const ArchetypeModal: React.FC<ArchetypeModalProps> = ({
               <span className="font-semibold text-slate-100">{spell.name}</span>
             </button>
 
-            <div
+            <SpellDescription
               id={`${idPrefix}-spell-desc-${spell.id}`}
               className={`pl-4 text-[11px] leading-snug text-slate-300 transition-all duration-150 ease-out ${
                 isActive ? "max-h-32 opacity-100" : "max-h-0 overflow-hidden opacity-0"
               }`}
               aria-hidden={!isActive}
-            >
-              {spell.description}
-            </div>
+              description={spell.description}
+            />
           </li>
         );
       })}

--- a/src/game/spells.ts
+++ b/src/game/spells.ts
@@ -285,7 +285,8 @@ const SPELL_REGISTRY: Record<string, SpellDefinition> = {
   iceShard: {
     id: "iceShard",
     name: "Ice Shard",
-    description: "Freeze an enemy card’s value this round. +🗡️: That card can’t gain initiative.",
+    description: `Freeze an enemy card’s value this round.
++🗡️: That card can’t gain initiative.`,
     targetSummary: "Target: Enemy card (+optional 🗡️)",
     cost: 1,
     icon: "🗡️",
@@ -318,7 +319,8 @@ const SPELL_REGISTRY: Record<string, SpellDefinition> = {
   mirrorImage: {
     id: "mirrorImage",
     name: "Mirror Image",
-    description: "Copy the opposing card’s value. +👁️: Add the value of a 👁️ card from your reserve.",
+    description: `Copy the opposing card’s value.
++👁️: Add the value of a 👁️ card from your reserve.`,
     targetSummary: "Target: Ally card (+optional 👁️ from reserve)",
     cost: 4,
     icon: "👁️",
@@ -351,7 +353,8 @@ const SPELL_REGISTRY: Record<string, SpellDefinition> = {
   arcaneShift: {
     id: "arcaneShift",
     name: "Arcane Shift",
-    description: "Advance a wheel by 1. +🌒: Add the value of a 🌒 card.",
+    description: `Advance a wheel by 1.
++🌒: Add the value of a 🌒 card.`,
     targetSummary: "Target: Active wheel (+optional 🌒)",
     cost: 3,
     icon: "🌒",
@@ -382,7 +385,8 @@ const SPELL_REGISTRY: Record<string, SpellDefinition> = {
   hex: {
     id: "hex",
     name: "Hex",
-    description: "Drain 2 from the opponent’s reserve. +🐍: Add the value of a 🐍 card.",
+    description: `Drain 2 from the opponent’s reserve.
++🐍: Add the value of a 🐍 card.`,
     targetSummary: "Target: Enemy card (+optional 🐍)",
     cost: 4,
     icon: "🐍",
@@ -410,7 +414,8 @@ const SPELL_REGISTRY: Record<string, SpellDefinition> = {
   timeTwist: {
     id: "timeTwist",
     name: "Time Twist",
-    description: "Discard a reserve card to gain initiative. +👁️: If the card was 👁️, draw 1.",
+    description: `Discard a reserve card to gain initiative.
++👁️: If the card was 👁️, draw 1.`,
     targetSummary: "Target: Your reserve card",
     cost: 5,
     icon: "⏳",
@@ -435,7 +440,8 @@ const SPELL_REGISTRY: Record<string, SpellDefinition> = {
   kindle: {
     id: "kindle",
     name: "Kindle",
-    description: "Increase a card by 2. +🔥: Add the value of a 🔥 card.",
+    description: `Increase a card by 2.
++🔥: Add the value of a 🔥 card.`,
     targetSummary: "Target: Your card (+optional 🔥)",
     cost: 2,
     icon: "🔥",
@@ -466,7 +472,8 @@ const SPELL_REGISTRY: Record<string, SpellDefinition> = {
   suddenStrike: {
     id: "suddenStrike",
     name: "Sudden Strike",
-    description: "If the opposing card is lower, gain initiative. +🗡️: Also gain initiative on a tie.",
+    description: `If the opposing card is lower, gain initiative.
++🗡️: Also gain initiative on a tie.`,
     targetSummary: "Target: Your committed card",
     cost: 3,
     icon: "🗡️",
@@ -492,7 +499,8 @@ const SPELL_REGISTRY: Record<string, SpellDefinition> = {
   leech: {
     id: "leech",
     name: "Leech",
-    description: "Transfer value from an adjacent card to your own. +🐍: Also drain reserve equal to a 🐍 card’s value.",
+    description: `Transfer value from an adjacent card to your own.
++🐍: Also drain reserve equal to a 🐍 card’s value.`,
     targetSummary: "Targets: Your card → adjacent (+optional 🐍)",
     cost: 4,
     icon: "🐍",
@@ -529,7 +537,8 @@ const SPELL_REGISTRY: Record<string, SpellDefinition> = {
   crosscut: {
     id: "crosscut",
     name: "Crosscut",
-    description: "Reveal a reserve against an opposing card; drain their reserve by the positive difference. +🗡️: Gain initiative if you drained.",
+    description: `Reveal a reserve against an opposing card; drain their reserve by the positive difference.
++🗡️: Gain initiative if you drained.`,
     targetSummary: "Targets: Your reserve → opposing committed",
     cost: 3,
     icon: "🗡️",
@@ -562,7 +571,8 @@ const SPELL_REGISTRY: Record<string, SpellDefinition> = {
   offering: {
     id: "offering",
     name: "Offering",
-    description: "Discard a reserve to increase a card by its value. +🔥: Double it if the card was 🔥.",
+    description: `Discard a reserve to increase a card by its value.
++🔥: Double it if the card was 🔥.`,
     targetSummary: "Targets: Your committed → reserve to discard",
     cost: 4,
     icon: "🔥",
@@ -591,7 +601,8 @@ const SPELL_REGISTRY: Record<string, SpellDefinition> = {
   phantom: {
     id: "phantom",
     name: "Phantom",
-    description: "Swap two committed cards. +🌒: Swap a 🌒 committed card with one in reserve instead.",
+    description: `Swap two committed cards.
++🌒: Swap a 🌒 committed card with one in reserve instead.`,
     targetSummary: "Targets: Two committed (+optional 🌒 committed → reserve)",
     cost: 3,
     icon: "🌒",


### PR DESCRIPTION
## Summary
- update every spell description in the registry to use newline-delimited strings
- ensure optional arcana bonuses and other secondary effects render on their own line everywhere the shared SpellDescription component is used

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e12db702d0833298bbf93a794d82e6