### PR TITLE
Fix reserve card selection handler in skill mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -355,7 +355,7 @@ export default function ThreeWheel_WinsOnly({
   );
 
   const handleSkillReserveSelect = useCallback(
-    (cardId: string) => {
+    ({ cardId }: { cardId: string }) => {
       handleSkillTargetSelect({ kind: "reserve", cardId });
     },
     [handleSkillTargetSelect],


### PR DESCRIPTION
## Summary
- ensure the skill reserve selection callback accepts the card selection object so the correct id is passed downstream

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4344ba05883329ffb3784c3a415b9