### PR TITLE
Move skill phase to occur after round resolution

### DIFF
--- a/src/features/threeWheel/components/HUDPanels.tsx
+++ b/src/features/threeWheel/components/HUDPanels.tsx
@@ -55,7 +55,12 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
     const rs = isPlayer ? rsP : rsE;
     const hasInit = initiative === side;
     const isReserveVisible =
-      (phase === "showEnemy" || phase === "anim" || phase === "roundEnd" || phase === "ended") && rs !== null;
+      (phase === "showEnemy" ||
+        phase === "anim" ||
+        phase === "skill" ||
+        phase === "roundEnd" ||
+        phase === "ended") &&
+      rs !== null;
     const reserveHighlighted = Boolean(reserveSpellHighlights?.[side]);
 
     const manaCount = isPlayer ? manaPools.player : manaPools.enemy;

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -463,7 +463,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
   const panelStyle = variant === "standalone" ? standaloneStyle : groupedStyle;
 
   const resultIndicators =
-    (phase === "roundEnd" || phase === "ended") && (
+    (phase === "skill" || phase === "roundEnd" || phase === "ended") && (
       <>
         <span
           aria-label={`Wheel ${index + 1} player result`}

--- a/src/features/threeWheel/utils/skillPhase.ts
+++ b/src/features/threeWheel/utils/skillPhase.ts
@@ -1,25 +1,17 @@
 import type { CorePhase } from "../../../game/types";
 
-export type RevealDecision = "skillPhase" | "revealRound";
-
-export interface RevealFlowOptions {
-  currentPhase: CorePhase;
+export interface PostResolvePhaseOptions {
   isSkillMode: boolean;
   skillCompleted: boolean;
 }
 
-export function decideRevealFlow({
-  currentPhase,
+export function determinePostResolvePhase({
   isSkillMode,
   skillCompleted,
-}: RevealFlowOptions): RevealDecision {
-  if (currentPhase !== "choose") {
-    return "revealRound";
-  }
-
+}: PostResolvePhaseOptions): CorePhase {
   if (isSkillMode && !skillCompleted) {
-    return "skillPhase";
+    return "skill";
   }
 
-  return "revealRound";
+  return "roundEnd";
 }

--- a/src/game/hooks/useSpellCasting.ts
+++ b/src/game/hooks/useSpellCasting.ts
@@ -93,16 +93,18 @@ export function useSpellCasting(options: UseSpellCastingOptions): UseSpellCastin
   const [phaseBeforeSpell, setPhaseBeforeSpell] = useState<CorePhase | null>(null);
 
   const phaseForLogic = phaseBeforeSpell ?? phase;
+  const normalizedPhaseForLogic: CorePhase =
+    phaseForLogic === "skill" ? "roundEnd" : phaseForLogic;
 
   const getSpellCost = useCallback(
     (spell: SpellDefinition): number =>
       computeSpellCost(spell, {
         caster,
         opponent,
-        phase: phaseForLogic,
+        phase: normalizedPhaseForLogic,
         runtimeState: runtimeStateRef.current,
       }),
-    [caster, opponent, phaseForLogic, runtimeStateRef],
+    [caster, normalizedPhaseForLogic, opponent, runtimeStateRef],
   );
 
   const handleResolvePendingSpell = useCallback(
@@ -112,7 +114,7 @@ export function useSpellCasting(options: UseSpellCastingOptions): UseSpellCastin
         targetOverride,
         caster,
         opponent,
-        phase: phaseForLogic,
+        phase: normalizedPhaseForLogic,
         runtimeState: runtimeStateRef.current,
       });
 
@@ -159,8 +161,8 @@ export function useSpellCasting(options: UseSpellCastingOptions): UseSpellCastin
       caster,
       clearPendingSpell,
       closeGrimoire,
+      normalizedPhaseForLogic,
       opponent,
-      phaseForLogic,
       runtimeStateRef,
       setManaPools,
     ],
@@ -196,7 +198,7 @@ export function useSpellCasting(options: UseSpellCastingOptions): UseSpellCastin
         pendingSpell && pendingSpell.side === localSide ? pendingSpell : null;
 
       const allowedPhases = spell.allowedPhases ?? ["choose"];
-      if (!allowedPhases.includes(phaseForLogic)) return;
+      if (!allowedPhases.includes(normalizedPhaseForLogic)) return;
 
       const effectiveCost = getSpellCost(spell);
       const availableMana = refundablePending ? localMana + refundablePending.spentMana : localMana;
@@ -234,6 +236,7 @@ export function useSpellCasting(options: UseSpellCastingOptions): UseSpellCastin
       handlePendingSpellCancel,
       localMana,
       localSide,
+      normalizedPhaseForLogic,
       pendingSpell,
       phaseForLogic,
       setManaPools,

--- a/tests/skillPhaseTransition.test.ts
+++ b/tests/skillPhaseTransition.test.ts
@@ -1,53 +1,23 @@
 import assert from "node:assert/strict";
 
-import { decideRevealFlow } from "../src/features/threeWheel/utils/skillPhase.js";
-import type { CorePhase } from "../src/game/types.js";
-
-const choosePhase: CorePhase = "choose";
-const roundEndPhase: CorePhase = "roundEnd";
+import { determinePostResolvePhase } from "../src/features/threeWheel/utils/skillPhase.js";
 
 assert.equal(
-  decideRevealFlow({ currentPhase: choosePhase, isSkillMode: false, skillCompleted: false }),
-  "revealRound",
-  "Classic flow should reveal immediately when Skill Mode is disabled.",
+  determinePostResolvePhase({ isSkillMode: false, skillCompleted: false }),
+  "roundEnd",
+  "Classic flow should proceed directly to the round end phase.",
 );
 
 assert.equal(
-  decideRevealFlow({ currentPhase: choosePhase, isSkillMode: true, skillCompleted: false }),
-  "skillPhase",
-  "Skill Mode should enter the Skill Phase before combat when unresolved.",
+  determinePostResolvePhase({ isSkillMode: true, skillCompleted: false }),
+  "skill",
+  "Skill Mode should enter the Skill phase after resolve when unfinished.",
 );
 
 assert.equal(
-  decideRevealFlow({ currentPhase: choosePhase, isSkillMode: true, skillCompleted: true }),
-  "revealRound",
-  "Skill Mode should continue to reveal once the Skill Phase is complete.",
+  determinePostResolvePhase({ isSkillMode: true, skillCompleted: true }),
+  "roundEnd",
+  "Skill Mode should skip the Skill phase once it has been completed.",
 );
-
-assert.equal(
-  decideRevealFlow({ currentPhase: roundEndPhase, isSkillMode: true, skillCompleted: false }),
-  "revealRound",
-  "Non-choose phases should bypass the Skill Phase entirely.",
-);
-
-type ModeScenario = {
-  label: string;
-  phase: CorePhase;
-  skillCompleted: boolean;
-  expected: ReturnType<typeof decideRevealFlow>;
-};
-
-const grimoireRegressionCases: ModeScenario[] = [
-  { label: "Grimoire choose", phase: "choose", skillCompleted: true, expected: "revealRound" },
-  { label: "Ante roundEnd", phase: "roundEnd", skillCompleted: false, expected: "revealRound" },
-];
-
-grimoireRegressionCases.forEach(({ label, phase, skillCompleted, expected }) => {
-  assert.equal(
-    decideRevealFlow({ currentPhase: phase, isSkillMode: false, skillCompleted }),
-    expected,
-    `${label} should continue to match pre-skill behaviour.`,
-  );
-});
 
 console.log("Skill phase transition checks passed.");


### PR DESCRIPTION
## Summary
- move the skill phase to follow round resolution and reuse the Next button to finish the round
- align UI elements, spell casting checks, and HUD displays with the new post-resolve skill flow
- add a utility for determining the post-resolve phase and update skill phase tests accordingly

## Testing
- npm run test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e5524bbb548332b79e13e0cc5a4730