### PR TITLE
Enable direct touch card dragging

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -276,7 +276,7 @@ export default function ThreeWheel_WinsOnly({
     canReveal,
   } = derived;
 
-  const { wheelRefs, ptrPos } = refs;
+  const { wheelRefs, ptrPos, ptrDragOffset } = refs;
 
   const {
     setHandClearance,
@@ -1579,6 +1579,7 @@ export default function ThreeWheel_WinsOnly({
         ptrDragCard={ptrDragCard}
         ptrDragType={ptrDragType}
         ptrPos={ptrPos}
+        ptrDragOffset={ptrDragOffset}
         onMeasure={setHandClearance}
         pendingSpell={pendingSpell}
         isAwaitingSpellTarget={isAwaitingSpellTarget}


### PR DESCRIPTION
## Summary
- add per-element touch-action handling and touch pointer offset tracking in the three wheel game hook so touch drags expose the data the UI needs
- update the hand dock to reposition the real card during touch drags and suppress the ghost overlay for touch interactions
- thread the new drag offset ref through the app so the dock can read shared pointer coordinates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e251d2668c83328684bb707db06021