### PR TITLE
Restore native HTML dragging

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -255,7 +255,6 @@ export default function ThreeWheel_WinsOnly({
     reserveSums,
     isPtrDragging,
     ptrDragCard,
-    ptrDragType,
     lockedWheelSize,
     log,
   } = state;
@@ -284,7 +283,6 @@ export default function ThreeWheel_WinsOnly({
     setDragCardId,
     setDragOverWheel,
     startPointerDrag,
-    startTouchDrag,
     assignToWheelLocal,
     handleRevealClick,
     handleNextClick: handleNextClickBase,
@@ -1547,7 +1545,6 @@ export default function ThreeWheel_WinsOnly({
                 theme={THEME}
                 initiativeOverride={initiativeOverride}
                 startPointerDrag={startPointerDrag}
-                startTouchDrag={startTouchDrag}
                 wheelHudColor={wheelHUD[i]}
                 pendingSpell={pendingSpell}
                 onSpellTargetSelect={handleSpellTargetSelect}
@@ -1574,10 +1571,8 @@ export default function ThreeWheel_WinsOnly({
         assignToWheelLocal={assignToWheelLocal}
         setDragCardId={setDragCardId}
         startPointerDrag={startPointerDrag}
-        startTouchDrag={startTouchDrag}
         isPtrDragging={isPtrDragging}
         ptrDragCard={ptrDragCard}
-        ptrDragType={ptrDragType}
         ptrPos={ptrPos}
         onMeasure={setHandClearance}
         pendingSpell={pendingSpell}

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -62,7 +62,6 @@ export interface WheelPanelProps {
   theme: Theme;
   initiativeOverride: LegacySide | null;
   startPointerDrag: (card: Card, e: React.PointerEvent<HTMLButtonElement>) => void;
-  startTouchDrag: (card: Card, e: React.TouchEvent<HTMLButtonElement>) => void;
   wheelHudColor: string | null;
   pendingSpell: {
     side: LegacySide;
@@ -124,7 +123,6 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
   theme,
   initiativeOverride,
   startPointerDrag,
-  startTouchDrag,
   wheelHudColor,
   pendingSpell,
   onSpellTargetSelect,
@@ -298,12 +296,6 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
       startPointerDrag(card, e);
     };
 
-    const handleTouchStart = (e: React.TouchEvent<HTMLButtonElement>) => {
-      if (!canInteractNormally) return;
-      e.stopPropagation();
-      startTouchDrag(card, e);
-    };
-
     return (
       <StSCard
         card={card}
@@ -315,7 +307,6 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
         onPointerDown={handlePointerDown}
-        onTouchStart={handleTouchStart}
         className={slotTargetable ? "ring-2 ring-sky-400" : undefined}
         spellTargetable={slotTargetable}
       />


### PR DESCRIPTION
## Summary
- remove the custom touch drag pathway so cards use native HTML drag and drop again
- drop the touch-specific ghost offset logic and related wiring from HandDock and WheelPanel
- simplify the game hook and App wiring to only expose the pointer-based drag helper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1cd6a959c83329f24cb219b0cb46d