### PR TITLE
Adjust skill phase flow and interactions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1343,37 +1343,11 @@ export default function ThreeWheel_WinsOnly({
               <div className="text-sm font-semibold text-slate-200">Skill Phase</div>
               <div className="text-xs text-slate-300 max-w-xs">
                 {skillPhase.activeSide === localLegacySide
-                  ? "Activate a skill or pass to end your turn."
+                  ? "Click a card to use its skill or pass to end your turn."
                   : `Waiting for ${namesByLegacy[skillPhase.activeSide]}...`}
               </div>
-              {skillPhase.activeSide === localLegacySide && (
-                <ul className="flex flex-col gap-2 max-w-xs text-left">
-                  {skillPhase.options.length === 0 ? (
-                    <li className="text-xs text-slate-400">No ready skills.</li>
-                  ) : (
-                    skillPhase.options.map((option) => (
-                      <li key={option.card.id} className="rounded border border-slate-700 bg-slate-800/70 p-2 text-xs">
-                        <div className="flex items-center justify-between gap-2">
-                          <div className="font-semibold text-slate-100 truncate">
-                            {option.card.name ?? `Card ${option.lane + 1}`}
-                          </div>
-                          <button
-                            type="button"
-                            className="rounded bg-emerald-400 px-2 py-0.5 text-[11px] font-semibold text-slate-900 disabled:opacity-50"
-                            onClick={() => activateSkillOption(option.lane)}
-                            disabled={!option.canActivate}
-                          >
-                            Activate
-                          </button>
-                        </div>
-                        <div className="mt-1 text-slate-300">{option.description}</div>
-                        {!option.canActivate && option.reason ? (
-                          <div className="mt-1 text-[11px] text-rose-300">{option.reason}</div>
-                        ) : null}
-                      </li>
-                    ))
-                  )}
-                </ul>
+              {skillPhase.activeSide === localLegacySide && skillPhase.options.every((opt) => !opt.canActivate) && (
+                <div className="text-xs text-slate-400">No ready skills.</div>
               )}
               {skillPhase.activeSide === localLegacySide && (
                 <button
@@ -1621,6 +1595,15 @@ export default function ThreeWheel_WinsOnly({
                 spellHighlightedCardIds={spellHighlightedCardIds}
                 skillExhausted={skillPhase?.exhausted ?? null}
                 isSkillMode={isSkillMode}
+                onSkillActivate={activateSkillOption}
+                skillPhaseActiveSide={skillPhase?.activeSide ?? null}
+                skillOptions={
+                  skillPhase?.options.map((option) => ({
+                    lane: option.lane,
+                    canActivate: option.canActivate,
+                    reason: option.reason,
+                  })) ?? []
+                }
               />
             </div>
           ))}
@@ -1651,6 +1634,7 @@ export default function ThreeWheel_WinsOnly({
         isAwaitingSpellTarget={isAwaitingSpellTarget}
         onSpellTargetSelect={handleSpellTargetSelect}
         spellHighlightedCardIds={spellHighlightedCardIds}
+        isSkillMode={isSkillMode}
       />
 
       <FirstRunCoach

--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -35,6 +35,7 @@ type StSCardProps = {
   ariaLabel?: string;
   ariaPressed?: React.AriaAttributes["aria-pressed"];
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  showSkillColor?: boolean;
 } & Omit<
   React.ButtonHTMLAttributes<HTMLButtonElement>,
   "onClick" | "children" | "className" | "disabled" | "aria-label" | "aria-pressed"
@@ -52,12 +53,16 @@ export default memo(function StSCard({
   ariaLabel,
   ariaPressed,
   onClick,
+  showSkillColor = false,
   style,
   ...buttonProps
 }: StSCardProps) {
   const dims = size === "lg" ? { w: 120, h: 160 } : size === "md" ? { w: 92, h: 128 } : { w: 72, h: 96 };
   const arcana = useMemo(() => getCardArcana(card), [card]);
-  const skillNumberColor = useMemo(() => getSkillAbilityColorClass(card), [card]);
+  const skillNumberColor = useMemo(
+    () => (showSkillColor ? getSkillAbilityColorClass(card) : null),
+    [card, showSkillColor],
+  );
 
   return (
     <button

--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -51,6 +51,7 @@ interface HandDockProps {
     location: SpellTargetLocation;
   }) => void;
   spellHighlightedCardIds: readonly string[];
+  isSkillMode?: boolean;
 }
 
 const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
@@ -76,6 +77,7 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
     isAwaitingSpellTarget,
     onSpellTargetSelect,
     spellHighlightedCardIds,
+    isSkillMode = false,
   }, forwardedRef) => {
     const dockRef = useRef<HTMLDivElement | null>(null);
     const ghostRef = useRef<HTMLDivElement | null>(null);
@@ -232,9 +234,9 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
           }}
           aria-hidden
         >
-          <div style={{ transform: "scale(0.9)", filter: "drop-shadow(0 6px 8px rgba(0,0,0,.35))" }}>
-            <StSCard card={ptrDragCard} />
-          </div>
+      <div style={{ transform: "scale(0.9)", filter: "drop-shadow(0 6px 8px rgba(0,0,0,.35))" }}>
+        <StSCard card={ptrDragCard} showSkillColor={isSkillMode} />
+      </div>
         </div>
       ) : null;
 
@@ -276,6 +278,7 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
                       className="pointer-events-auto"
                       card={card}
                       selected={isSelected}
+                      showSkillColor={isSkillMode}
                       disabled={awaitingManualTarget && !cardSelectable}
                       spellAffected={isSpellAffected}
                       onPick={() => {


### PR DESCRIPTION
## Summary
- start the skill phase after the resolve animation completes and update state transitions accordingly
- allow players to trigger skills directly from cards with inline guidance instead of the previous popup
- surface skill-specific number colors on cards throughout skill mode, including in the hand dock

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4216104ec8332bab13bf98f01ae1a