### PR TITLE
Reduce app viewport height to 75 percent

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1062,10 +1062,13 @@ export default function ThreeWheel_WinsOnly({
 
   return (
     <div
-      className={`min-h-[100svh] w-full max-w-full overflow-x-hidden overflow-y-hidden text-slate-100 p-1 grid gap-2 ${rootModeClassName}`}
+      className={`mx-auto w-full max-w-[720px] overflow-x-hidden overflow-y-hidden text-slate-100 p-1 grid gap-2 ${rootModeClassName}`}
       style={{
         gridTemplateRows: "auto auto 1fr auto",
-        minHeight: "var(--app-min-height, 100svh)",
+        minHeight: "var(--app-min-height, min(100svh, 1600px))",
+        height: "var(--app-min-height, min(100svh, 1600px))",
+        maxHeight: "var(--app-min-height, min(100svh, 1600px))",
+        maxWidth: "var(--app-max-width, min(100vw, 720px))",
       }}
       data-game-mode={effectiveGameMode}
       data-mana-enabled={grimoireAttrValue}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1062,8 +1062,11 @@ export default function ThreeWheel_WinsOnly({
 
   return (
     <div
-      className={`h-screen w-screen overflow-x-hidden overflow-y-hidden text-slate-100 p-1 grid gap-2 ${rootModeClassName}`}
-      style={{ gridTemplateRows: "auto auto 1fr auto" }}
+      className={`min-h-[75svh] w-full max-w-full overflow-x-hidden overflow-y-hidden text-slate-100 p-1 grid gap-2 ${rootModeClassName}`}
+      style={{
+        gridTemplateRows: "auto auto 1fr auto",
+        minHeight: "var(--app-min-height, 75svh)",
+      }}
       data-game-mode={effectiveGameMode}
       data-mana-enabled={grimoireAttrValue}
       data-spells-enabled={grimoireAttrValue}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1062,10 +1062,10 @@ export default function ThreeWheel_WinsOnly({
 
   return (
     <div
-      className={`min-h-[75svh] w-full max-w-full overflow-x-hidden overflow-y-hidden text-slate-100 p-1 grid gap-2 ${rootModeClassName}`}
+      className={`min-h-[100svh] w-full max-w-full overflow-x-hidden overflow-y-hidden text-slate-100 p-1 grid gap-2 ${rootModeClassName}`}
       style={{
         gridTemplateRows: "auto auto 1fr auto",
-        minHeight: "var(--app-min-height, 75svh)",
+        minHeight: "var(--app-min-height, 100svh)",
       }}
       data-game-mode={effectiveGameMode}
       data-mana-enabled={grimoireAttrValue}

--- a/src/index.css
+++ b/src/index.css
@@ -9,18 +9,31 @@
  */
 
 :root {
-  --app-min-height: 100vh;
+  --app-min-height: min(100vh, 1600px);
+  --app-max-width: min(100vw, 720px);
 }
 
 @supports (height: 100svh) {
   :root {
-    --app-min-height: 100svh;
+    --app-min-height: min(100svh, 1600px);
   }
 }
 
 @supports (height: 100dvh) {
   :root {
-    --app-min-height: 100dvh;
+    --app-min-height: min(100dvh, 1600px);
+  }
+}
+
+@supports (width: 100svw) {
+  :root {
+    --app-max-width: min(100svw, 720px);
+  }
+}
+
+@supports (width: 100dvw) {
+  :root {
+    --app-max-width: min(100dvw, 720px);
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -9,26 +9,26 @@
  */
 
 :root {
-  --app-min-height: 75vh;
+  --app-min-height: 100vh;
 }
 
 @supports (height: 100svh) {
   :root {
-    --app-min-height: 75svh;
+    --app-min-height: 100svh;
   }
 }
 
 @supports (height: 100dvh) {
   :root {
-    --app-min-height: 75dvh;
+    --app-min-height: 100dvh;
   }
 }
 
 html,
 body,
 #root {
-  min-height: 75vh;
-  min-height: var(--app-min-height, 75vh);
+  min-height: 100vh;
+  min-height: var(--app-min-height, 100vh);
   width: 100%;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,30 @@
  * tailwind.config.js.  It also includes typographic rules for headings.
  */
 
+:root {
+  --app-min-height: 75vh;
+}
+
+@supports (height: 100svh) {
+  :root {
+    --app-min-height: 75svh;
+  }
+}
+
+@supports (height: 100dvh) {
+  :root {
+    --app-min-height: 75dvh;
+  }
+}
+
+html,
+body,
+#root {
+  min-height: 75vh;
+  min-height: var(--app-min-height, 75vh);
+  width: 100%;
+}
+
 body {
   /* Apply a warm wood background texture across the entire game.  The dark
    * slate fallback ensures the UI remains legible if the image fails to


### PR DESCRIPTION
## Summary
- adjust the root app container to target 75% of the safe viewport height via the Tailwind utility and custom property fallback
- update the global CSS variable and html/body/#root min-height rules to reflect the new 75% viewport sizing across browsers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e25f7f32348332a2f0539bb40ed306