### PR TITLE
Adjust pointer and touch drag handling for three wheel game

### DIFF
--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -1625,6 +1625,8 @@ export function useThreeWheelGame({
     (card: Card, e: ReactPointerEvent) => {
       if (phaseRef.current !== "choose") return;
       if (e.pointerType === "mouse") return;
+      if (e.pointerType === "touch") return;
+      e.preventDefault();
       e.currentTarget.setPointerCapture?.(e.pointerId);
       setSelectedCardId(card.id);
       setDragCardId(card.id);
@@ -1670,7 +1672,6 @@ export function useThreeWheelGame({
 
   const startTouchDrag = useCallback(
     (card: Card, e: ReactTouchEvent<HTMLButtonElement>) => {
-      if (supportsPointerEventsRef.current) return;
       if (phaseRef.current !== "choose") return;
       if (e.touches.length === 0) return;
 
@@ -1735,7 +1736,7 @@ export function useThreeWheelGame({
       window.addEventListener("touchend", onEnd, { passive: false, capture: true });
       window.addEventListener("touchcancel", onCancel, { passive: false, capture: true });
     },
-    [active, addTouchDragCss, assignToWheelLocal, getDropTargetAt, setDragOverWheel, supportsPointerEventsRef]
+    [active, addTouchDragCss, assignToWheelLocal, getDropTargetAt, setDragOverWheel]
   );
 
   const state: ThreeWheelGameState = {


### PR DESCRIPTION
## Summary
- ignore pointer drags initiated by touch while preventing default behavior for other pointer types
- remove the pointer event support guard so touch drags always use the touchmove listeners

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1a58b9a9c83329ec0c4b8c02f0d08