### PR TITLE
Add touch drag support for mobile player cards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -283,6 +283,7 @@ export default function ThreeWheel_WinsOnly({
     setDragCardId,
     setDragOverWheel,
     startPointerDrag,
+    startTouchDrag,
     assignToWheelLocal,
     handleRevealClick,
     handleNextClick: handleNextClickBase,
@@ -1523,6 +1524,7 @@ export default function ThreeWheel_WinsOnly({
                 theme={THEME}
                 initiativeOverride={initiativeOverride}
                 startPointerDrag={startPointerDrag}
+                startTouchDrag={startTouchDrag}
                 wheelHudColor={wheelHUD[i]}
                 pendingSpell={pendingSpell}
                 onSpellTargetSelect={handleSpellTargetSelect}
@@ -1549,6 +1551,7 @@ export default function ThreeWheel_WinsOnly({
         assignToWheelLocal={assignToWheelLocal}
         setDragCardId={setDragCardId}
         startPointerDrag={startPointerDrag}
+        startTouchDrag={startTouchDrag}
         isPtrDragging={isPtrDragging}
         ptrDragCard={ptrDragCard}
         ptrPos={ptrPos}

--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -30,6 +30,7 @@ interface HandDockProps {
   assignToWheelLocal: (laneIndex: number, card: Card) => void;
   setDragCardId: (value: string | null) => void;
   startPointerDrag: (card: Card, e: React.PointerEvent<HTMLButtonElement>) => void;
+  startTouchDrag: (card: Card, e: React.TouchEvent<HTMLButtonElement>) => void;
   isPtrDragging: boolean;
   ptrDragCard: Card | null;
   ptrPos: React.MutableRefObject<{ x: number; y: number }>;
@@ -62,6 +63,7 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
     assignToWheelLocal,
     setDragCardId,
     startPointerDrag,
+    startTouchDrag,
     isPtrDragging,
     ptrDragCard,
     ptrPos,
@@ -222,6 +224,10 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
                   onPointerDown={(e) => {
                     if (awaitingManualTarget) return;
                     startPointerDrag(card, e);
+                  }}
+                  onTouchStart={(e) => {
+                    if (awaitingManualTarget) return;
+                    startTouchDrag(card, e);
                   }}
                   aria-pressed={isSelected}
                   aria-label={`Select ${card.name}`}

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -62,6 +62,7 @@ export interface WheelPanelProps {
   theme: Theme;
   initiativeOverride: LegacySide | null;
   startPointerDrag: (card: Card, e: React.PointerEvent<HTMLButtonElement>) => void;
+  startTouchDrag: (card: Card, e: React.TouchEvent<HTMLButtonElement>) => void;
   wheelHudColor: string | null;
   pendingSpell: {
     side: LegacySide;
@@ -123,6 +124,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
   theme,
   initiativeOverride,
   startPointerDrag,
+  startTouchDrag,
   wheelHudColor,
   pendingSpell,
   onSpellTargetSelect,
@@ -296,6 +298,12 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
       startPointerDrag(card, e);
     };
 
+    const handleTouchStart = (e: React.TouchEvent<HTMLButtonElement>) => {
+      if (!canInteractNormally) return;
+      e.stopPropagation();
+      startTouchDrag(card, e);
+    };
+
     return (
       <StSCard
         card={card}
@@ -307,6 +315,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
         onPointerDown={handlePointerDown}
+        onTouchStart={handleTouchStart}
         className={slotTargetable ? "ring-2 ring-sky-400" : undefined}
         spellTargetable={slotTargetable}
       />


### PR DESCRIPTION
## Summary
- add a touch-driven drag fallback for card interactions when pointer events are unavailable
- expose the touch drag handler through the three wheel hook and wire it to hand and slot card components
- forward the new handler from the app so mobile players can drag cards between the hand and wheel

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e19d77289083328f12a8f4da309c28