### PR TITLE
Color-code skill mode cards by ability

### DIFF
--- a/src/game/skills.ts
+++ b/src/game/skills.ts
@@ -69,6 +69,46 @@ export const SKILL_ABILITY_COLOR_HEX: Record<SkillAbility, string> = {
   reserveBoost: "#6ee7b7", // emerald-300
 };
 
+export const SKILL_ABILITY_CARD_TINTS: Record<
+  SkillAbility,
+  {
+    backgroundFrom: string;
+    backgroundTo: string;
+    border: string;
+    innerBorder: string;
+    glow: string;
+  }
+> = {
+  swapReserve: {
+    backgroundFrom: "rgba(252, 211, 77, 0.35)",
+    backgroundTo: "rgba(217, 119, 6, 0.25)",
+    border: "rgba(251, 191, 36, 0.65)",
+    innerBorder: "rgba(202, 138, 4, 0.55)",
+    glow: "0 0 18px rgba(251, 191, 36, 0.35)",
+  },
+  rerollReserve: {
+    backgroundFrom: "rgba(125, 211, 252, 0.38)",
+    backgroundTo: "rgba(14, 165, 233, 0.22)",
+    border: "rgba(125, 211, 252, 0.6)",
+    innerBorder: "rgba(56, 189, 248, 0.55)",
+    glow: "0 0 18px rgba(125, 211, 252, 0.35)",
+  },
+  boostSelf: {
+    backgroundFrom: "rgba(253, 164, 175, 0.38)",
+    backgroundTo: "rgba(244, 63, 94, 0.24)",
+    border: "rgba(251, 113, 133, 0.6)",
+    innerBorder: "rgba(244, 63, 94, 0.55)",
+    glow: "0 0 18px rgba(251, 113, 133, 0.35)",
+  },
+  reserveBoost: {
+    backgroundFrom: "rgba(110, 231, 183, 0.4)",
+    backgroundTo: "rgba(5, 150, 105, 0.24)",
+    border: "rgba(134, 239, 172, 0.6)",
+    innerBorder: "rgba(16, 185, 129, 0.55)",
+    glow: "0 0 18px rgba(52, 211, 153, 0.35)",
+  },
+};
+
 export function getSkillAbilityColorClass(card: Card | null): string | null {
   const ability = determineSkillAbility(card);
   return ability ? SKILL_ABILITY_COLORS[ability] : null;

--- a/src/index.css
+++ b/src/index.css
@@ -125,10 +125,13 @@ button[aria-label^="Card"] {
   background-position: center;
   border: none;
 }
-button[aria-label^="Card"] > div:first-child {
+button[aria-label^="Card"]:not([data-skill-ability]) > div:first-child {
   opacity: 0;
 }
-button[aria-label^="Card"] > div:nth-child(2) {
+button[aria-label^="Card"][data-skill-ability] > div:first-child {
+  opacity: 1;
+}
+button[aria-label^="Card"]:not([data-skill-ability]) > div:nth-child(2) {
   background-color: transparent;
   border: none;
 }


### PR DESCRIPTION
## Summary
- add reusable tint values for each skill ability
- render StS cards with ability metadata and gradients when skill mode is active
- adjust card CSS so skill mode cards display their tint instead of the wood frame

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e44029bfc48332ac4d2c713fab6d77