### PR TITLE
Filter Reserve Boost skill targeting to positive reserves

### DIFF
--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -19,6 +19,7 @@ import {
   type SpellTargetLocation,
 } from "../../../game/spells";
 import type { SkillTargetingState } from "../hooks/useThreeWheelGame";
+import { isReserveBoostTarget } from "../../../game/skills";
 
 interface HandDockProps {
   localLegacySide: LegacySide;
@@ -210,7 +211,9 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
         case "rerollReserve":
           return new Set(fighter.hand.map((card) => card.id));
         case "reserveBoost":
-          return new Set(fighter.hand.map((card) => card.id));
+          return new Set(
+            fighter.hand.filter((card) => isReserveBoostTarget(card)).map((card) => card.id),
+          );
         default:
           return new Set<string>();
       }

--- a/src/game/skills.ts
+++ b/src/game/skills.ts
@@ -74,9 +74,8 @@ export const SKILL_ABILITY_COLORS: Record<SkillAbility, string> = {
 export const SKILL_ABILITY_COLOR_HEX: Record<SkillAbility, string> = {
   swapReserve: "#fcd34d", // amber-300
   rerollReserve: "#3c99c4ff", // sky-500
-  boostSelf: "#fda4af", // rose-300
+  boostCard: "#fda4af", // rose-300
   reserveBoost: "#25d38dff", // emerald-200
-
 };
 
 export function getSkillAbilityColorClass(card: Card | null): string | null {

--- a/tests/skillAbilityClassification.test.ts
+++ b/tests/skillAbilityClassification.test.ts
@@ -76,4 +76,17 @@ const makeCard = (overrides: Partial<Record<keyof Card, unknown>>): Card => {
   assert.equal(determineSkillAbility(card), "rerollReserve");
 }
 
+{
+  const cards = [
+    makeCard({ id: "positive", number: 5, baseNumber: 5 }),
+    makeCard({ id: "zero", number: 0, baseNumber: 0 }),
+    makeCard({ id: "negative", number: -2, baseNumber: -2 }),
+    makeCard({ id: "basePositive", number: -7, baseNumber: 4 }),
+  ];
+  const reserveBoostTargets = cards
+    .filter((card) => isReserveBoostTarget(card))
+    .map((card) => card.id);
+  assert.deepEqual(reserveBoostTargets, ["positive", "basePositive"]);
+}
+
 console.log("skill ability classification tests passed");


### PR DESCRIPTION
## Summary
- update the hand dock Reserve Boost skill targeting to only include reserves that satisfy `isReserveBoostTarget`
- import the reserve boost predicate for use in the component and align skill color mappings with the declared abilities
- extend the skill ability classification test to confirm Reserve Boost only targets reserves with positive skill values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4791869b48332b7aff54ba641166a