### PR TITLE
Move skill pass button into skill phase banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1109,6 +1109,12 @@ export default function ThreeWheel_WinsOnly({
           : "Click a card to use its skill or pass to end your turn."
         : `Waiting for ${namesByLegacy[skillPhase.activeSide]}...`
       : "";
+  const showSkillPassButton =
+    phase === "skill" &&
+    isSkillMode &&
+    !!skillPhase &&
+    skillPhase.activeSide === localLegacySide &&
+    !isAwaitingSkillTarget;
   const hudAccentColor = HUD_COLORS[localLegacySide];
 
   useEffect(() => {
@@ -1397,23 +1403,14 @@ export default function ThreeWheel_WinsOnly({
               {skillPhase.activeSide === localLegacySide && skillPhase.options.every((opt) => !opt.canActivate) && (
                 <div className="text-xs text-slate-400">No ready skills.</div>
               )}
-              {skillPhase.activeSide === localLegacySide && (
+              {skillPhase.activeSide === localLegacySide && isAwaitingSkillTarget && (
                 <div className="flex items-center justify-end gap-2 self-end">
-                  {isAwaitingSkillTarget && (
-                    <button
-                      type="button"
-                      onClick={handleSkillTargetCancel}
-                      className="rounded bg-slate-700 px-2.5 py-0.5 text-xs font-semibold text-slate-200 hover:bg-slate-600"
-                    >
-                      Cancel
-                    </button>
-                  )}
                   <button
                     type="button"
-                    onClick={passSkillTurn}
+                    onClick={handleSkillTargetCancel}
                     className="rounded bg-slate-700 px-2.5 py-0.5 text-xs font-semibold text-slate-200 hover:bg-slate-600"
                   >
-                    Pass
+                    Cancel
                   </button>
                 </div>
               )}
@@ -1605,8 +1602,19 @@ export default function ThreeWheel_WinsOnly({
 
       {skillPhaseMessage && (
         <div className="relative z-10 -mt-2 mb-2 flex justify-center px-2">
-          <div className="max-w-md rounded-lg border border-slate-700 bg-slate-900/90 px-3 py-1.5 text-center text-xs text-slate-200 shadow">
-            {skillPhaseMessage}
+          <div className="max-w-md rounded-lg border border-slate-700 bg-slate-900/90 px-3 py-1.5 text-xs text-slate-200 shadow">
+            <div className="flex flex-wrap items-center justify-center gap-2 text-center">
+              <span className="block">{skillPhaseMessage}</span>
+              {showSkillPassButton && (
+                <button
+                  type="button"
+                  onClick={passSkillTurn}
+                  className="rounded bg-slate-700 px-2.5 py-0.5 text-xs font-semibold text-slate-200 hover:bg-slate-600"
+                >
+                  Pass
+                </button>
+              )}
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- move the skill phase pass control into the instructional banner shown during skill mode
- only show the pass control when the local player is not targeting to keep the banner uncluttered

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e440cf988c8332920f48c8a25bda07