### PR TITLE
Refine spell effect payloads and centralized logging

### DIFF
--- a/src/game/spellEngine.ts
+++ b/src/game/spellEngine.ts
@@ -91,7 +91,6 @@ const RUNTIME_CLEANUP_KEYS: Array<keyof SpellRuntimeState | string> = [
   "handDiscards",
   "positionSwaps",
   "initiativeChallenges",
-  "log",
 ];
 
 export function resolvePendingSpell(params: ResolveSpellParams): SpellResolutionResult {
@@ -106,6 +105,37 @@ export function resolvePendingSpell(params: ResolveSpellParams): SpellResolution
     if (owner === "ally") return casterSideLegacy;
     if (owner === "enemy") return opponentSideLegacy;
     return null;
+  };
+
+  const extractCardDetails = (
+    target: SpellTargetInstance | undefined,
+  ): {
+    lane: number | null;
+    cardName?: string;
+    cardValue?: number | null;
+    leftValue?: number | null;
+    rightValue?: number | null;
+    location?: string | null;
+  } => {
+    if (!target || target.type !== "card") {
+      return { lane: null };
+    }
+    const laneRaw = target.lane;
+    const lane = Number.isInteger(laneRaw) ? (laneRaw as number) : null;
+    const cardName = typeof target.cardName === "string" ? target.cardName : undefined;
+    const cardValue =
+      typeof target.cardValue === "number" && Number.isFinite(target.cardValue)
+        ? (target.cardValue as number)
+        : null;
+    const leftValueRaw = (target as { leftValue?: unknown }).leftValue;
+    const leftValue =
+      typeof leftValueRaw === "number" && Number.isFinite(leftValueRaw) ? (leftValueRaw as number) : null;
+    const rightValueRaw = (target as { rightValue?: unknown }).rightValue;
+    const rightValue =
+      typeof rightValueRaw === "number" && Number.isFinite(rightValueRaw) ? (rightValueRaw as number) : null;
+    const locationRaw = (target as { location?: unknown }).location;
+    const location = typeof locationRaw === "string" ? locationRaw : null;
+    return { lane, cardName, cardValue, leftValue, rightValue, location };
   };
 
   if (targetOverride !== undefined) {
@@ -174,65 +204,108 @@ export function resolvePendingSpell(params: ResolveSpellParams): SpellResolution
     return { outcome: "error", error, manaRefund: 0 };
   }
 
-  const mirrorCopyEffects = Array.isArray(runtimeState.mirrorCopyEffects)
-    ? runtimeState.mirrorCopyEffects
-        .map((effect: unknown) => {
-          if (!effect || typeof effect !== "object") return null;
-          const targetCardId = (effect as { targetCardId?: unknown }).targetCardId;
-          if (typeof targetCardId !== "string") return null;
-          const mode = (effect as { mode?: unknown }).mode;
-          return {
-            targetCardId,
-            mode: typeof mode === "string" ? mode : undefined,
-          };
-        })
-        .filter((effect): effect is { targetCardId: string; mode: string | undefined } => effect !== null)
-    : undefined;
+  const mirrorCopyEffectsList = Array.isArray(runtimeState.mirrorCopyEffects)
+    ? runtimeState.mirrorCopyEffects.reduce<
+        Array<{ targetCardId: string; mode?: string; cardName?: string; lane?: number | null }>
+      >((acc, effect: unknown) => {
+        if (!effect || typeof effect !== "object") return acc;
+        const targetCardId = (effect as { targetCardId?: unknown }).targetCardId;
+        if (typeof targetCardId !== "string") return acc;
+        const mode = (effect as { mode?: unknown }).mode;
+        const cardName = (effect as { cardName?: unknown }).cardName;
+        const laneRaw = (effect as { lane?: unknown }).lane;
+        acc.push({
+          targetCardId,
+          mode: typeof mode === "string" ? mode : undefined,
+          cardName: typeof cardName === "string" ? cardName : undefined,
+          lane: Number.isInteger(laneRaw) ? (laneRaw as number) : null,
+        });
+        return acc;
+      }, [])
+    : [];
+  const mirrorCopyEffects = mirrorCopyEffectsList.length > 0 ? mirrorCopyEffectsList : undefined;
 
-  const wheelTokenAdjustments = Array.isArray(runtimeState.wheelTokenAdjustments)
-    ? runtimeState.wheelTokenAdjustments
-        .map((entry: unknown) => {
-          if (!entry || typeof entry !== "object") return null;
-          const amount = (entry as { amount?: unknown }).amount;
-          if (typeof amount !== "number") return null;
-          const target = (entry as { target?: unknown }).target;
-          if (!target || typeof target !== "object") return null;
-          const targetType = (target as { type?: unknown }).type;
-          const wheelId = (target as { wheelId?: unknown }).wheelId;
-          if (targetType !== "wheel" || typeof wheelId !== "string") return null;
-          const idx = Number.parseInt(wheelId, 10);
-          if (!Number.isInteger(idx)) return null;
-          return { wheelIndex: idx, amount };
-        })
-        .filter((entry): entry is { wheelIndex: number; amount: number } => entry !== null)
-    : undefined;
+  const wheelTokenAdjustmentsList = Array.isArray(runtimeState.wheelTokenAdjustments)
+    ? runtimeState.wheelTokenAdjustments.reduce<
+        Array<{ wheelIndex: number; amount: number; casterName?: string }>
+      >((acc, entry: unknown) => {
+        if (!entry || typeof entry !== "object") return acc;
+        const amount = (entry as { amount?: unknown }).amount;
+        if (typeof amount !== "number") return acc;
+        const target = (entry as { target?: unknown }).target;
+        if (!target || typeof target !== "object") return acc;
+        const targetType = (target as { type?: unknown }).type;
+        const wheelId = (target as { wheelId?: unknown }).wheelId;
+        if (targetType !== "wheel" || typeof wheelId !== "string") return acc;
+        const idx = Number.parseInt(wheelId, 10);
+        if (!Number.isInteger(idx)) return acc;
+        const casterName = (entry as { caster?: unknown }).caster;
+        acc.push({
+          wheelIndex: idx,
+          amount,
+          casterName: typeof casterName === "string" ? casterName : undefined,
+        });
+        return acc;
+      }, [])
+    : [];
+  const wheelTokenAdjustments = wheelTokenAdjustmentsList.length > 0 ? wheelTokenAdjustmentsList : undefined;
 
