### PR TITLE
Reveal board cards while targeting spells

### DIFF
--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -221,6 +221,8 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
     pendingSpell?.spell.id === "mirrorImage" &&
     pendingSpell.side === localLegacySide;
 
+  const revealBoardDuringSpell = awaitingSpellTarget && pendingSpell?.side === localLegacySide;
+
   const shouldShowLeftCard =
     shouldShowSlotCard({
       hasCard: !!leftSlot.card,
@@ -228,6 +230,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
       localLegacySide,
       isPhaseChooseLike,
       slotTargetable: leftSlotTargetable,
+      revealBoardDuringSpell,
     }) || (revealOpposingCardDuringMirror && leftSlot.side !== localLegacySide);
   const shouldShowRightCard =
     shouldShowSlotCard({
@@ -236,6 +239,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
       localLegacySide,
       isPhaseChooseLike,
       slotTargetable: rightSlotTargetable,
+      revealBoardDuringSpell,
     }) || (revealOpposingCardDuringMirror && rightSlot.side !== localLegacySide);
 
   const wheelScope = activeStage?.type === "wheel" ? activeStage.scope : null;

--- a/src/features/threeWheel/utils/slotVisibility.ts
+++ b/src/features/threeWheel/utils/slotVisibility.ts
@@ -6,6 +6,7 @@ interface ShouldShowSlotCardArgs {
   localLegacySide: LegacySide;
   isPhaseChooseLike: boolean;
   slotTargetable: boolean;
+  revealBoardDuringSpell: boolean;
 }
 
 export const shouldShowSlotCard = ({
@@ -14,9 +15,11 @@ export const shouldShowSlotCard = ({
   localLegacySide,
   isPhaseChooseLike,
   slotTargetable,
+  revealBoardDuringSpell,
 }: ShouldShowSlotCardArgs): boolean => {
   if (!hasCard) return false;
   if (slotSide === localLegacySide) return true;
+  if (revealBoardDuringSpell) return true;
   if (!isPhaseChooseLike) return true;
   return slotTargetable;
 };

--- a/tests/slotVisibility.test.ts
+++ b/tests/slotVisibility.test.ts
@@ -17,6 +17,7 @@ assert.equal(
     localLegacySide: player,
     isPhaseChooseLike: isChooseLikePhase("choose"),
     slotTargetable: false,
+    revealBoardDuringSpell: false,
   }),
   false,
   "Enemy slots should remain hidden during a normal choose phase",
@@ -30,6 +31,7 @@ assert.equal(
     localLegacySide: player,
     isPhaseChooseLike: isChooseLikePhase("spellTargeting"),
     slotTargetable: true,
+    revealBoardDuringSpell: false,
   }),
   true,
   "Targetable enemy slots should stay visible while selecting spell targets",
@@ -43,9 +45,24 @@ assert.equal(
     localLegacySide: player,
     isPhaseChooseLike: isChooseLikePhase("spellTargeting"),
     slotTargetable: false,
+    revealBoardDuringSpell: false,
   }),
   true,
   "Friendly slots should remain visible whenever a card is present",
+);
+
+// All board cards are revealed while the local player is casting a spell.
+assert.equal(
+  shouldShowSlotCard({
+    hasCard: true,
+    slotSide: enemy,
+    localLegacySide: player,
+    isPhaseChooseLike: isChooseLikePhase("spellTargeting"),
+    slotTargetable: false,
+    revealBoardDuringSpell: true,
+  }),
+  true,
+  "Enemy slots should be revealed when the local player is casting a spell",
 );
 
 console.log("slotVisibility tests passed");


### PR DESCRIPTION
## Summary
- keep board cards visible for the local player while selecting spell targets
- pass spell reveal flag through the wheel panel to slot visibility logic
- expand slot visibility tests to cover the new reveal behaviour

## Testing
- npm test -- slotVisibility

------
https://chatgpt.com/codex/tasks/task_e_68e1805da6f08332b6cffa2a0e972999