### PR TITLE
Adjust touch ghost offset to card size

### DIFF
--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -163,9 +163,13 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
       const el = ghostRef.current;
       if (!el) return;
 
-      const rect = el.getBoundingClientRect();
-      const halfWidth = rect.width ? rect.width / 2 : 0;
-      const halfHeight = rect.height ? rect.height / 2 : 0;
+      const cardEl = el.querySelector("button");
+      const rect = cardEl?.getBoundingClientRect();
+      const defaultHalfWidth = 0;
+      const defaultHalfHeight = 0;
+      const halfWidth = rect?.width ? rect.width / 2 : defaultHalfWidth;
+      const halfHeight = rect?.height ? rect.height / 2 : defaultHalfHeight;
+
       ghostOffsetRef.current = { x: halfWidth, y: halfHeight };
       const { x, y } = ptrPos.current;
       el.style.transform = `translate(${x - halfWidth}px, ${y - halfHeight}px)`;


### PR DESCRIPTION
## Summary
- query the touch drag ghost for the underlying StSCard element
- derive half width and height from the card to update the ghost offsets
- fall back to the existing defaults so pointer drags remain unchanged

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1c23e327c833285d7902bc4207884