### PR TITLE
Adjust skill mode overlays

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1393,7 +1393,6 @@ export default function ThreeWheel_WinsOnly({
           )}
           {phase === "skill" && isSkillMode && skillPhase && (
             <div className="flex flex-col items-end gap-2 text-right">
-              <div className="text-sm font-semibold text-slate-200">Skill Phase</div>
               {skillPhase.activeSide === localLegacySide && skillPhase.options.every((opt) => !opt.canActivate) && (
                 <div className="text-xs text-slate-400">No ready skills.</div>
               )}
@@ -1602,20 +1601,16 @@ export default function ThreeWheel_WinsOnly({
           reserveSpellHighlights={reserveSpellHighlights}
         />
       </div>
-
-      {skillPhaseMessage && (
-        <div className="relative z-10 -mt-2 mb-2 flex justify-center px-2">
-          <div className="max-w-md rounded-lg border border-slate-700 bg-slate-900/90 px-3 py-1.5 text-center text-xs text-slate-200 shadow">
-            {skillPhaseMessage}
-          </div>
-        </div>
-      )}
-
       {/* Wheels center */}
       <div
         className="relative z-0 flex h-full items-center justify-center -translate-y-[36px] sm:-translate-y-6 lg:-translate-y-8"
         style={{ paddingBottom: handClearance }}
       >
+        {skillPhaseMessage && (
+          <div className="pointer-events-none absolute left-1/2 top-2 z-20 -translate-x-1/2 text-center text-xs font-semibold text-slate-200 drop-shadow">
+            {skillPhaseMessage}
+          </div>
+        )}
         <div
           ref={wheelPanelContainerRef}
           className="mx-auto flex h-full flex-col items-center justify-center gap-0 rounded-xl border border-transparent p-2 shadow"


### PR DESCRIPTION
## Summary
- remove the "Skill Phase" heading from the HUD to reduce clutter in skill mode
- reposition the skill phase prompt as an overlay without padding so it no longer shifts the wheel layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e440683ac883328c9ee47b06555711