-  const reserveDrains = Array.isArray(runtimeState.reserveDrains)
-    ? runtimeState.reserveDrains
-        .map((entry: unknown) => {
-          if (!entry || typeof entry !== "object") return null;
-          const amount = (entry as { amount?: unknown }).amount;
-          if (typeof amount !== "number") return null;
+  const reserveDrainsList = Array.isArray(runtimeState.reserveDrains)
+    ? runtimeState.reserveDrains.reduce<
+        Array<{
+          side: LegacySide;
+          amount: number;
+          cardId?: string;
+          cardName?: string;
+          lane?: number | null;
+          casterName?: string;
+        }>
+      >((acc, entry: unknown) => {
+        if (!entry || typeof entry !== "object") return acc;
+        const amount = (entry as { amount?: unknown }).amount;
+        if (typeof amount !== "number") return acc;
 
-          let targetSide: LegacySide | null = null;
-          const target = (entry as { target?: unknown }).target;
-          if (target && typeof target === "object" && (target as { type?: unknown }).type === "card") {
-            const owner = (target as { owner?: unknown }).owner as SpellTargetOwnership | undefined;
-            targetSide = ownerToLegacy(owner);
-          }
+        let targetSide: LegacySide | null = null;
+        const target = (entry as { target?: unknown }).target;
+        let targetCardId: string | undefined;
+        let targetCardName: string | undefined;
+        let targetLane: number | null = null;
+        if (target && typeof target === "object" && (target as { type?: unknown }).type === "card") {
+          const owner = (target as { owner?: unknown }).owner as SpellTargetOwnership | undefined;
+          targetSide = ownerToLegacy(owner);
+          const details = extractCardDetails(target as SpellTargetInstance | undefined);
+          targetCardId = (target as { cardId?: unknown }).cardId as string | undefined;
+          targetCardName = details.cardName;
+          targetLane = details.lane;
+        }
 
-          if (!targetSide) {
-            targetSide = opponentSideLegacy;
-          }
+        if (!targetSide) {
+          targetSide = opponentSideLegacy;
+        }
 
-          return { side: targetSide, amount };
-        })
-        .filter((entry): entry is { side: LegacySide; amount: number } => entry !== null)
-    : undefined;
+        const casterName = (entry as { caster?: unknown }).caster;
+        acc.push({
+          side: targetSide,
+          amount,
+          cardId: typeof targetCardId === "string" ? targetCardId : undefined,
+          cardName: targetCardName,
+          lane: targetLane,
+          casterName: typeof casterName === "string" ? casterName : undefined,
+        });
+        return acc;
+      }, [])
+    : [];
+  const reserveDrains = reserveDrainsList.length > 0 ? reserveDrainsList : undefined;
 
   const rawHandAdjustments = Array.isArray(runtimeState.handAdjustments)
     ? runtimeState.handAdjustments.reduce<
-        Array<{ side: LegacySide; cardId: string; numberDelta?: number }>
+        Array<{
+          side: LegacySide;
+          cardId: string;
+          cardName?: string;
+          numberDelta?: number;
+          cardValue?: number | null;
+        }>
       >((acc, entry: unknown) => {
         if (!entry || typeof entry !== "object") return acc;
         const target = (entry as { target?: unknown }).target;
@@ -244,10 +317,13 @@ export function resolvePendingSpell(params: ResolveSpellParams): SpellResolution
         const owner = ownerToLegacy((target as { owner?: unknown }).owner as SpellTargetOwnership | undefined);
         if (!owner) return acc;
         const numberDelta = (entry as { numberDelta?: unknown }).numberDelta;
+        const details = extractCardDetails(target as SpellTargetInstance | undefined);
         acc.push({
           side: owner,
           cardId,
+          cardName: details.cardName,
           numberDelta: typeof numberDelta === "number" ? numberDelta : undefined,
+          cardValue: details.cardValue ?? null,
         });
         return acc;
       }, [])
@@ -256,7 +332,7 @@ export function resolvePendingSpell(params: ResolveSpellParams): SpellResolution
   const handAdjustments = rawHandAdjustments && rawHandAdjustments.length > 0 ? rawHandAdjustments : undefined;
 
   const rawHandDiscards = Array.isArray(runtimeState.handDiscards)
