### PR TITLE
Fix skill availability after uses are spent

### DIFF
--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -1032,6 +1032,10 @@ export function useThreeWheelGame({
       if (exhausted) {
         return { ok: false, reason: "Exhausted." };
       }
+      const remainingUses = state.usesRemaining[side][laneIndex];
+      if (remainingUses <= 0) {
+        return { ok: false, reason: "No uses remaining." };
+      }
       const fighter = getFighterSnapshot(side);
       const reserveCards = fighter.hand;
 
@@ -1198,7 +1202,8 @@ export function useThreeWheelGame({
       ability: SkillAbility,
     ): SkillPhaseState | null => {
       const updatedExhaustedSide = [...state.exhausted[side]] as [boolean, boolean, boolean];
-      updatedExhaustedSide[laneIndex] = true;
+      const shouldExhaust = state.usesRemaining[side][laneIndex] <= 0;
+      updatedExhaustedSide[laneIndex] = shouldExhaust;
       let updatedState: SkillPhaseState = {
         ...state,
         exhausted: { ...state.exhausted, [side]: updatedExhaustedSide },


### PR DESCRIPTION
## Summary
- ensure skill availability checks respect remaining activations so abilities stop after their final use
- exhaust a lane only when its skill has no uses left, keeping multi-use abilities available while uses remain

## Testing
- npm test -- --runTestsByPath tests/threeWheel.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e4f3ff11f88332a8df2303ec9779fd