### PR TITLE
Refine skill ability targeting configuration

### DIFF
--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -24,7 +24,11 @@ import {
 import { DEFAULT_GAME_MODE, normalizeGameMode, type GameMode } from "../../../gameModes";
 import { easeInOutCubic, inSection, createSeededRng } from "../../../game/math";
 import { genWheelSections } from "../../../game/wheel";
-import { determineSkillAbility, type AbilityKind } from "../../../game/skills";
+import {
+  determineSkillAbility,
+  type AbilityKind,
+  type SkillTargetSelection,
+} from "../../../game/skills";
 import {
   makeFighter,
   refillTo,
@@ -204,7 +208,7 @@ export type ThreeWheelGameActions = {
   applySpellEffects: (payload: SpellEffectPayload, options?: { broadcast?: boolean }) => void;
   setAnteBet: (bet: number) => void;
   handleSkillConfirm: () => void;
-  useSkillAbility: (side: LegacySide, laneIndex: number) => void;
+  useSkillAbility: (side: LegacySide, laneIndex: number, targets?: SkillTargetSelection[]) => void;
 };
 
 export type ThreeWheelGameReturn = {
@@ -1763,7 +1767,7 @@ export function useThreeWheelGame({
   }, [isSkillMode, tryRevealRound]);
 
   const useSkillAbility = useCallback(
-    (side: LegacySide, laneIndex: number) => {
+    (side: LegacySide, laneIndex: number, _targets: SkillTargetSelection[] = []) => {
       let usedAbility: AbilityKind | null = null;
       setSkillState((prev) => {
         const lanes = prev.lanes[side];


### PR DESCRIPTION
## Summary
- update skill ability targeting metadata to support repeated selections per stage config
- restrict boost card abilities to friendly targets and clarify prompt copy

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e52d0fc6e88332835e2825b54642e5