### PR TITLE
Adjust viewport sizing to use safe area units

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1062,8 +1062,11 @@ export default function ThreeWheel_WinsOnly({
 
   return (
     <div
-      className={`h-screen w-screen overflow-x-hidden overflow-y-hidden text-slate-100 p-1 grid gap-2 ${rootModeClassName}`}
-      style={{ gridTemplateRows: "auto auto 1fr auto" }}
+      className={`min-h-[100svh] w-full max-w-full overflow-x-hidden overflow-y-hidden text-slate-100 p-1 grid gap-2 ${rootModeClassName}`}
+      style={{
+        gridTemplateRows: "auto auto 1fr auto",
+        minHeight: "var(--app-min-height, 100svh)",
+      }}
       data-game-mode={effectiveGameMode}
       data-mana-enabled={grimoireAttrValue}
       data-spells-enabled={grimoireAttrValue}

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,30 @@
  * tailwind.config.js.  It also includes typographic rules for headings.
  */
 
+:root {
+  --app-min-height: 100vh;
+}
+
+@supports (height: 100svh) {
+  :root {
+    --app-min-height: 100svh;
+  }
+}
+
+@supports (height: 100dvh) {
+  :root {
+    --app-min-height: 100dvh;
+  }
+}
+
+html,
+body,
+#root {
+  min-height: 100vh;
+  min-height: var(--app-min-height, 100vh);
+  width: 100%;
+}
+
 body {
   /* Apply a warm wood background texture across the entire game.  The dark
    * slate fallback ensures the UI remains legible if the image fails to


### PR DESCRIPTION
## Summary
- replace the root app container sizing with safe viewport units to avoid browser chrome toggling during drags
- ensure the document root elements stretch to the viewport and expose a custom property fallback for safe viewport heights

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e25f7f32348332a2f0539bb40ed306