### PR TITLE
Ensure skill calculations use printed values across abilities

### DIFF
--- a/src/game/skills.ts
+++ b/src/game/skills.ts
@@ -1,5 +1,5 @@
 import type { Card } from "./types";
-import { fmtNum } from "./values";
+import { fmtNum } from "./values.js";
 
 function coerceFiniteNumber(value: unknown): number | null {
   if (typeof value === "number") {
@@ -16,13 +16,13 @@ export type SkillAbility = "swapReserve" | "rerollReserve" | "boostSelf" | "rese
 
 export function getSkillCardValue(card: Card | null | undefined): number | null {
   if (!card) return null;
-  const numberValue = coerceFiniteNumber(card.number);
-  if (numberValue !== null) {
-    return numberValue;
-  }
   const baseValue = coerceFiniteNumber(card.baseNumber);
   if (baseValue !== null) {
     return baseValue;
+  }
+  const numberValue = coerceFiniteNumber(card.number);
+  if (numberValue !== null) {
+    return numberValue;
   }
   return null;
 }
@@ -41,10 +41,7 @@ export function determineSkillAbility(card: Card | null): SkillAbility | null {
 export function isReserveBoostTarget(card: Card | null | undefined): boolean {
   const value = getSkillCardValue(card);
   if (value === null) return false;
-  if (value > 0) {
-    return true;
-  }
-  return determineSkillAbility(card ?? null) !== null;
+  return value > 0;
 }
 
 export function describeSkillAbility(ability: SkillAbility, card: Card): string {

--- a/tests/skillAbilityClassification.test.ts
+++ b/tests/skillAbilityClassification.test.ts
@@ -4,6 +4,7 @@ import {
   describeSkillAbility,
   determineSkillAbility,
   getSkillCardValue,
+  isReserveBoostTarget,
 } from "../src/game/skills.js";
 import type { Card } from "../src/game/types.js";
 
@@ -38,4 +39,39 @@ const makeCard = (overrides: Partial<Record<keyof Card, unknown>>): Card => {
   const card = makeCard({ baseNumber: "3" as unknown as number });
   assert.equal(determineSkillAbility(card), "boostSelf");
   assert.equal(describeSkillAbility("boostSelf", card), "Add 3 to a card in play.");
+}
+
+{
+  const card = makeCard({ number: 5, baseNumber: 5 });
+  assert.equal(isReserveBoostTarget(card), true);
+}
+
+{
+  const card = makeCard({ number: 0, baseNumber: 0 });
+  assert.equal(isReserveBoostTarget(card), false);
+}
+
+{
+  const card = makeCard({ number: -2, baseNumber: -2 });
+  assert.equal(isReserveBoostTarget(card), false);
+}
+
+{
+  const card = makeCard({ number: -7, baseNumber: 4 });
+  assert.equal(getSkillCardValue(card), 4);
+  assert.equal(determineSkillAbility(card), "boostSelf");
+  assert.equal(isReserveBoostTarget(card), true);
+}
+
+{
+  const card = makeCard({ number: 6, baseNumber: -1 });
+  assert.equal(getSkillCardValue(card), -1);
+  assert.equal(determineSkillAbility(card), "swapReserve");
+  assert.equal(isReserveBoostTarget(card), false);
+}
+
+{
+  const card = makeCard({ baseNumber: 2 });
+  assert.equal(getSkillCardValue(card), 2);
+  assert.equal(determineSkillAbility(card), "rerollReserve");
 }


### PR DESCRIPTION
## Summary
- prioritize baseNumber when deriving skill card values so that every skill ability uses its printed strength
- expand skill ability tests to cover printed-vs-modified values for each skill category

## Testing
- npm test
- node --experimental-specifier-resolution=node dist-tests/tests/skillAbilityClassification.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e44e09c954833297e542e0197b7243