### PR TITLE
Support targeted boost skills and tighten reserve rerolls

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "tsc --project tsconfig.tests.json && node --experimental-specifier-resolution=node dist-tests/tests/slotVisibility.test.js && node --experimental-specifier-resolution=node dist-tests/tests/spellEffects.test.js && node --experimental-specifier-resolution=node dist-tests/tests/mirrorImageResolution.test.js && node --experimental-specifier-resolution=node dist-tests/tests/resolveRoundSkipAnimation.test.js && node --experimental-specifier-resolution=node dist-tests/tests/preRevealStatSpellResolution.test.js && node --experimental-specifier-resolution=node dist-tests/tests/grimoireVisibility.test.js && node --experimental-specifier-resolution=node dist-tests/tests/cpuSpellSaving.test.js"
+    "test": "tsc --project tsconfig.tests.json && node --experimental-specifier-resolution=node dist-tests/tests/skillAbilityClassification.test.js && node --experimental-specifier-resolution=node dist-tests/tests/slotVisibility.test.js && node --experimental-specifier-resolution=node dist-tests/tests/spellEffects.test.js && node --experimental-specifier-resolution=node dist-tests/tests/mirrorImageResolution.test.js && node --experimental-specifier-resolution=node dist-tests/tests/resolveRoundSkipAnimation.test.js && node --experimental-specifier-resolution=node dist-tests/tests/preRevealStatSpellResolution.test.js && node --experimental-specifier-resolution=node dist-tests/tests/grimoireVisibility.test.js && node --experimental-specifier-resolution=node dist-tests/tests/cpuSpellSaving.test.js"
   },
   "dependencies": {
     "ably": "^2.12.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -361,6 +361,13 @@ export default function ThreeWheel_WinsOnly({
     [handleSkillTargetSelect],
   );
 
+  const handleSkillLaneSelect = useCallback(
+    ({ laneIndex }: { laneIndex: number }) => {
+      handleSkillTargetSelect({ kind: "lane", laneIndex });
+    },
+    [handleSkillTargetSelect],
+  );
+
   const handleSkillTargetCancel = useCallback(() => {
     cancelSkillTargeting();
   }, [cancelSkillTargeting]);
@@ -1096,6 +1103,8 @@ export default function ThreeWheel_WinsOnly({
         return "Select a reserve card to cycle.";
       case "reserveBoost":
         return "Select a reserve card to exhaust for a boost.";
+      case "boostCard":
+        return "Select a card to boost.";
       default:
         return "";
     }
@@ -1684,6 +1693,7 @@ export default function ThreeWheel_WinsOnly({
                   })) ?? []
                 }
                 skillTargeting={skillTargeting}
+                onSkillTargetSelect={handleSkillLaneSelect}
               />
             </div>
           ))}

--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -11,7 +11,6 @@ import { createPortal } from "react-dom";
 import { motion } from "framer-motion";
 import StSCard from "../../../components/StSCard";
 import type { Card, Fighter } from "../../../game/types";
-import { isReserveBoostTarget } from "../../../game/skills";
 import type { LegacySide } from "./WheelPanel";
 import { type SpellDefinition, type SpellTargetInstance } from "../../../game/spellEngine";
 import {
@@ -211,7 +210,7 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
         case "rerollReserve":
           return new Set(fighter.hand.map((card) => card.id));
         case "reserveBoost":
-          return new Set(fighter.hand.filter(isReserveBoostTarget).map((card) => card.id));
+          return new Set(fighter.hand.map((card) => card.id));
         default:
           return new Set<string>();
       }

--- a/src/game/skills.ts
+++ b/src/game/skills.ts
@@ -12,7 +12,7 @@ function coerceFiniteNumber(value: unknown): number | null {
   return null;
 }
 
-export type SkillAbility = "swapReserve" | "rerollReserve" | "boostSelf" | "reserveBoost";
+export type SkillAbility = "swapReserve" | "rerollReserve" | "boostCard" | "reserveBoost";
 
 export function getSkillCardValue(card: Card | null | undefined): number | null {
   if (!card) return null;
@@ -34,7 +34,7 @@ export function determineSkillAbility(card: Card | null): SkillAbility | null {
   if (value === null) return null;
   if (value <= 0) return "swapReserve";
   if (value === 1 || value === 2) return "rerollReserve";
-  if (value === 3 || value === 4) return "boostSelf";
+  if (value === 3 || value === 4) return "boostCard";
   return "reserveBoost";
 }
 
@@ -55,7 +55,7 @@ export function describeSkillAbility(ability: SkillAbility, card: Card): string 
       return "Swap this card with any reserve card, replacing it on the board.";
     case "rerollReserve":
       return "Discard a reserve card you select and draw a replacement.";
-    case "boostSelf":
+    case "boostCard":
       return `Add ${value} to a card in play.`;
     case "reserveBoost":
       return "Exhaust a reserve card to add its value to a card in play, exhausting it in the process.";
@@ -67,14 +67,14 @@ export function describeSkillAbility(ability: SkillAbility, card: Card): string 
 export const SKILL_ABILITY_COLORS: Record<SkillAbility, string> = {
   swapReserve: "text-amber-300",
   rerollReserve: "text-sky-300",
-  boostSelf: "text-rose-300",
+  boostCard: "text-rose-300",
   reserveBoost: "text-emerald-300",
 };
 
 export const SKILL_ABILITY_COLOR_HEX: Record<SkillAbility, string> = {
   swapReserve: "#fcd34d", // amber-300
   rerollReserve: "#7dd3fc", // sky-300
-  boostSelf: "#fda4af", // rose-300
+  boostCard: "#fda4af", // rose-300
   reserveBoost: "#6ee7b7", // emerald-300
 };
 

--- a/tests/skillAbilityClassification.test.ts
+++ b/tests/skillAbilityClassification.test.ts
@@ -37,8 +37,8 @@ const makeCard = (overrides: Partial<Record<keyof Card, unknown>>): Card => {
 
 {
   const card = makeCard({ baseNumber: "3" as unknown as number });
-  assert.equal(determineSkillAbility(card), "boostSelf");
-  assert.equal(describeSkillAbility("boostSelf", card), "Add 3 to a card in play.");
+  assert.equal(determineSkillAbility(card), "boostCard");
+  assert.equal(describeSkillAbility("boostCard", card), "Add 3 to a card in play.");
 }
 
 {
@@ -59,7 +59,7 @@ const makeCard = (overrides: Partial<Record<keyof Card, unknown>>): Card => {
 {
   const card = makeCard({ number: -7, baseNumber: 4 });
   assert.equal(getSkillCardValue(card), 4);
-  assert.equal(determineSkillAbility(card), "boostSelf");
+  assert.equal(determineSkillAbility(card), "boostCard");
   assert.equal(isReserveBoostTarget(card), true);
 }
 
@@ -75,3 +75,5 @@ const makeCard = (overrides: Partial<Record<keyof Card, unknown>>): Card => {
   assert.equal(getSkillCardValue(card), 2);
   assert.equal(determineSkillAbility(card), "rerollReserve");
 }
+
+console.log("skill ability classification tests passed");


### PR DESCRIPTION
## Summary
- rename the boost skill to boostCard and require selecting a board card to receive the bonus
- teach the UI to handle board targeting, expose reserve skills on all cards, and relax reserve targeting restrictions
- preserve reroll counts across other skills so the two-reroll limit always forces a pass

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e46aa987cc8332909980569e82b12f