### PR TITLE
Ensure skill ability colors follow printed card values

### DIFF
--- a/src/game/skills.ts
+++ b/src/game/skills.ts
@@ -16,7 +16,10 @@ export function getSkillCardValue(card: Card | null | undefined): number | null 
 
 export function determineSkillAbility(card: Card | null): SkillAbility | null {
   if (!card) return null;
-  const value = getSkillCardValue(card);
+  const value =
+    typeof card.baseNumber === "number"
+      ? card.baseNumber
+      : getSkillCardValue(card);
   if (value === null) return null;
   if (value <= 0) return "swapReserve";
   if (value === 1 || value === 2) return "rerollReserve";


### PR DESCRIPTION
## Summary
- use the printed base number when deriving a card's skill ability so buffs no longer change the color mapping in skill mode

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e443d110048332abdb1045db43a307