### PR TITLE
Move skill activations to post-resolve interactions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -113,6 +113,13 @@ const SKILL_ABILITY_LABELS: Record<AbilityKind, string> = {
 const formatSkillAbility = (ability: AbilityKind | null) =>
   ability ? SKILL_ABILITY_LABELS[ability] ?? ability : "No ability";
 
+type SkillLaneDetail = {
+  ability: AbilityKind | null;
+  exhausted: boolean;
+  description: string | null;
+  label: string | null;
+};
+
 function createWheelSideState<T>(value: T): WheelSideState<T> {
   return [
     { player: value, enemy: value },
@@ -1070,21 +1077,36 @@ export default function ThreeWheel_WinsOnly({
       })()
     : "";
   const skillPhaseActive = isSkillMode && phaseForLogic === "skill";
-  const skillPhaseCompleted = skill.completed;
-  const skillLaneDetails = useMemo(
-    () =>
-      (skill.lanes[localLegacySide] ?? []).map((lane, laneIndex) => {
-        const card = assign[localLegacySide][laneIndex];
+  const skillLaneDetails = useMemo(() => {
+    const sides: LegacySide[] = ["player", "enemy"];
+    return sides.reduce((acc, side) => {
+      const lanes = skill.lanes[side] ?? [];
+      acc[side] = lanes.map((lane, laneIndex) => {
+        const card = assign[side][laneIndex];
         const ability = lane?.ability ?? null;
         const description = ability ? describeSkillAbility(ability, card ?? undefined) : null;
-        return {
+        const label = ability ? formatSkillAbility(ability) : null;
+        const detail: SkillLaneDetail = {
           ability,
           exhausted: lane?.exhausted ?? true,
           description,
+          label,
         };
-      }),
-    [assign, localLegacySide, skill.lanes],
-  );
+        return detail;
+      });
+      return acc;
+    }, {} as Record<LegacySide, SkillLaneDetail[]>);
+  }, [assign, skill.lanes]);
+
+  const localSkillLaneDetails = skillLaneDetails[localLegacySide] ?? [];
+  const remoteSkillLaneDetails = skillLaneDetails[remoteLegacySide] ?? [];
+  const localSkillReady = localSkillLaneDetails.some((lane) => lane.ability && !lane.exhausted);
+  const remoteSkillReady = remoteSkillLaneDetails.some((lane) => lane.ability && !lane.exhausted);
+  const skillPhaseMessage = localSkillReady
+    ? "Click a ready card to use its skill."
+    : remoteSkillReady
+    ? "Waiting for rival skill activations…"
+    : "No skills available this round.";
   const hudAccentColor = HUD_COLORS[localLegacySide];
 
   useEffect(() => {
@@ -1351,6 +1373,19 @@ export default function ThreeWheel_WinsOnly({
               )}
             </div>
           )}
+          {phase === "skill" && (
+            <div className="flex flex-col items-end gap-1 text-right">
+              <div className="text-[11px] text-amber-200 leading-tight">
+                {skillPhaseMessage}
+              </div>
+              <button
+                onClick={handleSkillConfirm}
+                className="px-2.5 py-0.5 rounded bg-amber-400 text-slate-900 font-semibold hover:bg-amber-300 transition"
+              >
+                Continue to battle
+              </button>
+            </div>
+          )}
           {phase === "roundEnd" && (
             <div className="flex flex-col items-end gap-1">
               <button
@@ -1529,64 +1564,6 @@ export default function ThreeWheel_WinsOnly({
         </div>
 
       </div>
-
-      {isSkillMode && (
-        <div className="mb-3 sm:mb-4 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[12px] text-amber-100 shadow-sm">
-          <div className="flex items-center justify-between gap-2">
-            <div className="font-semibold tracking-wide uppercase text-[11px]">Skill Phase</div>
-            <div className="text-[11px] font-semibold">
-              {skillPhaseActive ? (
-                <span className="text-amber-200 animate-pulse">Active now</span>
-              ) : skillPhaseCompleted ? (
-                <span className="text-emerald-200">Resolved</span>
-              ) : (
-                <span className="text-amber-200/90">Will trigger before combat</span>
-              )}
-            </div>
-          </div>
-          <ul className="mt-2 space-y-1">
-            {skillLaneDetails.map((lane, laneIndex) => {
-              const abilityLabel = formatSkillAbility(lane.ability);
-              const helperText = lane.description ?? "No ability this round.";
-              const canUseAbility = Boolean(lane.ability) && !lane.exhausted;
-              return (
-                <li key={laneIndex} className="flex items-start justify-between gap-2">
-                  <div className="flex-1">
-                    <div className="font-semibold text-[11px]">Lane {laneIndex + 1}: {abilityLabel}</div>
-                    <div className="text-[11px] text-amber-100/80 leading-snug">{helperText}</div>
-                  </div>
-                  {lane.ability ? (
-                    canUseAbility ? (
-                      <button
-                        type="button"
-                        onClick={() => useSkillAbility(localLegacySide, laneIndex)}
-                        disabled={!skillPhaseActive}
-                        className="rounded-full border border-amber-400/60 bg-amber-500/20 px-2 py-0.5 text-[11px] font-semibold text-amber-50 transition disabled:opacity-40 disabled:cursor-not-allowed hover:bg-amber-500/30"
-                      >
-                        {skillPhaseActive ? "Use" : "Ready"}
-                      </button>
-                    ) : (
-                      <span className="rounded-full border border-amber-200/30 px-2 py-0.5 text-[10px] text-amber-200/80">Spent</span>
-                    )
-                  ) : null}
-                </li>
-              );
-            })}
-          </ul>
-          {skillPhaseActive && (
-            <div className="mt-2 flex items-center justify-end">
-              <button
-                type="button"
-                onClick={handleSkillConfirm}
-                className="rounded-full bg-amber-400 px-3 py-1 text-[12px] font-semibold text-slate-900 shadow-sm transition hover:bg-amber-300"
-              >
-                Continue to battle
-              </button>
-            </div>
-          )}
-        </div>
-      )}
-
       {/* HUD */}
       <div className="relative z-10 mb-3 sm:mb-4">
         <HUDPanels
@@ -1656,6 +1633,12 @@ export default function ThreeWheel_WinsOnly({
                 isAwaitingSpellTarget={isAwaitingSpellTarget}
                 variant="grouped"
                 spellHighlightedCardIds={spellHighlightedCardIds}
+                skillPhaseActive={skillPhaseActive}
+                skillInfo={{
+                  player: skillLaneDetails.player?.[i] ?? null,
+                  enemy: skillLaneDetails.enemy?.[i] ?? null,
+                }}
+                onSkillActivate={useSkillAbility}
               />
             </div>
           ))}

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import CanvasWheel, { WheelHandle } from "../../../components/CanvasWheel";
 import StSCard from "../../../components/StSCard";
 import type { Card, Fighter, Phase, Section } from "../../../game/types";
+import type { AbilityKind } from "../../../game/skills";
 import {
   type SpellDefinition,
   type SpellTargetInstance,
@@ -23,6 +24,13 @@ export type { LegacySide } from "../utils/slotVisibility";
 type SlotView = { side: LegacySide; card: Card | null; name: string };
 
 type SideState<T> = Record<LegacySide, T>;
+
+type SkillLaneMeta = {
+  ability: AbilityKind | null;
+  label: string | null;
+  description: string | null;
+  exhausted: boolean;
+};
 
 interface Theme {
   panelBg: string;
@@ -80,6 +88,9 @@ export interface WheelPanelProps {
   onWheelTargetSelect?: (wheelIndex: number) => void;
   isAwaitingSpellTarget: boolean;
   variant?: "standalone" | "grouped";
+  skillPhaseActive?: boolean;
+  skillInfo?: Partial<Record<LegacySide, SkillLaneMeta | null>>;
+  onSkillActivate?: (side: LegacySide, laneIndex: number) => void;
 }
 
 const slotWidthPx = 80;
@@ -133,6 +144,9 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
   isAwaitingSpellTarget,
   variant = "standalone",
   spellHighlightedCardIds,
+  skillPhaseActive = false,
+  skillInfo,
+  onSkillActivate,
 }) => {
   const playerCard = assign.player[index];
   const enemyCard = assign.enemy[index];
@@ -175,6 +189,26 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
 
   const isLeftSelected = !!leftSlot.card && selectedCardId === leftSlot.card.id;
   const isRightSelected = !!rightSlot.card && selectedCardId === rightSlot.card.id;
+
+  const getSkillInfoForSide = (side: LegacySide): SkillLaneMeta | null => {
+    const info = skillInfo?.[side] ?? null;
+    return info ?? null;
+  };
+
+  const leftSkillInfo = getSkillInfoForSide("player");
+  const rightSkillInfo = getSkillInfoForSide("enemy");
+
+  const isSkillReadyForSide = (side: LegacySide, info: SkillLaneMeta | null): boolean =>
+    Boolean(
+      skillPhaseActive &&
+        side === localLegacySide &&
+        info &&
+        info.ability &&
+        !info.exhausted,
+    );
+
+  const leftSkillReady = isSkillReadyForSide("player", leftSkillInfo);
+  const rightSkillReady = isSkillReadyForSide("enemy", rightSkillInfo);
 
   const leftSlotOwnership: SpellTargetOwnership | null = pendingSpell
     ? leftSlot.side === pendingSpell.side
@@ -259,21 +293,27 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
     slot: SlotView,
     isSlotSelected: boolean,
     slotTargetable: boolean,
+    skillMeta: SkillLaneMeta | null,
+    skillReady: boolean,
   ) => {
     if (!slot.card) return null;
     const card = slot.card;
     const isSpellAffected = spellHighlightSet.has(card.id);
-    const canInteractNormally =
+    const canAssignDuringChoose =
       !awaitingSpellTarget && slot.side === localLegacySide && phase === "choose" && isWheelActive;
 
-    const cardInteractable = canInteractNormally || slotTargetable;
+    const cardInteractable = canAssignDuringChoose || slotTargetable || skillReady;
 
     const handlePick = () => {
       if (slotTargetable && slot.card) {
         onSpellTargetSelect?.({ side: slot.side, lane: index, card: slot.card, location: "board" });
         return;
       }
-      if (!canInteractNormally) return;
+      if (skillReady) {
+        onSkillActivate?.(slot.side, index);
+        return;
+      }
+      if (!canAssignDuringChoose) return;
       if (selectedCardId) {
         tapAssignIfSelected();
       } else {
@@ -308,6 +348,19 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
       startTouchDrag(card, e);
     };
 
+    const extraClasses: string[] = [];
+    if (slotTargetable) {
+      extraClasses.push("ring-2 ring-sky-400");
+    }
+    if (skillReady) {
+      extraClasses.push("ring-2 ring-amber-300 animate-pulse");
+    }
+
+    const ariaLabel =
+      skillMeta?.ability && skillReady
+        ? `${slot.name} skill ready: ${skillMeta.label ?? ""}`.trim()
+        : undefined;
+
     return (
       <StSCard
         card={card}
@@ -316,14 +369,49 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
         selected={isSlotSelected}
         spellAffected={isSpellAffected}
         onPick={handlePick}
-        draggable={canInteractNormally}
+        draggable={canAssignDuringChoose}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
         onPointerDown={handlePointerDown}
         onTouchStart={handleTouchStart}
-        className={slotTargetable ? "ring-2 ring-sky-400" : undefined}
+        className={extraClasses.join(" ") || undefined}
         spellTargetable={slotTargetable}
+        ariaLabel={ariaLabel}
+        title={skillMeta?.description ?? undefined}
       />
+    );
+  };
+
+  const renderSkillStatus = (
+    info: SkillLaneMeta | null,
+    side: LegacySide,
+    ready: boolean,
+  ): React.ReactNode => {
+    if (!info?.ability) return null;
+    const spent = info.exhausted;
+    const statusText = spent
+      ? "Spent"
+      : side === localLegacySide
+      ? ready
+        ? "Tap to activate"
+        : "Ready"
+      : "Rival skill";
+    const statusClass = spent ? "text-amber-200/40" : "text-amber-100/80";
+    return (
+      <>
+        <div
+          aria-hidden
+          className="pointer-events-none absolute top-1 left-1 rounded px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-amber-200/80 bg-amber-500/10"
+        >
+          {info.label ?? "Skill"}
+        </div>
+        <div
+          aria-hidden
+          className={`pointer-events-none absolute bottom-1 left-1 right-1 text-center text-[9px] leading-tight ${statusClass}`}
+        >
+          {statusText}
+        </div>
+      </>
     );
   };
 
@@ -451,15 +539,20 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
               return;
             }
           }
+          if (leftSkillReady && card) {
+            onSkillActivate?.(leftSlot.side, index);
+            return;
+          }
           if (awaitingSpellTarget) return;
+          if (phase !== "choose") return;
           if (leftSlot.side !== localLegacySide) return;
           if (selectedCardId) {
             tapAssignIfSelected();
-          } else if (leftSlot.card) {
-            setSelectedCardId(leftSlot.card.id);
+          } else if (card) {
+            setSelectedCardId(card.id);
           }
         }}
-        className="w-[80px] h-[92px] rounded-md border px-1 py-0 flex items-center justify-center flex-none"
+        className="relative w-[80px] h-[92px] rounded-md border px-1 py-0 flex items-center justify-center flex-none"
         style={{
           backgroundColor:
             dragOverWheel === index || isLeftSelected ? "rgba(182,138,78,.12)" : theme.slotBg,
@@ -473,15 +566,17 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
             ? "0 0 0 2px rgba(56,189,248,0.55)"
             : "none",
         }}
+        title={leftSkillInfo?.description ?? undefined}
         aria-label={`Wheel ${index + 1} left slot`}
       >
         {shouldShowLeftCard ? (
-          renderSlotCard(leftSlot, isLeftSelected, leftSlotTargetable)
+          renderSlotCard(leftSlot, isLeftSelected, leftSlotTargetable, leftSkillInfo, leftSkillReady)
         ) : (
           <div className="text-[11px] opacity-80 text-center">
             {leftSlot.side === localLegacySide ? "Your card" : leftSlot.name}
           </div>
         )}
+        {renderSkillStatus(leftSkillInfo, leftSlot.side, leftSkillReady)}
       </div>
 
       <div
@@ -522,7 +617,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
       </div>
 
       <div
-        className="w-[80px] h-[92px] rounded-md border px-1 py-0 flex items-center justify-center flex-none"
+        className="relative w-[80px] h-[92px] rounded-md border px-1 py-0 flex items-center justify-center flex-none"
         style={{
           backgroundColor:
             dragOverWheel === index || isRightSelected ? "rgba(182,138,78,.12)" : theme.slotBg,
@@ -562,22 +657,29 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
               return;
             }
           }
+          if (rightSkillReady && card) {
+            onSkillActivate?.(rightSlot.side, index);
+            return;
+          }
           if (awaitingSpellTarget) return;
+          if (phase !== "choose") return;
           if (rightSlot.side !== localLegacySide) return;
           if (selectedCardId) {
             tapAssignIfSelected();
-          } else if (rightSlot.card) {
-            setSelectedCardId(rightSlot.card.id);
+          } else if (card) {
+            setSelectedCardId(card.id);
           }
         }}
+        title={rightSkillInfo?.description ?? undefined}
       >
         {shouldShowRightCard ? (
-          renderSlotCard(rightSlot, isRightSelected, rightSlotTargetable)
+          renderSlotCard(rightSlot, isRightSelected, rightSlotTargetable, rightSkillInfo, rightSkillReady)
         ) : (
           <div className="text-[11px] opacity-60 text-center">
             {rightSlot.side === localLegacySide ? "Your card" : rightSlot.name}
           </div>
         )}
+        {renderSkillStatus(rightSkillInfo, rightSlot.side, rightSkillReady)}
       </div>
     </div>
   );

--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -1382,6 +1382,27 @@ export function useThreeWheelGame({
     attemptAutoReveal();
   }, [attemptAutoReveal, resolveVotes]);
 
+  useEffect(() => {
+    if (!isSkillMode) return;
+    if (phase !== "skill") return;
+
+    const hasReadyAbility = (["player", "enemy"] as LegacySide[]).some((side) =>
+      (skillState.lanes[side] ?? []).some((lane) => lane.ability && !lane.exhausted),
+    );
+
+    if (hasReadyAbility) {
+      return;
+    }
+
+    setSkillState((prev) => {
+      if (prev.completed) return prev;
+      const next = { ...prev, completed: true };
+      skillStateRef.current = next;
+      return next;
+    });
+    setPhase("roundEnd");
+  }, [isSkillMode, phase, setPhase, setSkillState, skillState]);
+
   function resolveRound(
     enemyPicks?: (Card | null)[],
     options?: {
@@ -1458,6 +1479,30 @@ export function useThreeWheelGame({
         clearRematchVotes();
         setPhase("ended");
         return;
+      }
+
+      if (isSkillMode) {
+        const hasReadyAbility = (["player", "enemy"] as LegacySide[]).some((side) =>
+          (skillStateRef.current.lanes[side] ?? []).some((lane) => lane.ability && !lane.exhausted),
+        );
+
+        if (hasReadyAbility) {
+          setSkillState((prev) => {
+            if (!prev.completed) return prev;
+            const next = { ...prev, completed: false };
+            skillStateRef.current = next;
+            return next;
+          });
+          setPhase("skill");
+          return;
+        }
+
+        setSkillState((prev) => {
+          if (prev.completed) return prev;
+          const next = { ...prev, completed: true };
+          skillStateRef.current = next;
+          return next;
+        });
       }
 
       setPhase("roundEnd");
@@ -1747,11 +1792,6 @@ export function useThreeWheelGame({
   ]);
 
   const handleSkillConfirm = useCallback(() => {
-    if (!isSkillMode) {
-      tryRevealRound({ force: true });
-      return;
-    }
-
     setSkillState((prev) => {
       if (prev.completed) return prev;
       const next = { ...prev, completed: true };
@@ -1759,8 +1799,8 @@ export function useThreeWheelGame({
       return next;
     });
 
-    tryRevealRound({ force: true });
-  }, [isSkillMode, tryRevealRound]);
+    setPhase("roundEnd");
+  }, [setPhase]);
 
   const useSkillAbility = useCallback(
     (side: LegacySide, laneIndex: number) => {

--- a/src/features/threeWheel/utils/skillPhase.ts
+++ b/src/features/threeWheel/utils/skillPhase.ts
@@ -10,15 +10,9 @@ export interface RevealFlowOptions {
 
 export function decideRevealFlow({
   currentPhase,
-  isSkillMode,
-  skillCompleted,
 }: RevealFlowOptions): RevealDecision {
   if (currentPhase !== "choose") {
     return "revealRound";
-  }
-
-  if (isSkillMode && !skillCompleted) {
-    return "skillPhase";
   }
 
   return "revealRound";

--- a/tests/skillPhaseTransition.test.ts
+++ b/tests/skillPhaseTransition.test.ts
@@ -14,40 +14,20 @@ assert.equal(
 
 assert.equal(
   decideRevealFlow({ currentPhase: choosePhase, isSkillMode: true, skillCompleted: false }),
-  "skillPhase",
-  "Skill Mode should enter the Skill Phase before combat when unresolved.",
+  "revealRound",
+  "Skill Mode no longer pauses the reveal flow before combat.",
 );
 
 assert.equal(
   decideRevealFlow({ currentPhase: choosePhase, isSkillMode: true, skillCompleted: true }),
   "revealRound",
-  "Skill Mode should continue to reveal once the Skill Phase is complete.",
+  "Skill Mode continues to reveal even after abilities resolve.",
 );
 
 assert.equal(
   decideRevealFlow({ currentPhase: roundEndPhase, isSkillMode: true, skillCompleted: false }),
   "revealRound",
-  "Non-choose phases should bypass the Skill Phase entirely.",
+  "Non-choose phases still bypass any additional flow.",
 );
-
-type ModeScenario = {
-  label: string;
-  phase: CorePhase;
-  skillCompleted: boolean;
-  expected: ReturnType<typeof decideRevealFlow>;
-};
-
-const grimoireRegressionCases: ModeScenario[] = [
-  { label: "Grimoire choose", phase: "choose", skillCompleted: true, expected: "revealRound" },
-  { label: "Ante roundEnd", phase: "roundEnd", skillCompleted: false, expected: "revealRound" },
-];
-
-grimoireRegressionCases.forEach(({ label, phase, skillCompleted, expected }) => {
-  assert.equal(
-    decideRevealFlow({ currentPhase: phase, isSkillMode: false, skillCompleted }),
-    expected,
-    `${label} should continue to match pre-skill behaviour.`,
-  );
-});
 
 console.log("Skill phase transition checks passed.");


### PR DESCRIPTION
## Summary
- remove the pre-combat skill phase stop so rounds resolve before any skill decisions
- surface skill readiness on the wheel cards and let players trigger skills directly from the board
- adjust the skill flow logic and tests to reflect the new activation timing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e52cfb72b8833287e9d14fd452dd9b