### PR TITLE
Highlight spell targets on cards and reserves

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -258,6 +258,7 @@ export default function ThreeWheel_WinsOnly({
     ptrDragType,
     lockedWheelSize,
     log,
+    spellHighlights,
   } = state;
 
   const {
@@ -409,6 +410,8 @@ export default function ThreeWheel_WinsOnly({
 
   const localHandCards = localLegacySide === "player" ? player.hand : enemy.hand;
   const localHandSymbols = useMemo(() => countSymbolsFromCards(localHandCards), [localHandCards]);
+  const spellHighlightedCardIds = spellHighlights.cards;
+  const reserveSpellHighlights = spellHighlights.reserve;
   const [spellLock, setSpellLock] = useState<{ round: number | null; ids: SpellId[] }>({
     round: null,
     ids: [],
@@ -1509,6 +1512,7 @@ export default function ThreeWheel_WinsOnly({
           onPlayerManaToggle={handlePlayerManaToggle}
           isGrimoireOpen={showGrimoire}
           playerManaButtonRef={playerManaButtonRef}
+          reserveSpellHighlights={reserveSpellHighlights}
         />
       </div>
 
@@ -1560,6 +1564,7 @@ export default function ThreeWheel_WinsOnly({
                 onWheelTargetSelect={handleWheelTargetSelect}
                 isAwaitingSpellTarget={isAwaitingSpellTarget}
                 variant="grouped"
+                spellHighlightedCardIds={spellHighlightedCardIds}
               />
             </div>
           ))}
@@ -1589,6 +1594,7 @@ export default function ThreeWheel_WinsOnly({
         pendingSpell={pendingSpell}
         isAwaitingSpellTarget={isAwaitingSpellTarget}
         onSpellTargetSelect={handleSpellTargetSelect}
+        spellHighlightedCardIds={spellHighlightedCardIds}
       />
 
       <FirstRunCoach

--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -30,6 +30,7 @@ type StSCardProps = {
   onPick?: () => void;
   className?: string;
   spellTargetable?: boolean;
+  spellAffected?: boolean;
   ariaLabel?: string;
   ariaPressed?: React.AriaAttributes["aria-pressed"];
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
@@ -46,6 +47,7 @@ export default memo(function StSCard({
   onPick,
   className,
   spellTargetable,
+  spellAffected,
   ariaLabel,
   ariaPressed,
   onClick,
@@ -70,6 +72,22 @@ export default memo(function StSCard({
       aria-pressed={ariaPressed}
       data-spell-targetable={spellTargetable ? "true" : undefined}
     >
+      {spellAffected ? (
+        <>
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 rounded-[12px] ring-2 ring-amber-300/70 animate-pulse"
+            style={{ boxShadow: "0 0 14px rgba(251,191,36,0.45)", zIndex: 3 }}
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -top-1 right-1 text-lg animate-pulse"
+            style={{ textShadow: "0 1px 4px rgba(0,0,0,0.7)", zIndex: 4 }}
+          >
+            ✨
+          </div>
+        </>
+      ) : null}
       <div className="absolute inset-0 rounded-xl border bg-gradient-to-br from-slate-600 to-slate-800 border-slate-400"></div>
       <div className="absolute inset-px rounded-[10px] bg-slate-900/85 backdrop-blur-[1px] border border-slate-700/70" />
       <div className="absolute inset-0 flex flex-col items-center justify-center">

--- a/src/features/threeWheel/components/HUDPanels.tsx
+++ b/src/features/threeWheel/components/HUDPanels.tsx
@@ -25,6 +25,7 @@ interface HUDPanelsProps {
   onPlayerManaToggle?: () => void;
   isGrimoireOpen?: boolean;
   playerManaButtonRef?: React.Ref<HTMLButtonElement>;
+  reserveSpellHighlights: Record<LegacySide, boolean>;
 }
 
 const HUDPanels: React.FC<HUDPanelsProps> = ({
@@ -41,6 +42,7 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
   onPlayerManaToggle,
   isGrimoireOpen,
   playerManaButtonRef,
+  reserveSpellHighlights,
 }) => {
   const rsP = reserveSums ? reserveSums.player : null;
   const rsE = reserveSums ? reserveSums.enemy : null;
@@ -54,6 +56,7 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
     const hasInit = initiative === side;
     const isReserveVisible =
       (phase === "showEnemy" || phase === "anim" || phase === "roundEnd" || phase === "ended") && rs !== null;
+    const reserveHighlighted = Boolean(reserveSpellHighlights?.[side]);
 
     const manaCount = isPlayer ? manaPools.player : manaPools.enemy;
 
@@ -158,12 +161,23 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
                   background: "#1b1209ee",
                   borderColor: theme.slotBorder,
                   color: theme.textWarm,
+                  boxShadow: reserveHighlighted ? "0 0 12px rgba(251,191,36,0.4)" : undefined,
                 }}
                 title={rs !== null ? `Reserve: ${rs}` : undefined}
+                data-spell-affected={reserveHighlighted ? "true" : undefined}
               >
                 <span className="sm:hidden mr-1">Reserve:</span>
                 <span className="hidden sm:inline">Reserve: </span>
                 <span className="font-bold tabular-nums">{rs ?? 0}</span>
+                {reserveHighlighted ? (
+                  <span
+                    aria-hidden
+                    className="ml-1 text-sm leading-none animate-pulse"
+                    style={{ textShadow: "0 1px 4px rgba(0,0,0,0.7)" }}
+                  >
+                    ✨
+                  </span>
+                ) : null}
               </div>
             )}
           </div>

--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -50,6 +50,7 @@ interface HandDockProps {
     card: Card;
     location: SpellTargetLocation;
   }) => void;
+  spellHighlightedCardIds: readonly string[];
 }
 
 const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
@@ -74,6 +75,7 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
     pendingSpell,
     isAwaitingSpellTarget,
     onSpellTargetSelect,
+    spellHighlightedCardIds,
   }, forwardedRef) => {
     const dockRef = useRef<HTMLDivElement | null>(null);
     const ghostRef = useRef<HTMLDivElement | null>(null);
@@ -209,6 +211,8 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
 
     const stageLocation = activeStage?.type === "card" ? activeStage.location ?? "board" : null;
 
+    const spellHighlightSet = useMemo(() => new Set(spellHighlightedCardIds), [spellHighlightedCardIds]);
+
     const ghost =
       isPtrDragging && ptrDragCard ? (
         <div
@@ -251,6 +255,7 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
           >
             {localFighter.hand.map((card, idx) => {
               const isSelected = selectedCardId === card.id;
+              const isSpellAffected = spellHighlightSet.has(card.id);
               const cardSelectable = awaitingCardTarget && (stageLocation === "any" || stageLocation === "hand");
               return (
                 <div key={card.id} className="group relative pointer-events-auto" style={{ zIndex: 10 + idx }}>
@@ -272,6 +277,7 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
                       card={card}
                       selected={isSelected}
                       disabled={awaitingManualTarget && !cardSelectable}
+                      spellAffected={isSpellAffected}
                       onPick={() => {
                         if (cardSelectable) {
                           const side = localLegacySide;

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import CanvasWheel, { WheelHandle } from "../../../components/CanvasWheel";
 import StSCard from "../../../components/StSCard";
 import type { Card, Fighter, Phase, Section } from "../../../game/types";
@@ -70,6 +70,7 @@ export interface WheelPanelProps {
     targets: SpellTargetInstance[];
     currentStage: number;
   } | null;
+  spellHighlightedCardIds: readonly string[];
   onSpellTargetSelect?: (selection: {
     side: LegacySide;
     lane: number | null;
@@ -131,6 +132,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
   onWheelTargetSelect,
   isAwaitingSpellTarget,
   variant = "standalone",
+  spellHighlightedCardIds,
 }) => {
   const playerCard = assign.player[index];
   const enemyCard = assign.enemy[index];
@@ -161,6 +163,8 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
   const pendingOwnership: SpellTargetOwnership | null = awaitingCardTarget && activeStage?.type === "card"
     ? activeStage.ownership
     : null;
+
+  const spellHighlightSet = useMemo(() => new Set(spellHighlightedCardIds), [spellHighlightedCardIds]);
 
   const leftSlot: SlotView = { side: "player", card: playerCard, name: namesByLegacy.player };
   const rightSlot: SlotView = { side: "enemy", card: enemyCard, name: namesByLegacy.enemy };
@@ -259,6 +263,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
   ) => {
     if (!slot.card) return null;
     const card = slot.card;
+    const isSpellAffected = spellHighlightSet.has(card.id);
     const canInteractNormally =
       !awaitingSpellTarget && slot.side === localLegacySide && phase === "choose" && isWheelActive;
 
@@ -310,6 +315,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
         size="sm"
         disabled={!cardInteractable}
         selected={isSlotSelected}
+        spellAffected={isSpellAffected}
         onPick={handlePick}
         draggable={canInteractNormally}
         onDragStart={handleDragStart}


### PR DESCRIPTION
## Summary
- track recent spell effect targets in the game hook and expose highlight metadata
- surface spell highlights to hand, wheel, and HUD components and render glowing overlays
- add card-level sparkle indicators and reserve HUD flare to show active spell effects

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e3e126eb8483328e7a904d2b68d08c