### PR TITLE
Adjust touch drag card ghost positioning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -255,6 +255,7 @@ export default function ThreeWheel_WinsOnly({
     reserveSums,
     isPtrDragging,
     ptrDragCard,
+    ptrDragType,
     lockedWheelSize,
     log,
   } = state;
@@ -1576,6 +1577,7 @@ export default function ThreeWheel_WinsOnly({
         startTouchDrag={startTouchDrag}
         isPtrDragging={isPtrDragging}
         ptrDragCard={ptrDragCard}
+        ptrDragType={ptrDragType}
         ptrPos={ptrPos}
         onMeasure={setHandClearance}
         pendingSpell={pendingSpell}

--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -33,6 +33,7 @@ interface HandDockProps {
   startTouchDrag: (card: Card, e: React.TouchEvent<HTMLButtonElement>) => void;
   isPtrDragging: boolean;
   ptrDragCard: Card | null;
+  ptrDragType: "pointer" | "touch" | null;
   ptrPos: React.MutableRefObject<{ x: number; y: number }>;
   onMeasure?: (px: number) => void;
   pendingSpell: {
@@ -66,6 +67,7 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
     startTouchDrag,
     isPtrDragging,
     ptrDragCard,
+    ptrDragType,
     ptrPos,
     onMeasure,
     pendingSpell,
@@ -124,7 +126,9 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
         if (x !== prevX || y !== prevY) {
           prevX = x;
           prevY = y;
-          el.style.transform = `translate(${x - 48}px, ${y - 64}px)`;
+          const offsetX = ptrDragType === "touch" ? 72 : 48;
+          const offsetY = ptrDragType === "touch" ? 140 : 64;
+          el.style.transform = `translate(${x - offsetX}px, ${y - offsetY}px)`;
         }
         rafId = window.requestAnimationFrame(syncPosition);
       };
@@ -136,7 +140,7 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
           window.cancelAnimationFrame(rafId);
         }
       };
-    }, [isPtrDragging, ptrPos]);
+    }, [isPtrDragging, ptrDragType, ptrPos]);
 
     const localFighter: Fighter = localLegacySide === "player" ? player : enemy;
 
@@ -273,7 +277,16 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
               position: "fixed",
               left: 0,
               top: 0,
-              transform: `translate(${ptrPos.current.x - 48}px, ${ptrPos.current.y - 64}px)`,
+              transform: (() => {
+                const baseX = ptrPos.current.x;
+                const baseY = ptrPos.current.y;
+                if (ptrDragType === "touch") {
+                  const touchOffsetX = 72;
+                  const touchOffsetY = 140;
+                  return `translate(${baseX - touchOffsetX}px, ${baseY - touchOffsetY}px)`;
+                }
+                return `translate(${baseX - 48}px, ${baseY - 64}px)`;
+              })(),
               pointerEvents: "none",
               zIndex: 9999,
             }}

--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -124,6 +124,7 @@ export type ThreeWheelGameState = {
   reserveSums: null | { player: number; enemy: number };
   isPtrDragging: boolean;
   ptrDragCard: Card | null;
+  ptrDragType: "pointer" | "touch" | null;
   log: GameLogEntry[];
 };
 
@@ -473,6 +474,7 @@ export function useThreeWheelGame({
 
   const [isPtrDragging, setIsPtrDragging] = useState(false);
   const [ptrDragCard, setPtrDragCard] = useState<Card | null>(null);
+  const [ptrDragType, setPtrDragType] = useState<"pointer" | "touch" | null>(null);
   const ptrPos = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
 
   const supportsPointerEventsRef = useRef<boolean>(
@@ -1632,6 +1634,7 @@ export function useThreeWheelGame({
       setDragCardId(card.id);
       setPtrDragCard(card);
       setIsPtrDragging(true);
+      setPtrDragType("pointer");
       addTouchDragCss(true);
       ptrPos.current = { x: e.clientX, y: e.clientY };
 
@@ -1660,6 +1663,7 @@ export function useThreeWheelGame({
         setPtrDragCard(null);
         setDragOverWheel(null);
         setDragCardId(null);
+        setPtrDragType(null);
         addTouchDragCss(false);
       }
 
@@ -1699,6 +1703,7 @@ export function useThreeWheelGame({
       setDragCardId(card.id);
       setPtrDragCard(card);
       setIsPtrDragging(true);
+      setPtrDragType("touch");
       addTouchDragCss(true);
       updatePosition(touch.clientX, touch.clientY);
 
@@ -1729,6 +1734,7 @@ export function useThreeWheelGame({
         setPtrDragCard(null);
         setDragOverWheel(null);
         setDragCardId(null);
+        setPtrDragType(null);
         addTouchDragCss(false);
       }
 
@@ -1769,6 +1775,7 @@ export function useThreeWheelGame({
     reserveSums,
     isPtrDragging,
     ptrDragCard,
+    ptrDragType,
     log,
   };
 


### PR DESCRIPTION
## Summary
- track whether the player is dragging with touch or pointer in the three wheel game state
- offset the hand card ghost when dragging via touch so it remains visible under a fingertip on mobile
- pass the drag type through the app so the hand dock ghost stays synced with touch movement

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1b68c6f84833297421b0eda64819e