### PR TITLE
Adjust skill reserve targeting, descriptions, and restore colors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1092,6 +1092,8 @@ export default function ThreeWheel_WinsOnly({
     switch (skillTargeting.ability) {
       case "swapReserve":
         return "Select a reserve card to swap in.";
+      case "rerollReserve":
+        return "Select a reserve card to cycle.";
       case "reserveBoost":
         return "Select a reserve card to exhaust for a boost.";
       default:

--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -3,7 +3,12 @@ import React, { memo, useMemo } from "react";
 import type { Arcana, Card } from "../game/types";
 import { getArcanaIcon, getCardArcana } from "../game/arcana";
 import { fmtNum, isSplit } from "../game/values";
-import { getSkillAbilityColorClass } from "../game/skills";
+import {
+  SKILL_ABILITY_COLORS,
+  SKILL_ABILITY_COLOR_HEX,
+  determineSkillAbility,
+  type SkillAbility,
+} from "../game/skills";
 
 const ARCANA_COLOR_CLASS: Record<Arcana, string> = {
   fire: "text-orange-300",
@@ -59,10 +64,24 @@ export default memo(function StSCard({
 }: StSCardProps) {
   const dims = size === "lg" ? { w: 120, h: 160 } : size === "md" ? { w: 92, h: 128 } : { w: 72, h: 96 };
   const arcana = useMemo(() => getCardArcana(card), [card]);
-  const skillNumberColor = useMemo(
-    () => (showSkillColor ? getSkillAbilityColorClass(card) : null),
-    [card, showSkillColor],
-  );
+  const { skillNumberClass, skillNumberHex, skillAbility } = useMemo<{
+    skillNumberClass: string | null;
+    skillNumberHex: string | null;
+    skillAbility: SkillAbility | null;
+  }>(() => {
+    if (!showSkillColor) {
+      return { skillNumberClass: null, skillNumberHex: null, skillAbility: null };
+    }
+    const ability = determineSkillAbility(card);
+    if (!ability) {
+      return { skillNumberClass: null, skillNumberHex: null, skillAbility: null };
+    }
+    return {
+      skillNumberClass: SKILL_ABILITY_COLORS[ability],
+      skillNumberHex: SKILL_ABILITY_COLOR_HEX[ability],
+      skillAbility: ability,
+    };
+  }, [card, showSkillColor]);
 
   return (
     <button
@@ -104,8 +123,10 @@ export default memo(function StSCard({
           </div>
         ) : (
           <div
-            className={`mt+10 text-3xl font-extrabold ${skillNumberColor ?? "text-white/90"}`}
-            data-skill-color={skillNumberColor ? "true" : undefined}
+            className={`mt+10 text-3xl font-extrabold ${skillNumberClass ?? "text-white/90"}`}
+            data-skill-color={skillNumberClass ? "true" : undefined}
+            data-skill-ability={skillAbility ?? undefined}
+            style={skillNumberHex ? { color: skillNumberHex } : undefined}
           >
             {fmtNum(card.number as number)}
           </div>

--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -208,6 +208,8 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
       switch (skillTargeting.ability) {
         case "swapReserve":
           return new Set(fighter.hand.map((card) => card.id));
+        case "rerollReserve":
+          return new Set(fighter.hand.map((card) => card.id));
         case "reserveBoost":
           return new Set(
             fighter.hand

--- a/src/game/skills.ts
+++ b/src/game/skills.ts
@@ -18,13 +18,13 @@ export function describeSkillAbility(ability: SkillAbility, card: Card): string 
   const value = typeof card.number === "number" ? fmtNum(card.number) : "0";
   switch (ability) {
     case "swapReserve":
-      return "Swap this card with one from your reserve.";
+      return "Swap this card with any reserve card, replacing it on the board.";
     case "rerollReserve":
-      return "Discard your reserve cards and draw replacements.";
+      return "Discard a reserve card you select and draw a replacement.";
     case "boostSelf":
       return `Add ${value} to a card in play.`;
     case "reserveBoost":
-      return "Exhaust a reserve card to add its value to a card in play.";
+      return "Exhaust a reserve card to add its value to a card in play, exhausting it in the process.";
     default:
       return "Activate skill.";
   }
@@ -37,7 +37,19 @@ export const SKILL_ABILITY_COLORS: Record<SkillAbility, string> = {
   reserveBoost: "text-emerald-300",
 };
 
+export const SKILL_ABILITY_COLOR_HEX: Record<SkillAbility, string> = {
+  swapReserve: "#fcd34d", // amber-300
+  rerollReserve: "#7dd3fc", // sky-300
+  boostSelf: "#fda4af", // rose-300
+  reserveBoost: "#6ee7b7", // emerald-300
+};
+
 export function getSkillAbilityColorClass(card: Card | null): string | null {
   const ability = determineSkillAbility(card);
   return ability ? SKILL_ABILITY_COLORS[ability] : null;
+}
+
+export function getSkillAbilityColorHex(card: Card | null): string | null {
+  const ability = determineSkillAbility(card);
+  return ability ? SKILL_ABILITY_COLOR_HEX[ability] : null;
 }


### PR DESCRIPTION
## Summary
- update skill descriptions to reflect the refreshed reserve abilities
- allow swap, reroll, and reserve boost skills to target specific reserve cards when needed
- refresh reserve targeting prompts and selection handling so cycling and boost skills register clicks correctly
- restore skill mode number coloring so each ability keeps its distinct hue

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e42bc54fd483328533ed44c67b0a05