### PR TITLE
Adjust skill banner spacing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1580,7 +1580,9 @@ export default function ThreeWheel_WinsOnly({
       </div>
 
       {/* HUD */}
-      <div className="relative z-10 mb-3 sm:mb-4">
+      <div
+        className={`relative z-10 ${skillPhaseMessage ? "mb-[2px]" : "mb-3 sm:mb-4"}`}
+      >
         <HUDPanels
           manaPools={manaPools}
           isGrimoireMode={isGrimoireMode}
@@ -1600,7 +1602,7 @@ export default function ThreeWheel_WinsOnly({
       </div>
 
       {skillPhaseMessage && (
-        <div className="relative z+10 -mt+20 mb+20 flex justify-center px-2">
+        <div className="relative z-10 flex justify-center px-2">
           <div className="max-w-md rounded-lg border border-slate-700 bg-slate-900/90 px-3 py-1.5 text-xs text-slate-200 shadow">
             <div className="flex flex-wrap items-center justify-center gap-2 text-center">
               <span className="block">{skillPhaseMessage}</span>


### PR DESCRIPTION
## Summary
- reduce the HUD panel margin when the skill banner is present to leave a 2px gap
- tidy the skill banner container classes to maintain consistent layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e46b03dc888332aecfa0eb7526e23f