### PR TITLE
Adjust skill reserve targeting and descriptions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1092,6 +1092,8 @@ export default function ThreeWheel_WinsOnly({
     switch (skillTargeting.ability) {
       case "swapReserve":
         return "Select a reserve card to swap in.";
+      case "rerollReserve":
+        return "Select a reserve card to cycle.";
       case "reserveBoost":
         return "Select a reserve card to exhaust for a boost.";
       default:

--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -208,6 +208,8 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
       switch (skillTargeting.ability) {
         case "swapReserve":
           return new Set(fighter.hand.map((card) => card.id));
+        case "rerollReserve":
+          return new Set(fighter.hand.map((card) => card.id));
         case "reserveBoost":
           return new Set(
             fighter.hand

--- a/src/game/skills.ts
+++ b/src/game/skills.ts
@@ -18,13 +18,13 @@ export function describeSkillAbility(ability: SkillAbility, card: Card): string 
   const value = typeof card.number === "number" ? fmtNum(card.number) : "0";
   switch (ability) {
     case "swapReserve":
-      return "Swap this card with one from your reserve.";
+      return "Swap this card with any reserve card, replacing it on the board.";
     case "rerollReserve":
-      return "Discard your reserve cards and draw replacements.";
+      return "Discard a reserve card you select and draw a replacement.";
     case "boostSelf":
       return `Add ${value} to a card in play.`;
     case "reserveBoost":
-      return "Exhaust a reserve card to add its value to a card in play.";
+      return "Exhaust a reserve card to add its value to a card in play, exhausting it in the process.";
     default:
       return "Activate skill.";
   }


### PR DESCRIPTION
## Summary
- update skill descriptions to reflect the refreshed reserve abilities
- allow swap, reroll, and reserve boost skills to target specific reserve cards when needed
- refresh reserve targeting prompts and selection handling so cycling and boost skills register clicks correctly

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e42bc54fd483328533ed44c67b0a05