### PR TITLE
Limit spell banner to spell log entries

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from "framer-motion";
-import { useThreeWheelGame } from "./features/threeWheel/hooks/useThreeWheelGame";
+import { useThreeWheelGame, type GameLogEntry } from "./features/threeWheel/hooks/useThreeWheelGame";
 import React, {
   useMemo,
   useRef,
@@ -358,13 +358,13 @@ export default function ThreeWheel_WinsOnly({
   const [showGrimoire, setShowGrimoire] = useState(false);
   const closeGrimoire = useCallback(() => setShowGrimoire(false), [setShowGrimoire]);
 
-  const [spellBanner, setSpellBanner] = useState<string | null>(null);
+  const [spellBannerEntry, setSpellBannerEntry] = useState<GameLogEntry | null>(null);
   const spellBannerTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const latestLogEntry = log.length > 0 ? log[0] : null;
+  const latestSpellEntry = log.find((entry) => entry.type === "spell") ?? null;
 
   useEffect(() => {
-    if (!latestLogEntry) {
-      setSpellBanner(null);
+    if (!latestSpellEntry) {
+      setSpellBannerEntry(null);
       if (spellBannerTimeoutRef.current) {
         clearTimeout(spellBannerTimeoutRef.current);
         spellBannerTimeoutRef.current = null;
@@ -372,13 +372,15 @@ export default function ThreeWheel_WinsOnly({
       return;
     }
 
-    setSpellBanner(latestLogEntry);
+    setSpellBannerEntry(latestSpellEntry);
     if (spellBannerTimeoutRef.current) {
       clearTimeout(spellBannerTimeoutRef.current);
     }
 
     const timeoutId = setTimeout(() => {
-      setSpellBanner(null);
+      setSpellBannerEntry((current) =>
+        current && current.id === latestSpellEntry.id ? null : current,
+      );
       if (spellBannerTimeoutRef.current === timeoutId) {
         spellBannerTimeoutRef.current = null;
       }
@@ -392,7 +394,7 @@ export default function ThreeWheel_WinsOnly({
         spellBannerTimeoutRef.current = null;
       }
     };
-  }, [latestLogEntry]);
+  }, [latestSpellEntry]);
 
   useEffect(() => {
     return () => {
@@ -1040,9 +1042,9 @@ export default function ThreeWheel_WinsOnly({
       data-awaiting-spell-target={isAwaitingSpellTarget ? "true" : "false"}
     >
       <AnimatePresence>
-        {spellBanner ? (
+        {spellBannerEntry ? (
           <motion.div
-            key={spellBanner}
+            key={spellBannerEntry.id}
             initial={{ opacity: 0, y: -16 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -16 }}
@@ -1057,7 +1059,7 @@ export default function ThreeWheel_WinsOnly({
                 color: hudAccentColor,
               }}
             >
-              {spellBanner}
+              {spellBannerEntry.message}
             </div>
           </motion.div>
         ) : null}

--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -76,6 +76,24 @@ type AnteState = {
   odds: Record<LegacySide, number>;
 };
 
+export type GameLogEntryType = "general" | "spell";
+
+export type GameLogEntry = {
+  id: string;
+  message: string;
+  type: GameLogEntryType;
+};
+
+let logIdCounter = 0;
+const createLogEntry = (
+  message: string,
+  type: GameLogEntryType = "general",
+): GameLogEntry => ({
+  id: `log-${Date.now().toString(36)}-${(logIdCounter++).toString(36)}`,
+  message,
+  type,
+});
+
 export type ThreeWheelGameState = {
   player: Fighter;
   enemy: Fighter;
@@ -106,7 +124,7 @@ export type ThreeWheelGameState = {
   reserveSums: null | { player: number; enemy: number };
   isPtrDragging: boolean;
   ptrDragCard: Card | null;
-  log: string[];
+  log: GameLogEntry[];
 };
 
 export type ThreeWheelGameDerived = {
@@ -617,10 +635,11 @@ export function useThreeWheelGame({
   const [reserveSums, setReserveSums] = useState<null | { player: number; enemy: number }>(null);
 
   const START_LOG = "A Shade Bandit eyes your purse...";
-  const [log, setLog] = useState<string[]>([START_LOG]);
+  const [log, setLog] = useState<GameLogEntry[]>(() => [createLogEntry(START_LOG)]);
 
-  const appendLog = useCallback((s: string) => {
-    setLog((prev) => [s, ...prev].slice(0, 60));
+  const appendLog = useCallback((message: string, options?: { type?: GameLogEntryType }) => {
+    const entry = createLogEntry(message, options?.type ?? "general");
+    setLog((prev) => [entry, ...prev].slice(0, 60));
   }, []);
 
   const canReveal = useMemo(() => {
@@ -1501,7 +1520,7 @@ export function useThreeWheelGame({
     setReserveSums(null);
     setWheelHUD([null, null, null]);
 
-    setLog([START_LOG]);
+    setLog([createLogEntry(START_LOG)]);
 
     wheelRngRef.current = createSeededRng(seed);
     setWheelSections(generateWheelSet());

--- a/src/game/spellEngine.ts
+++ b/src/game/spellEngine.ts
@@ -405,7 +405,7 @@ export type SpellEffectApplicationContext<CardT> = {
   updateTokens: (updater: (prev: [number, number, number]) => [number, number, number]) => void;
   updateLaneChillStacks: (updater: (prev: LaneChillStacks) => LaneChillStacks) => void;
   setInitiative: (side: LegacySide) => void;
-  appendLog: (message: string) => void;
+  appendLog: (message: string, options?: { type?: "general" | "spell" }) => void;
   initiative: LegacySide;
   isMultiplayer: boolean;
   broadcastEffects?: (payload: SpellEffectPayload) => void;
@@ -779,7 +779,7 @@ export function applySpellEffects<CardT extends { id: string }>(
   if (Array.isArray(logMessages)) {
     logMessages.forEach((entry) => {
       if (typeof entry === "string" && entry.trim().length > 0) {
-        appendLog(entry);
+        appendLog(entry, { type: "spell" });
       }
     });
   }
@@ -787,7 +787,7 @@ export function applySpellEffects<CardT extends { id: string }>(
   if (Array.isArray(delayedEffects)) {
     delayedEffects.forEach((entry) => {
       if (typeof entry === "string" && entry.trim().length > 0) {
-        appendLog(entry);
+        appendLog(entry, { type: "spell" });
       }
     });
   }


### PR DESCRIPTION
## Summary
- add log entry metadata so spell logs are tagged separately from general updates
- keep the spell banner active only when the newest spell log is available and ignore other messages
- mark spell-engine log writes as spell entries to preserve banner behavior for delayed effects

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17e90664c83329c9395bfc1a62bea