### PR TITLE
Adjust mobile wheel position

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1514,7 +1514,7 @@ export default function ThreeWheel_WinsOnly({
 
       {/* Wheels center */}
       <div
-        className="relative z-0 flex h-full items-center justify-center -translate-y-4 sm:-translate-y-6 lg:-translate-y-8"
+        className="relative z-0 flex h-full items-center justify-center -translate-y-[24px] sm:-translate-y-6 lg:-translate-y-8"
         style={{ paddingBottom: handClearance }}
       >
         <div


### PR DESCRIPTION
## Summary
- increase the base upward translation on the wheel stack so the wheels sit about 8px higher on narrow screens

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e26a1b77888332857faa7b165dac69