### PR TITLE
Render touch drag ghost card via portal

### DIFF
--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -7,6 +7,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 import { motion } from "framer-motion";
 import StSCard from "../../../components/StSCard";
 import type { Card, Fighter } from "../../../game/types";
@@ -78,6 +79,7 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
     const ghostRef = useRef<HTMLDivElement | null>(null);
     const cardDimensionsRef = useRef<{ width: number; height: number }>({ width: 72, height: 96 });
     const ghostOffsetRef = useRef<{ x: number; y: number }>({ x: 48, y: 64 });
+    const [ghostPortalTarget, setGhostPortalTarget] = useState<HTMLElement | null>(null);
     const handleDockRef = useCallback(
       (node: HTMLDivElement | null) => {
         dockRef.current = node;
@@ -116,6 +118,12 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
         window.removeEventListener("orientationchange", compute);
       };
     }, [onMeasure]);
+
+    useEffect(() => {
+      if (typeof document !== "undefined") {
+        setGhostPortalTarget(document.body);
+      }
+    }, []);
 
     useEffect(() => {
       if (!isPtrDragging) return;
@@ -201,119 +209,124 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
 
     const stageLocation = activeStage?.type === "card" ? activeStage.location ?? "board" : null;
 
-    return (
-      <div
-        ref={handleDockRef}
-        className="fixed bottom-0 z-40 pointer-events-none select-none"
-        style={overlayStyle}
-        data-awaiting-spell-target={awaitingCardTarget ? "true" : "false"}
-      >
+    const ghost =
+      isPtrDragging && ptrDragCard ? (
         <div
-          className="mx-auto max-w-[1400px] flex justify-center gap-1.5 py-0.5"
+          ref={ghostRef}
           style={{
-            width: typeof wheelPanelWidth === "number" ? wheelPanelWidth : undefined,
-            maxWidth: "min(100vw, 1400px)",
+            position: "fixed",
+            left: 0,
+            top: 0,
+            transform: (() => {
+              const baseX = ptrPos.current.x;
+              const baseY = ptrPos.current.y;
+              const { x: offsetX, y: offsetY } = ghostOffsetRef.current;
+              return `translate(${baseX - offsetX}px, ${baseY - offsetY}px)`;
+            })(),
+            pointerEvents: "none",
+            zIndex: 9999,
           }}
+          aria-hidden
         >
-          {localFighter.hand.map((card, idx) => {
-            const isSelected = selectedCardId === card.id;
-            const cardSelectable = awaitingCardTarget && (stageLocation === "any" || stageLocation === "hand");
-            return (
-              <div key={card.id} className="group relative pointer-events-auto" style={{ zIndex: 10 + idx }}>
-                <motion.div
-                  data-hand-card
-                  initial={false}
-                  animate={{
-                    y: isSelected ? -Math.max(8, liftPx - 10) : -liftPx,
-                    opacity: 1,
-                    scale: isSelected ? 1.06 : 1,
-                  }}
-                  whileHover={{ y: -Math.max(8, liftPx - 10), opacity: 1, scale: 1.04 }}
-                  transition={{ type: "spring", stiffness: 320, damping: 22 }}
-                  className={`drop-shadow-xl ${isSelected ? "ring-2 ring-amber-300" : ""}`}
-                >
-                  <StSCard
-                    data-hand-card
-                    className="pointer-events-auto"
-                    card={card}
-                    selected={isSelected}
-                    disabled={awaitingManualTarget && !cardSelectable}
-                    onPick={() => {
-                      if (cardSelectable) {
-                        const side = localLegacySide;
-                        onSpellTargetSelect?.({ side, lane: null, card, location: "hand" });
-                        return;
-                      }
-                      if (awaitingManualTarget) return;
-                      if (!selectedCardId) {
-                        setSelectedCardId(card.id);
-                        return;
-                      }
-
-                      if (selectedCardId === card.id) {
-                        setSelectedCardId(null);
-                        return;
-                      }
-
-                      const lane = localLegacySide === "player" ? assign.player : assign.enemy;
-                      const slotIdx = lane.findIndex((c) => c?.id === selectedCardId);
-                      if (slotIdx !== -1) {
-                        assignToWheelLocal(slotIdx, card);
-                        return;
-                      }
-
-                      setSelectedCardId(card.id);
-                    }}
-                    draggable={!awaitingManualTarget}
-                    onDragStart={(e) => {
-                      if (awaitingManualTarget) return;
-                      setDragCardId(card.id);
-                      try {
-                        e.dataTransfer.setData("text/plain", card.id);
-                      } catch {}
-                      e.dataTransfer.effectAllowed = "move";
-                    }}
-                    onDragEnd={() => setDragCardId(null)}
-                    onPointerDown={(e) => {
-                      if (awaitingManualTarget) return;
-                      startPointerDrag(card, e);
-                    }}
-                    onTouchStart={(e) => {
-                      if (awaitingManualTarget) return;
-                      startTouchDrag(card, e);
-                    }}
-                    aria-pressed={isSelected}
-                    aria-label={`Select ${card.name}`}
-                  />
-                </motion.div>
-              </div>
-            );
-          })}
-      </div>
-        {isPtrDragging && ptrDragCard && (
-          <div
-            ref={ghostRef}
-            style={{
-              position: "fixed",
-              left: 0,
-              top: 0,
-              transform: (() => {
-                const baseX = ptrPos.current.x;
-                const baseY = ptrPos.current.y;
-                const { x: offsetX, y: offsetY } = ghostOffsetRef.current;
-                return `translate(${baseX - offsetX}px, ${baseY - offsetY}px)`;
-              })(),
-              pointerEvents: "none",
-              zIndex: 9999,
-            }}
-            aria-hidden
-          >
-            <div style={{ transform: "scale(0.9)", filter: "drop-shadow(0 6px 8px rgba(0,0,0,.35))" }}>
-              <StSCard card={ptrDragCard} />
-            </div>
+          <div style={{ transform: "scale(0.9)", filter: "drop-shadow(0 6px 8px rgba(0,0,0,.35))" }}>
+            <StSCard card={ptrDragCard} />
           </div>
-        )}
-      </div>
+        </div>
+      ) : null;
+
+    return (
+      <>
+        <div
+          ref={handleDockRef}
+          className="fixed bottom-0 z-40 pointer-events-none select-none"
+          style={overlayStyle}
+          data-awaiting-spell-target={awaitingCardTarget ? "true" : "false"}
+        >
+          <div
+            className="mx-auto max-w-[1400px] flex justify-center gap-1.5 py-0.5"
+            style={{
+              width: typeof wheelPanelWidth === "number" ? wheelPanelWidth : undefined,
+              maxWidth: "min(100vw, 1400px)",
+            }}
+          >
+            {localFighter.hand.map((card, idx) => {
+              const isSelected = selectedCardId === card.id;
+              const cardSelectable = awaitingCardTarget && (stageLocation === "any" || stageLocation === "hand");
+              return (
+                <div key={card.id} className="group relative pointer-events-auto" style={{ zIndex: 10 + idx }}>
+                  <motion.div
+                    data-hand-card
+                    initial={false}
+                    animate={{
+                      y: isSelected ? -Math.max(8, liftPx - 10) : -liftPx,
+                      opacity: 1,
+                      scale: isSelected ? 1.06 : 1,
+                    }}
+                    whileHover={{ y: -Math.max(8, liftPx - 10), opacity: 1, scale: 1.04 }}
+                    transition={{ type: "spring", stiffness: 320, damping: 22 }}
+                    className={`drop-shadow-xl ${isSelected ? "ring-2 ring-amber-300" : ""}`}
+                  >
+                    <StSCard
+                      data-hand-card
+                      className="pointer-events-auto"
+                      card={card}
+                      selected={isSelected}
+                      disabled={awaitingManualTarget && !cardSelectable}
+                      onPick={() => {
+                        if (cardSelectable) {
+                          const side = localLegacySide;
+                          onSpellTargetSelect?.({ side, lane: null, card, location: "hand" });
+                          return;
+                        }
+                        if (awaitingManualTarget) return;
+                        if (!selectedCardId) {
+                          setSelectedCardId(card.id);
+                          return;
+                        }
+
+                        if (selectedCardId === card.id) {
+                          setSelectedCardId(null);
+                          return;
+                        }
+
+                        const lane = localLegacySide === "player" ? assign.player : assign.enemy;
+                        const slotIdx = lane.findIndex((c) => c?.id === selectedCardId);
+                        if (slotIdx !== -1) {
+                          assignToWheelLocal(slotIdx, card);
+                          return;
+                        }
+
+                        setSelectedCardId(card.id);
+                      }}
+                      draggable={!awaitingManualTarget}
+                      onDragStart={(e) => {
+                        if (awaitingManualTarget) return;
+                        setDragCardId(card.id);
+                        try {
+                          e.dataTransfer.setData("text/plain", card.id);
+                        } catch {}
+                        e.dataTransfer.effectAllowed = "move";
+                      }}
+                      onDragEnd={() => setDragCardId(null)}
+                      onPointerDown={(e) => {
+                        if (awaitingManualTarget) return;
+                        startPointerDrag(card, e);
+                      }}
+                      onTouchStart={(e) => {
+                        if (awaitingManualTarget) return;
+                        startTouchDrag(card, e);
+                      }}
+                      aria-pressed={isSelected}
+                      aria-label={`Select ${card.name}`}
+                    />
+                  </motion.div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+        {ghostPortalTarget && ghost ? createPortal(ghost, ghostPortalTarget) : ghost}
+      </>
     );
   });
 


### PR DESCRIPTION
## Summary
- render the hand drag ghost card via a portal so it is no longer constrained by the transformed HandDock container
- initialize the portal target on mount to ensure the ghost renders in document.body when dragging

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e2566cd0908332bfa33b948ca22ba5