### PR TITLE
Fix skill ability value coercion

### DIFF
--- a/src/game/skills.ts
+++ b/src/game/skills.ts
@@ -1,25 +1,36 @@
 import type { Card } from "./types";
 import { fmtNum } from "./values";
 
+function coerceFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
 export type SkillAbility = "swapReserve" | "rerollReserve" | "boostSelf" | "reserveBoost";
 
 export function getSkillCardValue(card: Card | null | undefined): number | null {
   if (!card) return null;
-  if (typeof card.number === "number") {
-    return card.number;
+  const numberValue = coerceFiniteNumber(card.number);
+  if (numberValue !== null) {
+    return numberValue;
   }
-  if (typeof card.baseNumber === "number") {
-    return card.baseNumber;
+  const baseValue = coerceFiniteNumber(card.baseNumber);
+  if (baseValue !== null) {
+    return baseValue;
   }
   return null;
 }
 
 export function determineSkillAbility(card: Card | null): SkillAbility | null {
   if (!card) return null;
-  const value =
-    typeof card.baseNumber === "number"
-      ? card.baseNumber
-      : getSkillCardValue(card);
+  const baseValue = coerceFiniteNumber(card.baseNumber);
+  const value = baseValue ?? getSkillCardValue(card);
   if (value === null) return null;
   if (value <= 0) return "swapReserve";
   if (value === 1 || value === 2) return "rerollReserve";
@@ -38,11 +49,9 @@ export function isReserveBoostTarget(card: Card | null | undefined): boolean {
 
 export function describeSkillAbility(ability: SkillAbility, card: Card): string {
   const printedValue =
-    typeof card.baseNumber === "number"
-      ? card.baseNumber
-      : typeof card.number === "number"
-        ? card.number
-        : 0;
+    coerceFiniteNumber(card.baseNumber) ??
+    coerceFiniteNumber(card.number) ??
+    0;
   const value = fmtNum(printedValue);
   switch (ability) {
     case "swapReserve":

--- a/tests/skillAbilityClassification.test.ts
+++ b/tests/skillAbilityClassification.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+
+import {
+  describeSkillAbility,
+  determineSkillAbility,
+  getSkillCardValue,
+} from "../src/game/skills.js";
+import type { Card } from "../src/game/types.js";
+
+const makeCard = (overrides: Partial<Record<keyof Card, unknown>>): Card => {
+  const card: Card = {
+    id: "test-card",
+    name: "Test",
+    tags: [],
+  };
+  Object.assign(card as unknown as Record<string, unknown>, overrides);
+  return card;
+};
+
+{
+  const card = makeCard({ number: 1, baseNumber: 1 });
+  assert.equal(getSkillCardValue(card), 1);
+  assert.equal(determineSkillAbility(card), "rerollReserve");
+}
+
+{
+  const card = makeCard({ number: "1" as unknown as number });
+  assert.equal(getSkillCardValue(card), 1);
+  assert.equal(determineSkillAbility(card), "rerollReserve");
+}
+
+{
+  const card = makeCard({ number: "8" as unknown as number });
+  assert.equal(determineSkillAbility(card), "reserveBoost");
+}
+
+{
+  const card = makeCard({ baseNumber: "3" as unknown as number });
+  assert.equal(determineSkillAbility(card), "boostSelf");
+  assert.equal(describeSkillAbility("boostSelf", card), "Add 3 to a card in play.");
+}


### PR DESCRIPTION
## Summary
- normalize skill card values so numeric strings are treated like their numeric equivalents
- ensure skill ability descriptions use the coerced numeric value
- add regression tests covering skill ability detection when card values arrive as strings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e44ad780b483328da7421da5be2fda