### PR TITLE
Fix skill mode player card number colors

### DIFF
--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -105,6 +105,7 @@ export default memo(function StSCard({
         ) : (
           <div
             className={`mt+10 text-3xl font-extrabold ${skillNumberColor ?? "text-white/90"}`}
+            data-skill-color={skillNumberColor ? "true" : undefined}
           >
             {fmtNum(card.number as number)}
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -132,7 +132,7 @@ button[aria-label^="Card"] > div:nth-child(2) {
   background-color: transparent;
   border: none;
 }
-button[aria-label^="Card"] .text-3xl {
+button[aria-label^="Card"] .text-3xl:not([data-skill-color="true"]) {
   color: #f5e7c4;
 }
 


### PR DESCRIPTION
## Summary
- prevent the hand card styling from overriding skill number colors
- flag skill-colored card numbers so the default hand theme is skipped

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e426c752208332b8284b953f81f20c