### PR TITLE
Allow skipping optional spell targets

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -434,6 +434,7 @@ export default function ThreeWheel_WinsOnly({
     handlePendingSpellCancel,
     handleSpellTargetSelect,
     handleWheelTargetSelect,
+    handleOptionalStageSkip,
   } = useSpellCasting({
     caster: casterFighter,
     opponent: opponentFighter,
@@ -1070,13 +1071,24 @@ export default function ThreeWheel_WinsOnly({
               <div className="text-[13px] font-semibold text-slate-100">
                 Select {activeTargetStageLabel ?? "a target"} for {pendingSpell.spell.name}
               </div>
-              <button
-                type="button"
-                onClick={() => handlePendingSpellCancel(true)}
-                className="rounded border border-slate-600 px-2.5 py-1 text-[11px] text-slate-200 transition hover:border-slate-400 hover:text-white"
-              >
-                Cancel spell
-              </button>
+              <div className="flex flex-col items-end gap-1">
+                <button
+                  type="button"
+                  onClick={() => handlePendingSpellCancel(true)}
+                  className="rounded border border-slate-600 px-2.5 py-1 text-[11px] text-slate-200 transition hover:border-slate-400 hover:text-white"
+                >
+                  Cancel spell
+                </button>
+                {activeTargetStage?.optional ? (
+                  <button
+                    type="button"
+                    onClick={handleOptionalStageSkip}
+                    className="rounded border border-slate-600 px-2.5 py-1 text-[11px] text-slate-200 transition hover:border-slate-400 hover:text-white"
+                  >
+                    Skip optional target
+                  </button>
+                ) : null}
+              </div>
             </div>
             <div className="mt-2 text-[11px] leading-snug text-slate-300">
               {targetingPrompt}

--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -111,8 +111,13 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
 
   const activeStage = pendingSpell ? getSpellTargetStage(pendingSpell.spell.target, pendingSpell.currentStage) : null;
 
+  const activeStageSelection = pendingSpell?.targets?.[pendingSpell.currentStage];
+
   const awaitingManualTarget = Boolean(
-    isAwaitingSpellTarget && pendingSpell && activeStage && spellTargetStageRequiresManualSelection(activeStage),
+    isAwaitingSpellTarget &&
+      pendingSpell &&
+      activeStage &&
+      spellTargetStageRequiresManualSelection(activeStage, activeStageSelection),
   );
 
   const awaitingCardTarget = awaitingManualTarget && activeStage?.type === "card";

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -141,8 +141,13 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
 
   const activeStage = pendingSpell ? getSpellTargetStage(pendingSpell.spell.target, pendingSpell.currentStage) : null;
 
+  const activeStageSelection = pendingSpell?.targets?.[pendingSpell.currentStage];
+
   const awaitingManualTarget = Boolean(
-    isAwaitingSpellTarget && pendingSpell && activeStage && spellTargetStageRequiresManualSelection(activeStage),
+    isAwaitingSpellTarget &&
+      pendingSpell &&
+      activeStage &&
+      spellTargetStageRequiresManualSelection(activeStage, activeStageSelection),
   );
 
   const awaitingCardTarget = awaitingManualTarget && activeStage?.type === "card";

--- a/src/game/hooks/useSpellCasting.ts
+++ b/src/game/hooks/useSpellCasting.ts
@@ -40,6 +40,7 @@ export type UseSpellCastingResult = {
     selection: { side: LegacySide; lane: number | null; card: Card; location: SpellTargetLocation },
   ) => void;
   handleWheelTargetSelect: (wheelIndex: number) => void;
+  handleOptionalStageSkip: () => void;
 };
 
 const enqueueMicrotask = (task: () => void) => {
@@ -323,6 +324,12 @@ export function useSpellCasting(options: UseSpellCastingOptions): UseSpellCastin
     [handleResolvePendingSpell, isWheelActive, localSide, pendingSpell],
   );
 
+  const handleOptionalStageSkip = useCallback(() => {
+    if (!pendingSpell) return;
+    if (pendingSpell.side !== localSide) return;
+    handleResolvePendingSpell(pendingSpell);
+  }, [handleResolvePendingSpell, localSide, pendingSpell]);
+
   const awaitingSpellTarget = useMemo(() => {
     if (!pendingSpell) return false;
     const stage = getSpellTargetStage(pendingSpell.spell.target, pendingSpell.currentStage);
@@ -344,5 +351,6 @@ export function useSpellCasting(options: UseSpellCastingOptions): UseSpellCastin
     handlePendingSpellCancel,
     handleSpellTargetSelect,
     handleWheelTargetSelect,
+    handleOptionalStageSkip,
   };
 }

--- a/src/game/spellEngine.ts
+++ b/src/game/spellEngine.ts
@@ -120,9 +120,18 @@ export function resolvePendingSpell(params: ResolveSpellParams): SpellResolution
     stageIndex += 1;
   }
 
+  const overrideProvided = targetOverride !== undefined;
+
   while (stageIndex < stages.length) {
     const stage = stages[stageIndex];
-    if (spellTargetStageRequiresManualSelection(stage)) break;
+    let existingTarget = pendingTargets[stageIndex];
+
+    if (!overrideProvided && stage.optional && !existingTarget) {
+      existingTarget = { type: "none", stageIndex };
+      pendingTargets[stageIndex] = existingTarget;
+    }
+
+    if (spellTargetStageRequiresManualSelection(stage, existingTarget)) break;
     if (stage.type === "self") {
       pendingTargets[stageIndex] = { type: "self", stageIndex };
       stageIndex += 1;
@@ -130,6 +139,10 @@ export function resolvePendingSpell(params: ResolveSpellParams): SpellResolution
     }
     if (stage.type === "none") {
       pendingTargets[stageIndex] = { type: "none", stageIndex };
+      stageIndex += 1;
+      continue;
+    }
+    if (stage.optional && pendingTargets[stageIndex]?.type === "none") {
       stageIndex += 1;
       continue;
     }

--- a/src/game/spells.ts
+++ b/src/game/spells.ts
@@ -43,20 +43,27 @@ const normalizeTarget = (target: SpellTargetDefinition): SpellTargetStageDefinit
 
 export const spellTargetStageRequiresManualSelection = (
   stage: SpellTargetStageDefinition,
+  existingTarget?: SpellTargetInstance | null,
 ): boolean => {
   switch (stage.type) {
     case "card":
-      // If optional, UI may present a Skip option; still a manual selection stage.
-      return stage.automatic === true ? false : true;
+      if (stage.automatic === true) return false;
+      if (stage.optional && existingTarget && existingTarget.type === "none") {
+        return false;
+      }
+      return true;
     case "wheel":
-      return stage.optional === true ? true : true;
+      if (stage.optional && existingTarget && existingTarget.type === "none") {
+        return false;
+      }
+      return true;
     default:
       return false;
   }
 };
 
 export const spellTargetRequiresManualSelection = (target: SpellTargetDefinition): boolean => {
-  return normalizeTarget(target).some(spellTargetStageRequiresManualSelection);
+  return normalizeTarget(target).some((stage) => spellTargetStageRequiresManualSelection(stage));
 };
 
 export const getSpellTargetStage = (


### PR DESCRIPTION
## Summary
- let optional spell targeting stages be skipped without manual selection by updating targeting helpers and resolver logic
- expose a Skip control for optional spell prompts and wire it through the spell casting hook and UI overlays
- ensure card and wheel panels respect skipped optional stages when determining whether manual input is required

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17c497150833283f9ee4d76b920f6