### PR TITLE
Fix skill ability targeting using printed card values

### DIFF
--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -1921,6 +1921,7 @@ export function useThreeWheelGame({
             : `pad-${Date.now()}-${Math.random().toString(36).slice(2)}`,
         name: "Reserve",
         number: 0,
+        baseNumber: 0,
         kind: "normal",
       } as unknown as Card);
     }

--- a/src/features/threeWheel/utils/combat.ts
+++ b/src/features/threeWheel/utils/combat.ts
@@ -71,6 +71,7 @@ export function ensureFiveHand<T extends Fighter>(f: T, TARGET = 5): T {
           : `pad-${Date.now()}-${Math.random().toString(36).slice(2)}`,
       name: "Reserve",
       number: 0,
+      baseNumber: 0,
       kind: "normal",
     } as unknown as Card);
   }

--- a/src/game/skills.ts
+++ b/src/game/skills.ts
@@ -6,7 +6,12 @@ export type SkillAbility = "swapReserve" | "rerollReserve" | "boostSelf" | "rese
 export function determineSkillAbility(card: Card | null): SkillAbility | null {
   if (!card) return null;
   if (!isNormal(card)) return null;
-  const value = typeof card.number === "number" ? card.number : null;
+  const value =
+    typeof card.baseNumber === "number"
+      ? card.baseNumber
+      : typeof card.number === "number"
+        ? card.number
+        : null;
   if (value === null) return null;
   if (value <= 0) return "swapReserve";
   if (value === 1 || value === 2) return "rerollReserve";
@@ -15,7 +20,13 @@ export function determineSkillAbility(card: Card | null): SkillAbility | null {
 }
 
 export function describeSkillAbility(ability: SkillAbility, card: Card): string {
-  const value = typeof card.number === "number" ? fmtNum(card.number) : "0";
+  const printedValue =
+    typeof card.baseNumber === "number"
+      ? card.baseNumber
+      : typeof card.number === "number"
+        ? card.number
+        : 0;
+  const value = fmtNum(printedValue);
   switch (ability) {
     case "swapReserve":
       return "Swap this card with any reserve card, replacing it on the board.";

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -36,6 +36,11 @@ export type Card = {
   name: string;
   type?: CardType;      // default "normal"
   number?: number;      // when type === "normal"
+  /**
+   * Tracks the printed number for skill calculations so buffs/debuffs don't
+   * change a card's intrinsic ability.
+   */
+  baseNumber?: number;
   leftValue?: number;   // when type === "split"
   rightValue?: number;  // when type === "split"
   tags: TagId[];

--- a/src/player/profileStore.tsx
+++ b/src/player/profileStore.tsx
@@ -523,6 +523,7 @@ function cardFromId(cardId: string): Card {
     name: `${num}`,
     type: "normal",
     number: num,
+    baseNumber: num,
     tags: [],
   };
 
@@ -550,6 +551,7 @@ function buildGrimoireDeck(symbols: GrimoireSymbols): Card[] {
       name: `${number}`,
       type: "normal",
       number,
+      baseNumber: number,
       tags: [],
       arcana,
     };
@@ -564,6 +566,7 @@ function buildGrimoireDeck(symbols: GrimoireSymbols): Card[] {
       name: `${number}`,
       type: "normal",
       number,
+      baseNumber: number,
       tags: ["grimoireFiller"],
     };
     cards.push(filler);


### PR DESCRIPTION
## Summary
- add a `baseNumber` field to cards so skills reference the printed value instead of buffs
- update skill ability logic to rely on the printed value and keep descriptions consistent
- ensure generated and filler cards populate `baseNumber` to stabilize skill targeting

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e436c034e08332a4a75047ce8c13d0