### PR TITLE
Fix reserve skill selection handler

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -355,7 +355,7 @@ export default function ThreeWheel_WinsOnly({
   );
 
   const handleSkillReserveSelect = useCallback(
-    (cardId: string) => {
+    ({ cardId }: { cardId: string }) => {
       handleSkillTargetSelect({ kind: "reserve", cardId });
     },
     [handleSkillTargetSelect],


### PR DESCRIPTION
## Summary
- adjust the skill reserve selection callback to accept the card selection object
- ensure reserve ability activations receive the selected card id correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4334d2dd08332af014404fc5f4da3