### PR TITLE
Refine spell effects to only apply intended outcomes

### DIFF
--- a/src/features/threeWheel/utils/spellEffectTransforms.ts
+++ b/src/features/threeWheel/utils/spellEffectTransforms.ts
@@ -42,7 +42,13 @@ export type SpellEffectPayload = {
   handAdjustments?: Array<{ side: LegacySide; cardId: string; numberDelta?: number }>;
   handDiscards?: Array<{ side: LegacySide; cardId: string }>;
   positionSwaps?: Array<{ side: LegacySide; laneA: number; laneB: number }>;
-  initiativeChallenges?: Array<{ side: LegacySide; lane: number; cardId: string; mode: "higher" | "lower" }>;
+  initiativeChallenges?: Array<{
+    side: LegacySide;
+    lane: number;
+    cardId: string;
+    mode: "higher" | "lower";
+    winOnTie?: boolean;
+  }>;
   chilledCards?: ChilledCardUpdate[];
   delayedEffects?: string[];
   initiative?: LegacySide | null;

--- a/src/game/spellEffectHandlers.ts
+++ b/src/game/spellEffectHandlers.ts
@@ -468,8 +468,10 @@ export function handleInitiativeEffects<CardT extends { id: string }>(
       const opponentCard = opponentLanes[laneIndex as number] as CardLikeWithValues | null;
       const challengerValue = getCardValue(challengerCard);
       const opponentValue = getCardValue(opponentCard);
-      const success =
-        challenge.mode === "lower" ? challengerValue < opponentValue : challengerValue > opponentValue;
+      const winOnTie = challenge.winOnTie === true;
+      const success = challenge.mode === "lower"
+        ? challengerValue < opponentValue || (winOnTie && challengerValue === opponentValue)
+        : challengerValue > opponentValue || (winOnTie && challengerValue === opponentValue);
       if (success) {
         setInitiative(challengerSide);
       }

--- a/src/game/spellEngine.ts
+++ b/src/game/spellEngine.ts
@@ -334,11 +334,21 @@ export function resolvePendingSpell(params: ResolveSpellParams): SpellResolution
           if (!owner) return null;
           const mode = (entry as { mode?: unknown }).mode;
           const normalizedMode = mode === "lower" ? "lower" : "higher";
-          return { side: owner, lane: lane as number, cardId, mode: normalizedMode };
+          const winOnTie = (entry as { winOnTie?: unknown }).winOnTie === true;
+          return winOnTie
+            ? { side: owner, lane: lane as number, cardId, mode: normalizedMode, winOnTie: true }
+            : { side: owner, lane: lane as number, cardId, mode: normalizedMode };
         })
         .filter(
-          (entry): entry is { side: LegacySide; lane: number; cardId: string; mode: "higher" | "lower" } =>
-            entry !== null,
+          (
+            entry,
+          ): entry is {
+            side: LegacySide;
+            lane: number;
+            cardId: string;
+            mode: "higher" | "lower";
+            winOnTie?: boolean;
+          } => entry !== null,
         )
     : undefined;
 

--- a/tests/spellEffects.test.ts
+++ b/tests/spellEffects.test.ts
@@ -12,6 +12,7 @@ import {
   type AssignmentState,
   type SpellEffectPayload,
 } from "../src/game/spellEngine.js";
+import { handleInitiativeEffects } from "../src/game/spellEffectHandlers.js";
 import type { Card, Fighter } from "../src/game/types.js";
 
 const opponentOf = (side: LegacySide): LegacySide => (side === "player" ? "enemy" : "player");
@@ -199,6 +200,37 @@ const opponentOf = (side: LegacySide): LegacySide => (side === "player" ? "enemy
   assert.deepEqual(tokens, [0, 0, 0]);
   assert.deepEqual(reserveSums, { player: 5, enemy: 5 });
   assert.deepEqual(chillStacks, { player: [0, 0, 0], enemy: [0, 0, 0] });
+}
+
+// handleInitiativeEffects honors winOnTie when challenge values match.
+{
+  const assignState: AssignmentState<Card> = {
+    player: [
+      { id: "p0", name: "Duelist", number: 4, tags: [] },
+      null,
+      null,
+    ],
+    enemy: [
+      { id: "e0", name: "Raider", number: 4, tags: [] },
+      null,
+      null,
+    ],
+  };
+  let initiative: LegacySide = "enemy";
+
+  handleInitiativeEffects<Card>({
+    initiativeChallenges: [
+      { side: "player", lane: 0, cardId: "p0", mode: "higher", winOnTie: true },
+    ],
+    initiativeTarget: null,
+    latestAssignments: assignState,
+    setInitiative: (side) => {
+      initiative = side;
+    },
+    currentInitiative: initiative,
+  });
+
+  assert.equal(initiative, "player");
 }
 
 console.log("spellEffects tests passed");


### PR DESCRIPTION
## Summary
- keep Fireball focused on damage plus its optional 🔥 boost by removing the hidden cost escalation
- let Ice Shard's optional 🗡️ pick add an extra freeze stack and update spell text accordingly
- implement Sudden Strike's tie-breaking option by extending initiative challenges to support tie wins and cover the behavior with tests

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e40cf0a6088332b9df9c59c9522722