### PR TITLE
Fix appendLog initialization in three wheel hook

### DIFF
--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -706,6 +706,11 @@ export function useThreeWheelGame({
   const START_LOG = `A ${enemyName} eyes your purse...`;
   const [log, setLog] = useState<GameLogEntry[]>(() => [createLogEntry(START_LOG)]);
 
+  const appendLog = useCallback((message: string, options?: { type?: GameLogEntryType }) => {
+    const entry = createLogEntry(message, options?.type ?? "general");
+    setLog((prev) => [entry, ...prev].slice(0, 60));
+  }, []);
+
   const [spellHighlights, setSpellHighlights] = useState<SpellHighlightState>(() => createEmptySpellHighlights());
   const spellHighlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [skillState, setSkillState] = useState<SkillPhaseState | null>(null);
@@ -1265,11 +1270,6 @@ export function useThreeWheelGame({
         spellHighlightTimeoutRef.current = null;
       }
     };
-  }, []);
-
-  const appendLog = useCallback((message: string, options?: { type?: GameLogEntryType }) => {
-    const entry = createLogEntry(message, options?.type ?? "general");
-    setLog((prev) => [entry, ...prev].slice(0, 60));
   }, []);
 
   const canReveal = useMemo(() => {


### PR DESCRIPTION
## Summary
- define the appendLog callback alongside the log state so it can be referenced by other hooks without hitting the temporal dead zone

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e41dade90483329f5cfed090259754