### PR TITLE
Allow boosted reserve cards to fuel ReserveBoost

### DIFF
--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -36,6 +36,7 @@ import { fmtNum, isNormal } from "../../../game/values";
 import {
   describeSkillAbility,
   determineSkillAbility,
+  getReserveBoostValue,
   getSkillCardValue,
   isReserveBoostTarget,
   type SkillAbility,
@@ -995,17 +996,17 @@ export function useThreeWheelGame({
         return { value: 0, card: null };
       }
       let chosenCard: Card = reserveCards[0];
-      let bestValue = getSkillCardValue(chosenCard) ?? Number.NEGATIVE_INFINITY;
+      let bestValue = getReserveBoostValue(chosenCard) ?? Number.NEGATIVE_INFINITY;
       if (preferredCardId) {
         const match = reserveCards.find((card) => card.id === preferredCardId);
         if (!match) {
           return { value: 0, card: null };
         }
         chosenCard = match;
-        bestValue = getSkillCardValue(chosenCard) ?? Number.NEGATIVE_INFINITY;
+        bestValue = getReserveBoostValue(chosenCard) ?? Number.NEGATIVE_INFINITY;
       } else {
         for (const candidate of reserveCards) {
-          const value = getSkillCardValue(candidate) ?? Number.NEGATIVE_INFINITY;
+          const value = getReserveBoostValue(candidate) ?? Number.NEGATIVE_INFINITY;
           if (value > bestValue) {
             chosenCard = candidate;
             bestValue = value;
@@ -1017,7 +1018,7 @@ export function useThreeWheelGame({
         const discard = [...prev.discard, chosenCard];
         return { ...prev, hand, discard };
       });
-      const boostValue = getSkillCardValue(chosenCard) ?? 0;
+      const boostValue = getReserveBoostValue(chosenCard) ?? 0;
       return { value: boostValue, card: chosenCard };
     },
     [getFighterSnapshot, updateFighter],
@@ -1678,7 +1679,7 @@ export function useThreeWheelGame({
     let bestPositiveReserve = Number.NEGATIVE_INFINITY;
 
     for (const reserve of reserveCards) {
-      const value = getSkillCardValue(reserve);
+      const value = getReserveBoostValue(reserve);
       if (value === null) continue;
       if (value > highestReserveValue) {
         highestReserveValue = value;

--- a/src/game/skills.ts
+++ b/src/game/skills.ts
@@ -27,6 +27,25 @@ export function getSkillCardValue(card: Card | null | undefined): number | null 
   return null;
 }
 
+export function getReserveBoostValue(card: Card | null | undefined): number | null {
+  if (!card) return null;
+  const numberValue = coerceFiniteNumber(card.number);
+  const baseValue = coerceFiniteNumber(card.baseNumber);
+  if (baseValue !== null && baseValue < 0) {
+    return baseValue;
+  }
+  if (numberValue !== null && numberValue > 0) {
+    return numberValue;
+  }
+  if (baseValue !== null) {
+    return baseValue;
+  }
+  if (numberValue !== null) {
+    return numberValue;
+  }
+  return null;
+}
+
 export function determineSkillAbility(card: Card | null): SkillAbility | null {
   if (!card) return null;
   const baseValue = coerceFiniteNumber(card.baseNumber);
@@ -39,7 +58,7 @@ export function determineSkillAbility(card: Card | null): SkillAbility | null {
 }
 
 export function isReserveBoostTarget(card: Card | null | undefined): boolean {
-  const value = getSkillCardValue(card);
+  const value = getReserveBoostValue(card);
   if (value === null) return false;
   return value > 0;
 }

--- a/tests/skillAbilityClassification.test.ts
+++ b/tests/skillAbilityClassification.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   describeSkillAbility,
   determineSkillAbility,
+  getReserveBoostValue,
   getSkillCardValue,
   isReserveBoostTarget,
 } from "../src/game/skills.js";
@@ -87,6 +88,13 @@ const makeCard = (overrides: Partial<Record<keyof Card, unknown>>): Card => {
     .filter((card) => isReserveBoostTarget(card))
     .map((card) => card.id);
   assert.deepEqual(reserveBoostTargets, ["positive", "basePositive"]);
+}
+
+{
+  const card = makeCard({ number: 5, baseNumber: 0 });
+  assert.equal(getSkillCardValue(card), 0);
+  assert.equal(getReserveBoostValue(card), 5);
+  assert.equal(isReserveBoostTarget(card), true);
 }
 
 console.log("skill ability classification tests passed");


### PR DESCRIPTION
## Summary
- add a dedicated helper that computes reserve boost values using the current number when positive while preserving printed negatives
- update ReserveBoost targeting and value calculations to rely on the new helper so temporarily buffed reserve cards can be exhausted
- extend the skill classification test coverage to confirm boosted zero-value reserves are selectable

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4f0b5f070833282c032532a2344e5