### PR TITLE
Color skill cards by arcana

### DIFF
--- a/src/components/StSCard.tsx
+++ b/src/components/StSCard.tsx
@@ -1,20 +1,12 @@
 // src/components/StSCard.tsx
 import React, { memo, useMemo } from "react";
 import type { Arcana, Card } from "../game/types";
-import { getArcanaIcon, getCardArcana } from "../game/arcana";
+import { getArcanaIcon, getArcanaTextClass, getCardArcana } from "../game/arcana";
 import { fmtNum, isSplit } from "../game/values";
-
-const ARCANA_COLOR_CLASS: Record<Arcana, string> = {
-  fire: "text-orange-300",
-  blade: "text-sky-200",
-  eye: "text-violet-200",
-  moon: "text-slate-200",
-  serpent: "text-emerald-300",
-};
 
 function ArcanaGlyph({ arcana }: { arcana: Arcana }) {
   const icon = getArcanaIcon(arcana);
-  const color = ARCANA_COLOR_CLASS[arcana] ?? "text-slate-200";
+  const color = getArcanaTextClass(arcana);
   return (
     <span aria-hidden className={`text-1x2 leading-none ${color}`}>
       {icon}

--- a/src/features/threeWheel/components/ArchetypeModal.tsx
+++ b/src/features/threeWheel/components/ArchetypeModal.tsx
@@ -4,6 +4,7 @@ import {
   ARCHETYPE_IDS,
   type ArchetypeId,
 } from "../../../game/archetypes";
+import { getArcanaTextClass } from "../../../game/arcana";
 import { getSpellDefinitions, type SpellDefinition } from "../../../game/spells";
 import { SpellDescription } from "../../../components/SpellDescription";
 
@@ -85,6 +86,11 @@ const ArchetypeModal: React.FC<ArchetypeModalProps> = ({
     <ul className="mt-2 space-y-1 text-xs text-slate-100/90">
       {spells.map((spell) => {
         const isActive = visibleSpellId === spell.id;
+        const primaryArcana = spell.requirements?.[0]?.arcana;
+        const spellNameClass = [
+          "font-semibold",
+          getArcanaTextClass(primaryArcana, "text-slate-100"),
+        ].join(" ");
         return (
           <li key={`${idPrefix}-${spell.id}`} className="flex flex-col gap-1">
             <button
@@ -120,7 +126,7 @@ const ArchetypeModal: React.FC<ArchetypeModalProps> = ({
               aria-expanded={isActive}
             >
               <span className="h-1.5 w-1.5 rounded-full bg-slate-500" aria-hidden />
-              <span className="font-semibold text-slate-100">{spell.name}</span>
+              <span className={spellNameClass}>{spell.name}</span>
             </button>
 
             <SpellDescription

--- a/src/game/arcana.ts
+++ b/src/game/arcana.ts
@@ -9,6 +9,14 @@ export const ARCANA_EMOJI: Record<Arcana, string> = {
   serpent: "🐍",
 };
 
+export const ARCANA_TEXT_CLASS: Record<Arcana, string> = {
+  fire: "text-orange-300",
+  blade: "text-sky-200",
+  eye: "text-violet-200",
+  moon: "text-slate-200",
+  serpent: "text-emerald-300",
+};
+
 const TAG_TO_ARCANA: Partial<Record<TagId, Arcana>> = {
   oddshift: "serpent",
   parityflip: "blade",
@@ -46,6 +54,11 @@ export function getCardArcana(card: Card): Arcana {
 
 export function getArcanaIcon(arcana: Arcana): string {
   return ARCANA_EMOJI[arcana];
+}
+
+export function getArcanaTextClass(arcana?: Arcana | null, fallback = "text-slate-200"): string {
+  if (!arcana) return fallback;
+  return ARCANA_TEXT_CLASS[arcana] ?? fallback;
 }
 
 export function matchesArcana(arcana: Arcana | undefined, requirement?: Arcana | Arcana[]): boolean {


### PR DESCRIPTION
## Summary
- add shared arcana text color helper so paradigms map to tailwind classes
- reuse the helper in the card glyph and archetype modal to tint skill names to their paradigm color

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e441b4be0c8332b5a246c7f584f185