-    ? runtimeState.handDiscards.reduce<Array<{ side: LegacySide; cardId: string }>>(
+    ? runtimeState.handDiscards.reduce<Array<{ side: LegacySide; cardId: string; cardName?: string }>>(
         (acc, entry: unknown) => {
           if (!entry || typeof entry !== "object") return acc;
           const target = (entry as { target?: unknown }).target;
@@ -267,7 +343,8 @@ export function resolvePendingSpell(params: ResolveSpellParams): SpellResolution
           if (typeof cardId !== "string") return acc;
           const owner = ownerToLegacy((target as { owner?: unknown }).owner as SpellTargetOwnership | undefined);
           if (!owner) return acc;
-          acc.push({ side: owner, cardId });
+          const details = extractCardDetails(target as SpellTargetInstance | undefined);
+          acc.push({ side: owner, cardId, cardName: details.cardName });
           return acc;
         },
         [],
@@ -276,63 +353,110 @@ export function resolvePendingSpell(params: ResolveSpellParams): SpellResolution
 
   const handDiscards = rawHandDiscards && rawHandDiscards.length > 0 ? rawHandDiscards : undefined;
 
-  const positionSwaps = Array.isArray(runtimeState.positionSwaps)
-    ? runtimeState.positionSwaps
-        .map((entry: unknown) => {
-          if (!entry || typeof entry !== "object") return null;
-          const first = (entry as { first?: unknown }).first;
-          const second = (entry as { second?: unknown }).second;
-          if (
-            !first ||
-            typeof first !== "object" ||
-            (first as { type?: unknown }).type !== "card" ||
-            !second ||
-            typeof second !== "object" ||
-            (second as { type?: unknown }).type !== "card"
-          ) {
-            return null;
-          }
-          const laneA = (first as { lane?: unknown }).lane;
-          const laneB = (second as { lane?: unknown }).lane;
-          if (!Number.isInteger(laneA) || !Number.isInteger(laneB)) return null;
-          const owner = ownerToLegacy((first as { owner?: unknown }).owner as SpellTargetOwnership | undefined);
-          if (!owner) return null;
-          return { side: owner, laneA: laneA as number, laneB: laneB as number };
-        })
-        .filter((entry): entry is { side: LegacySide; laneA: number; laneB: number } => entry !== null)
-    : undefined;
+  const positionSwapsList = Array.isArray(runtimeState.positionSwaps)
+    ? runtimeState.positionSwaps.reduce<
+        Array<{
+          side: LegacySide;
+          laneA: number;
+          laneB: number;
+          cardA?: {
+            cardId?: string;
+            cardName?: string;
+            lane?: number | null;
+            cardValue?: number | null;
+            location?: string | null;
+          };
+          cardB?: {
+            cardId?: string;
+            cardName?: string;
+            lane?: number | null;
+            cardValue?: number | null;
+            location?: string | null;
+          };
+          casterName?: string;
+        }>
+      >((acc, entry: unknown) => {
+        if (!entry || typeof entry !== "object") return acc;
+        const first = (entry as { first?: unknown }).first as SpellTargetInstance | undefined;
+        const second = (entry as { second?: unknown }).second as SpellTargetInstance | undefined;
+        if (!first || !second || first.type !== "card" || second.type !== "card") {
+          return acc;
+        }
+        const laneA = first.lane;
+        const laneB = second.lane;
+        if (!Number.isInteger(laneA) || !Number.isInteger(laneB)) return acc;
+        const owner = ownerToLegacy(first.owner as SpellTargetOwnership | undefined);
+        if (!owner) return acc;
+        const cardA = extractCardDetails(first);
+        const cardB = extractCardDetails(second);
+        const casterName = (entry as { caster?: unknown }).caster;
+        acc.push({
+          side: owner,
+          laneA: laneA as number,
+          laneB: laneB as number,
+          cardA: {
+            cardId: first.cardId,
+            cardName: cardA.cardName,
+            lane: cardA.lane,
+            cardValue: cardA.cardValue,
+            location: cardA.location,
+          },
+          cardB: {
+            cardId: second.cardId,
+            cardName: cardB.cardName,
+            lane: cardB.lane,
+            cardValue: cardB.cardValue,
+            location: cardB.location,
+          },
+          casterName: typeof casterName === "string" ? casterName : undefined,
+        });
+        return acc;
+      }, [])
+    : [];
+  const positionSwaps = positionSwapsList.length > 0 ? positionSwapsList : undefined;
 
-  const initiativeChallenges = Array.isArray(runtimeState.initiativeChallenges)
-    ? runtimeState.initiativeChallenges
-        .map((entry: unknown) => {
-          if (!entry || typeof entry !== "object") return null;
-          const target = (entry as { target?: unknown }).target;
-          if (!target || typeof target !== "object" || (target as { type?: unknown }).type !== "card") {
-            return null;
-          }
-          const cardId = (target as { cardId?: unknown }).cardId;
-          if (typeof cardId !== "string") return null;
-          const lane = (target as { lane?: unknown }).lane;
-          if (!Number.isInteger(lane)) return null;
-          const owner = ownerToLegacy((target as { owner?: unknown }).owner as SpellTargetOwnership | undefined);
-          if (!owner) return null;
-          const mode = (entry as { mode?: unknown }).mode;
-          const normalizedMode = mode === "lower" ? "lower" : "higher";
-          return { side: owner, lane: lane as number, cardId, mode: normalizedMode };
-        })
-        .filter(
-          (entry): entry is { side: LegacySide; lane: number; cardId: string; mode: "higher" | "lower" } =>
-            entry !== null,
-        )
-    : undefined;
-
-  const logMessages = Array.isArray(runtimeState.log)
-    ? runtimeState.log.filter((entry: unknown): entry is string => typeof entry === "string")
-    : undefined;
+  const initiativeChallengesList = Array.isArray(runtimeState.initiativeChallenges)
+    ? runtimeState.initiativeChallenges.reduce<
+        Array<{
+          side: LegacySide;
+          lane: number;
+          cardId: string;
+          cardName?: string;
+          mode: "higher" | "lower";
+          casterName?: string;
+        }>
+      >((acc, entry: unknown) => {
+        if (!entry || typeof entry !== "object") return acc;
+        const target = (entry as { target?: unknown }).target;
+        if (!target || typeof target !== "object" || (target as { type?: unknown }).type !== "card") {
+          return acc;
+        }
+        const cardId = (target as { cardId?: unknown }).cardId;
+        if (typeof cardId !== "string") return acc;
+        const lane = (target as { lane?: unknown }).lane;
+        if (!Number.isInteger(lane)) return acc;
+        const owner = ownerToLegacy((target as { owner?: unknown }).owner as SpellTargetOwnership | undefined);
+        if (!owner) return acc;
+        const mode = (entry as { mode?: unknown }).mode;
+        const normalizedMode = mode === "lower" ? "lower" : "higher";
+        const details = extractCardDetails(target as SpellTargetInstance | undefined);
+        const casterName = (entry as { caster?: unknown }).caster;
+        acc.push({
+          side: owner,
+          lane: lane as number,
+          cardId,
+          cardName: details.cardName,
+          mode: normalizedMode,
+          casterName: typeof casterName === "string" ? casterName : undefined,
+        });
+        return acc;
+      }, [])
+    : [];
+  const initiativeChallenges = initiativeChallengesList.length > 0 ? initiativeChallengesList : undefined;
 
   const runtimeSummary = collectRuntimeSpellEffects(runtimeState, descriptor.side);
 
-  const effectPayload: SpellEffectPayload = { caster: descriptor.side };
+  const effectPayload: SpellEffectPayload = { caster: descriptor.side, casterName: caster.name };
   if (mirrorCopyEffects && mirrorCopyEffects.length > 0) {
     effectPayload.mirrorCopyEffects = mirrorCopyEffects;
   }
@@ -369,9 +493,6 @@ export function resolvePendingSpell(params: ResolveSpellParams): SpellResolution
   if (runtimeSummary.initiative) {
     effectPayload.initiative = runtimeSummary.initiative;
   }
-  if (logMessages && logMessages.length > 0) {
-    effectPayload.logMessages = logMessages;
-  }
 
   const hasEffect =
     (effectPayload.mirrorCopyEffects?.length ?? 0) > 0 ||
@@ -385,8 +506,7 @@ export function resolvePendingSpell(params: ResolveSpellParams): SpellResolution
     (effectPayload.initiativeChallenges?.length ?? 0) > 0 ||
     (effectPayload.chilledCards?.length ?? 0) > 0 ||
     (effectPayload.delayedEffects?.length ?? 0) > 0 ||
-    Boolean(effectPayload.initiative) ||
-    (effectPayload.logMessages?.length ?? 0) > 0;
+    Boolean(effectPayload.initiative);
 
   for (const key of RUNTIME_CLEANUP_KEYS) {
     if (key in runtimeState) {
@@ -483,6 +603,7 @@ export function applySpellEffects<CardT extends { id: string }>(
   } = context;
 
   const {
+    casterName: payloadCasterName,
     mirrorCopyEffects,
     wheelTokenAdjustments,
     reserveDrains,
@@ -495,11 +616,81 @@ export function applySpellEffects<CardT extends { id: string }>(
     chilledCards,
     delayedEffects,
     initiative: initiativeTarget,
-    logMessages,
   } = payload;
+
+  const defaultNameForSide = (side: LegacySide) => (side === "player" ? "Player" : "Enemy");
+  const baseCasterName =
+    typeof payloadCasterName === "string" && payloadCasterName.trim().length > 0
+      ? payloadCasterName.trim()
+      : defaultNameForSide(payload.caster);
+  const resolveCasterName = (name?: string): string => {
+    if (typeof name === "string" && name.trim().length > 0) return name.trim();
+    return baseCasterName;
+  };
+  const logEntries: string[] = [];
+
+  const readCardStat = (
+    card: CardLikeWithValues | null | undefined,
+    key: "number" | "leftValue" | "rightValue",
+  ): number | null => {
+    if (!card) return null;
+    const raw = (card as Record<typeof key, unknown>)[key];
+    return typeof raw === "number" && Number.isFinite(raw) ? (raw as number) : null;
+  };
+
+  const extractNameFromCard = (card: CardT | null | undefined): string | undefined => {
+    if (!card) return undefined;
+    const name = (card as { name?: unknown }).name;
+    if (typeof name === "string" && name.trim().length > 0) {
+      return name.trim();
+    }
+    return undefined;
+  };
+
+  const formatCardLabel = (
+    card: CardT | null | undefined,
+    fallbackName?: string,
+    fallbackId?: string,
+  ): string => {
+    const primary = extractNameFromCard(card);
+    if (primary) return primary;
+    if (typeof fallbackName === "string" && fallbackName.trim().length > 0) {
+      return fallbackName.trim();
+    }
+    if (typeof fallbackId === "string" && fallbackId.trim().length > 0) {
+      return `card ${fallbackId.trim()}`;
+    }
+    return "a card";
+  };
+
+  const formatLaneLabel = (lane: number | null | undefined): string => {
+    if (typeof lane === "number" && Number.isInteger(lane) && lane >= 0) {
+      return `lane ${lane + 1}`;
+    }
+    return "the lane";
+  };
+
+  const describeSwapCard = (
+    card: CardT | null | undefined,
+    fallback?: { cardName?: string; cardId?: string },
+  ): string => {
+    if (!card) {
+      const fallbackName = fallback?.cardName;
+      if (typeof fallbackName === "string" && fallbackName.trim().length > 0) {
+        return fallbackName.trim();
+      }
+      const fallbackId = fallback?.cardId;
+      if (typeof fallbackId === "string" && fallbackId.trim().length > 0) {
+        return `card ${fallbackId.trim()}`;
+      }
+      return "an empty slot";
+    }
+    return formatCardLabel(card, fallback?.cardName, fallback?.cardId);
+  };
 
   let mirrorUpdatedAssignments: AssignmentState<CardT> | null = null;
   let latestAssignments: AssignmentState<CardT> = assignSnapshot;
+  const mirrorLogs: string[] = [];
   if (mirrorCopyEffects?.length) {
     updateAssignments((prev) => {
       let nextPlayer = prev.player;
@@ -550,6 +741,11 @@ export function applySpellEffects<CardT extends { id: string }>(
           nextEnemy[laneIndex] = copied;
         }
         changed = true;
+
+        const targetLabel = formatCardLabel(targetCard as CardT | null, effect.cardName, effect.targetCardId);
+        const laneLabel = formatLaneLabel(Number.isInteger(effect.lane) ? (effect.lane as number) : laneIndex);
+        const sourceDescriptor = effect.mode === "opponent" ? "their foe" : "their ally";
+        mirrorLogs.push(`${baseCasterName} mirrored ${targetLabel} on ${laneLabel} against ${sourceDescriptor}.`);
       });
 
       if (!changed) return prev;
@@ -559,6 +755,10 @@ export function applySpellEffects<CardT extends { id: string }>(
       return updated;
     });
   }
+
+  mirrorLogs.forEach((entry) => {
+    if (entry.trim().length > 0) logEntries.push(entry);
+  });
 
   const previewTokenTargets = (targets: [number, number, number]) => {
     for (let i = 0; i < targets.length; i++) {
@@ -573,6 +773,7 @@ export function applySpellEffects<CardT extends { id: string }>(
     previewTokenTargets(nextTokenSteps);
   }
 
+  const wheelLogs: string[] = [];
   if (wheelTokenAdjustments?.length) {
     const tokenUpdates = new Map<number, number>();
     let persistedTokens: [number, number, number] | null = null;
@@ -592,6 +793,12 @@ export function applySpellEffects<CardT extends { id: string }>(
         next[idx] = updated;
         changed = true;
         tokenUpdates.set(idx, updated);
+        const casterDisplay = resolveCasterName(adjustment.casterName);
+        const magnitude = Math.abs(adjustment.amount);
+        const direction = adjustment.amount >= 0 ? "advanced" : "reversed";
+        wheelLogs.push(
+          `${casterDisplay} ${direction} wheel ${idx + 1} by ${magnitude} (now ${updated}).`,
+        );
       });
 
       if (!changed) return prev;
@@ -608,6 +815,18 @@ export function applySpellEffects<CardT extends { id: string }>(
     }
   }
 
+  wheelLogs.forEach((entry) => {
+    if (entry.trim().length > 0) logEntries.push(entry);
+  });
+
+  const reserveChangeSummaries: Array<{
+    casterName: string;
+    side: LegacySide;
+    amount: number;
+    before: number;
+    after: number;
+    cardName?: string;
+  }> = [];
   if (reserveDrains?.length) {
     updateReserveSums((prev) => {
       if (!prev) return prev;
@@ -625,6 +844,14 @@ export function applySpellEffects<CardT extends { id: string }>(
         if (!changed) next = { ...prev } as ReserveState;
         next[side] = updated;
         changed = true;
+        reserveChangeSummaries.push({
+          casterName: resolveCasterName(drain.casterName),
+          side,
+          amount,
+          before: current,
+          after: updated,
+          cardName: drain.cardName,
+        });
       });
 
       if (!changed) return prev;
@@ -638,11 +865,100 @@ export function applySpellEffects<CardT extends { id: string }>(
     });
   }
 
+  if (reserveChangeSummaries.length > 0) {
+    reserveChangeSummaries.forEach((summary) => {
+      const sideDescriptor = summary.side === payload.caster ? "their reserve" : "the foe's reserve";
+      const via = summary.cardName ? ` via ${summary.cardName}` : "";
+      logEntries.push(
+        `${summary.casterName} drained ${summary.amount} from ${sideDescriptor}${via} (now ${summary.after}).`,
+      );
+    });
+  } else if ((reserveDrains ?? []).length > 0) {
+    (reserveDrains ?? []).forEach((drain) => {
+      const sideDescriptor = drain.side === payload.caster ? "their reserve" : "the foe's reserve";
+      const via = drain.cardName ? ` via ${drain.cardName}` : "";
+      logEntries.push(
+        `${resolveCasterName(drain.casterName)} drained ${drain.amount} from ${sideDescriptor}${via}.`,
+      );
+    });
+  }
+
+  const cardAdjustmentLogs: string[] = [];
   if (cardAdjustments?.length) {
     let updatedAssignments: AssignmentState<CardT> | null = null;
     updateAssignments((prev) => {
       const updated = applyCardStatAdjustments(prev, cardAdjustments as CardStatAdjustment[]);
       if (updated) {
+        cardAdjustments.forEach((adj) => {
+          if (!adj || typeof adj.cardId !== "string") return;
+          const owner = adj.owner;
+          const prevLanes = owner === "player" ? prev.player : prev.enemy;
+          const laneIndex =
+            Number.isInteger(adj.lane) && (adj.lane as number) >= 0
+              ? (adj.lane as number)
+              : prevLanes.findIndex((card) => card?.id === adj.cardId);
+          if (laneIndex < 0) return;
+          const beforeCard = prevLanes[laneIndex] as CardLikeWithValues | null;
+          const afterLanes = owner === "player" ? updated.player : updated.enemy;
+          const afterCard = afterLanes[laneIndex] as CardLikeWithValues | null;
+          if (!afterCard && !beforeCard) return;
+
+          const displayCard = (afterCard as CardT | null) ?? (beforeCard as CardT | null);
+          const cardLabel = formatCardLabel(displayCard, adj.cardName, adj.cardId);
+
+          const prevNumber =
+            typeof adj.cardValue === "number" && Number.isFinite(adj.cardValue)
+              ? Math.round(adj.cardValue)
+              : readCardStat(beforeCard, "number") ?? 0;
+          const nextNumber = readCardStat(afterCard, "number") ?? prevNumber;
+          const deltaNumber =
+            typeof adj.numberDelta === "number" && Number.isFinite(adj.numberDelta)
+              ? Math.round(adj.numberDelta)
+              : nextNumber - prevNumber;
+          if (deltaNumber < 0) {
+            cardAdjustmentLogs.push(
+              `${baseCasterName} dealt ${Math.abs(deltaNumber)} to ${cardLabel} (now ${nextNumber}).`,
+            );
+          } else if (deltaNumber > 0) {
+            cardAdjustmentLogs.push(
+              `${baseCasterName} boosted ${cardLabel} by ${deltaNumber} (now ${nextNumber}).`,
+            );
+          }
+
+          const prevLeft =
+            typeof adj.leftValue === "number" && Number.isFinite(adj.leftValue)
+              ? Math.round(adj.leftValue)
+              : readCardStat(beforeCard, "leftValue");
+          const nextLeft = readCardStat(afterCard, "leftValue");
+          const leftDelta =
+            typeof adj.leftValueDelta === "number" && Number.isFinite(adj.leftValueDelta)
+              ? Math.round(adj.leftValueDelta)
+              : typeof prevLeft === "number" && typeof nextLeft === "number"
+              ? nextLeft - prevLeft
+              : 0;
+          if (leftDelta !== 0 && typeof nextLeft === "number") {
+            cardAdjustmentLogs.push(
+              `${baseCasterName} shifted ${cardLabel}'s left value by ${leftDelta} (now ${nextLeft}).`,
+            );
+          }
+
+          const prevRight =
+            typeof adj.rightValue === "number" && Number.isFinite(adj.rightValue)
+              ? Math.round(adj.rightValue)
+              : readCardStat(beforeCard, "rightValue");
+          const nextRight = readCardStat(afterCard, "rightValue");
+          const rightDelta =
+            typeof adj.rightValueDelta === "number" && Number.isFinite(adj.rightValueDelta)
+              ? Math.round(adj.rightValueDelta)
+              : typeof prevRight === "number" && typeof nextRight === "number"
+              ? nextRight - prevRight
+              : 0;
+          if (rightDelta !== 0 && typeof nextRight === "number") {
+            cardAdjustmentLogs.push(
+              `${baseCasterName} shifted ${cardLabel}'s right value by ${rightDelta} (now ${nextRight}).`,
+            );
+          }
+        });
         updatedAssignments = updated;
         latestAssignments = updated;
         return updated;
@@ -656,6 +972,11 @@ export function applySpellEffects<CardT extends { id: string }>(
     }
   }
 
+  cardAdjustmentLogs.forEach((entry) => {
+    if (entry.trim().length > 0) logEntries.push(entry);
+  });
+
+  const handAdjustmentLogs: string[] = [];
   if (handAdjustments?.length) {
     handAdjustments.forEach((adjustment) => {
       updateFighter(adjustment.side, (fighter) => {
@@ -670,6 +991,22 @@ export function applySpellEffects<CardT extends { id: string }>(
           const nextValue = Math.max(0, Math.round(currentValue + adjustment.numberDelta));
           if (nextValue !== currentValue) {
             updatedCard.number = nextValue;
+            const delta = nextValue - currentValue;
+            const cardLabel = formatCardLabel(
+              currentCard as unknown as CardT,
+              adjustment.cardName,
+              adjustment.cardId,
+            );
+            const actorName = baseCasterName;
+            if (delta >= 0) {
+              handAdjustmentLogs.push(
+                `${actorName} boosted reserve card ${cardLabel} by ${delta} (now ${nextValue}).`,
+              );
+            } else {
+              handAdjustmentLogs.push(
+                `${actorName} reduced reserve card ${cardLabel} by ${Math.abs(delta)} (now ${nextValue}).`,
+              );
+            }
           }
         }
         if (nextHand[index] === updatedCard) return fighter;
@@ -679,6 +1016,11 @@ export function applySpellEffects<CardT extends { id: string }>(
     });
   }
 
+  handAdjustmentLogs.forEach((entry) => {
+    if (entry.trim().length > 0) logEntries.push(entry);
+  });
+
+  const handDiscardLogs: string[] = [];
   if (handDiscards?.length) {
     handDiscards.forEach((discard) => {
       updateFighter(discard.side, (fighter) => {
@@ -687,11 +1029,24 @@ export function applySpellEffects<CardT extends { id: string }>(
         const nextHand = [...fighter.hand];
         const [removed] = nextHand.splice(index, 1);
         const nextDiscard = removed ? [...fighter.discard, removed] : [...fighter.discard];
+        if (removed) {
+          const cardLabel = formatCardLabel(
+            removed as unknown as CardT,
+            discard.cardName,
+            discard.cardId,
+          );
+          handDiscardLogs.push(`${baseCasterName} discarded ${cardLabel} from reserve.`);
+        }
         return { ...fighter, hand: nextHand, discard: nextDiscard };
       });
     });
   }
 
+  handDiscardLogs.forEach((entry) => {
+    if (entry.trim().length > 0) logEntries.push(entry);
+  });
+
+  const drawLogs: string[] = [];
   if (drawCards?.length) {
     drawCards.forEach((request) => {
       if (!request) return;
@@ -713,11 +1068,25 @@ export function applySpellEffects<CardT extends { id: string }>(
         if (drawnCards.length === 0) return fighter;
         const nextDeck = fighter.deck.slice(drawAmount);
         const nextHand = [...fighter.hand, ...drawnCards];
+        const actorName =
+          typeof request.casterName === "string" && request.casterName.trim().length > 0
+            ? request.casterName.trim()
+            : side === payload.caster
+            ? baseCasterName
+            : defaultNameForSide(side);
+        drawLogs.push(
+          `${actorName} drew ${drawAmount} card${drawAmount === 1 ? "" : "s"}.`,
+        );
         return { ...fighter, deck: nextDeck, hand: nextHand };
       });
     });
   }
 
+  drawLogs.forEach((entry) => {
+    if (entry.trim().length > 0) logEntries.push(entry);
+  });
+
+  const swapLogs: string[] = [];
   if (positionSwaps?.length) {
     updateAssignments((prev) => {
       let nextPlayer = prev.player;
@@ -743,12 +1112,24 @@ export function applySpellEffects<CardT extends { id: string }>(
         const baseline = side === "player" ? prev.player : prev.enemy;
         const working = side === "player" ? nextPlayer : nextEnemy;
         const targetArray: (CardT | null)[] = working === baseline ? [...baseline] : [...working];
+        const cardABefore = lanes[laneA] as CardT | null;
+        const cardBBefore = lanes[laneB] as CardT | null;
+        const cardALabel = describeSwapCard(cardABefore, swap.cardA);
+        const cardBLabel = describeSwapCard(cardBBefore, swap.cardB);
+        const valueA = getCardValue(cardABefore as CardLikeWithValues | null);
+        const valueB = getCardValue(cardBBefore as CardLikeWithValues | null);
+        const laneLabelA = formatLaneLabel(laneA);
+        const laneLabelB = formatLaneLabel(laneB);
         const temp = targetArray[laneA];
         targetArray[laneA] = targetArray[laneB];
         targetArray[laneB] = temp;
         if (side === "player") nextPlayer = targetArray;
         else nextEnemy = targetArray;
         changed = true;
+        const actorName = resolveCasterName(swap.casterName);
+        swapLogs.push(
+          `${actorName} swapped ${laneLabelA} (${cardALabel} ${valueA}) with ${laneLabelB} (${cardBLabel} ${valueB}).`,
+        );
       });
 
       if (!changed) return prev;
@@ -758,13 +1139,55 @@ export function applySpellEffects<CardT extends { id: string }>(
     });
   }
 
+  swapLogs.forEach((entry) => {
+    if (entry.trim().length > 0) logEntries.push(entry);
+  });
+
+  const chillLogs: string[] = [];
   if (chilledCards?.length) {
+    let prevStacksSnapshot: LaneChillStacks | null = null;
+    let nextStacksSnapshot: LaneChillStacks | null = null;
     updateLaneChillStacks((prev) => {
+      prevStacksSnapshot = prev;
       const updated = applyChilledCardUpdates(prev, latestAssignments, chilledCards as ChilledCardUpdate[]);
-      return updated ?? prev;
+      if (updated) {
+        nextStacksSnapshot = updated;
+        return updated;
+      }
+      return prev;
+    });
+
+    chilledCards.forEach((update) => {
+      if (!update) return;
+      const owner = update.owner;
+      const lanes = owner === "player" ? latestAssignments.player : latestAssignments.enemy;
+      let laneIndex =
+        Number.isInteger(update.lane) && (update.lane as number) >= 0
+          ? (update.lane as number)
+          : lanes.findIndex((card) => card?.id === update.cardId);
+      if (laneIndex < 0) return;
+      const card = lanes[laneIndex] as CardT | null;
+      const cardLabel = formatCardLabel(card, update.cardName, update.cardId);
+      const laneLabel = formatLaneLabel(laneIndex);
+      const stacksArray = nextStacksSnapshot
+        ? owner === "player"
+          ? nextStacksSnapshot.player
+          : nextStacksSnapshot.enemy
+        : prevStacksSnapshot
+        ? owner === "player"
+          ? prevStacksSnapshot.player
+          : prevStacksSnapshot.enemy
+        : null;
+      const stackCount = stacksArray ? stacksArray[laneIndex] ?? 0 : update.stacks;
+      chillLogs.push(`${baseCasterName} chilled ${cardLabel} on ${laneLabel} (${stackCount} stacks).`);
     });
   }
 
+  chillLogs.forEach((entry) => {
+    if (entry.trim().length > 0) logEntries.push(entry);
+  });
+
+  const initiativeLogs: string[] = [];
   if (initiativeChallenges?.length) {
     initiativeChallenges.forEach((challenge) => {
       const laneIndex = challenge.lane;
@@ -782,28 +1205,50 @@ export function applySpellEffects<CardT extends { id: string }>(
       if (success) {
         setInitiative(challengerSide);
       }
+      const actorName = challenge.casterName
+        ? resolveCasterName(challenge.casterName)
+        : challengerSide === payload.caster
+        ? baseCasterName
+        : defaultNameForSide(challengerSide);
+      const cardLabel = formatCardLabel(challengerCard as CardT | null, challenge.cardName, challenge.cardId);
+      const laneLabel = formatLaneLabel(laneIndex as number);
+      if (success) {
+        const verb = challenge.mode === "lower" ? "outpaced" : "overpowered";
+        initiativeLogs.push(
+          `${actorName}'s ${cardLabel} on ${laneLabel} ${verb} the foe (${challengerValue} vs ${opponentValue}) to seize initiative.`,
+        );
+      } else {
+        const verb = challenge.mode === "lower" ? "slip under" : "overpower";
+        initiativeLogs.push(
+          `${actorName}'s ${cardLabel} on ${laneLabel} couldn't ${verb} the foe (${challengerValue} vs ${opponentValue}).`,
+        );
+      }
     });
   }
 
   if (initiativeTarget && initiativeTarget !== initiative) {
     setInitiative(initiativeTarget);
+    const actorName = initiativeTarget === payload.caster ? baseCasterName : defaultNameForSide(initiativeTarget);
+    initiativeLogs.push(`${actorName} claimed initiative.`);
   }
 
-  if (Array.isArray(logMessages)) {
-    logMessages.forEach((entry) => {
-      if (typeof entry === "string" && entry.trim().length > 0) {
-        appendLog(entry, { type: "spell" });
-      }
-    });
-  }
+  initiativeLogs.forEach((entry) => {
+    if (entry.trim().length > 0) logEntries.push(entry);
+  });
 
   if (Array.isArray(delayedEffects)) {
     delayedEffects.forEach((entry) => {
       if (typeof entry === "string" && entry.trim().length > 0) {
-        appendLog(entry, { type: "spell" });
+        logEntries.push(entry.trim());
       }
     });
   }
+
+  logEntries.forEach((entry) => {
+    if (entry.trim().length > 0) {
+      appendLog(entry.trim(), { type: "spell" });
+    }
+  });
 
   const shouldBroadcast = options?.broadcast ?? true;
   if (shouldBroadcast && isMultiplayer && broadcastEffects) {

--- a/tests/mirrorImageResolution.test.ts
+++ b/tests/mirrorImageResolution.test.ts
@@ -96,7 +96,7 @@ const createInitialAssignments = (): AssignmentState<TestCard> => ({
   assert.equal(reserveState?.player, 0);
   assert.equal(laneChillStacks.player[0], 0);
   assert.equal(initiative, initialInitiative);
-  assert.equal(logs.length, 0);
+  assert.deepEqual(logs, ["Player mirrored Valiant on lane 1 against their foe."]);
 }
 
 // Hex drains the opponent's reserve before reveal, flipping the ReserveSum outcome.
@@ -182,7 +182,7 @@ const createInitialAssignments = (): AssignmentState<TestCard> => ({
   assert.equal(adjustedEnemyReserve, 3);
   assert.equal(reserveWinner, "player");
   assert.equal(initiative, initialInitiative);
-  assert.equal(logs.length, 0);
+  assert.deepEqual(logs, ["Player drained 2 from the foe's reserve."]);
 }
 
 console.log("mirrorImageResolution tests passed");

--- a/tests/spellEffects.test.ts
+++ b/tests/spellEffects.test.ts
@@ -135,6 +135,7 @@ const opponentOf = (side: LegacySide): LegacySide => (side === "player" ? "enemy
 
   const payload: SpellEffectPayload = {
     caster: "player",
+    casterName: "Caster",
     cardAdjustments: [
       { owner: "player", cardId: "p1", numberDelta: 2 },
       { owner: "enemy", cardId: "e1", numberDelta: -1 },
@@ -144,7 +145,6 @@ const opponentOf = (side: LegacySide): LegacySide => (side === "player" ? "enemy
     drawCards: [{ side: "player", count: 3 }],
     positionSwaps: [{ side: "player", laneA: 0, laneB: 2 }],
     initiativeChallenges: [{ side: "player", lane: 1, cardId: "p1", mode: "higher" }],
-    logMessages: ["Spell resolved."],
   };
 
   applySpellEffects<Card>(payload, {
@@ -195,7 +195,15 @@ const opponentOf = (side: LegacySide): LegacySide => (side === "player" ? "enemy
   assert(playerFighter.hand.some((card) => card.id === "pd1"));
   assert(playerFighter.hand.some((card) => card.id === "pd2"));
   assert.equal(initiative, "player");
-  assert(log.includes("Spell resolved."));
+  assert.deepEqual(log, [
+    "Caster boosted Oracle by 2 (now 6).",
+    "Caster dealt 1 to Ghoul (now 2).",
+    "Caster boosted reserve card Spark by 2 (now 3).",
+    "Caster discarded Shade from reserve.",
+    "Caster drew 2 cards.",
+    "Caster swapped lane 1 (Striker 3) with lane 3 (Wisp 2).",
+    "Caster's Oracle on lane 2 overpowered the foe (6 vs 2) to seize initiative.",
+  ]);
   assert.deepEqual(tokens, [0, 0, 0]);
   assert.deepEqual(reserveSums, { player: 5, enemy: 5 });
   assert.deepEqual(chillStacks, { player: [0, 0, 0], enemy: [0, 0, 0] });


### PR DESCRIPTION
## Summary
- extend spell effect payload transforms with caster names, card metadata, and structured swap/chill details
- update applySpellEffects to synthesize log entries from the structured payloads and remove per-spell log strings
- adjust spell resolvers and tests to align with centralized narration and verify the new messaging

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e1832f3114833291ea1e6eaec92d2b