### PR TITLE
Implement exhaust mechanic and skill ability updates

### DIFF
--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -369,28 +369,35 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
       startTouchDrag(card, e);
     };
 
+    const isExhausted = Boolean(skillState?.exhausted);
+    const rotationClass = `inline-block transition-transform duration-200 ease-out ${
+      isExhausted ? "rotate-90" : ""
+    }`;
+
     return (
-      <StSCard
-        card={card}
-        size="sm"
-        disabled={!cardInteractable}
-        selected={isSlotSelected || isSkillAbilityLane}
-        spellAffected={isSpellAffected}
-        onPick={handlePick}
-        draggable={allowDrag}
-        onDragStart={allowDrag ? handleDragStart : undefined}
-        onDragEnd={allowDrag ? handleDragEnd : undefined}
-        onPointerDown={handlePointerDown}
-        onTouchStart={handleTouchStart}
-        className={
-          slotTargetable
-            ? "ring-2 ring-sky-400"
-            : laneTargetableForSkill || isSkillAbilityLane
-            ? "ring-2 ring-amber-300"
-            : undefined
-        }
-        spellTargetable={slotTargetable || laneTargetableForSkill}
-      />
+      <div className={rotationClass} data-exhausted={isExhausted ? "true" : undefined}>
+        <StSCard
+          card={card}
+          size="sm"
+          disabled={!cardInteractable}
+          selected={isSlotSelected || isSkillAbilityLane}
+          spellAffected={isSpellAffected}
+          onPick={handlePick}
+          draggable={allowDrag}
+          onDragStart={allowDrag ? handleDragStart : undefined}
+          onDragEnd={allowDrag ? handleDragEnd : undefined}
+          onPointerDown={handlePointerDown}
+          onTouchStart={handleTouchStart}
+          className={
+            slotTargetable
+              ? "ring-2 ring-sky-400"
+              : laneTargetableForSkill || isSkillAbilityLane
+              ? "ring-2 ring-amber-300"
+              : undefined
+          }
+          spellTargetable={slotTargetable || laneTargetableForSkill}
+        />
+      </div>
     );
   };
 

--- a/src/game/skills.ts
+++ b/src/game/skills.ts
@@ -30,7 +30,7 @@ export function getSkillCardValue(card: Card): number {
 }
 
 export function deriveAbilityForCard(printed: number): AbilityKind {
-  if (printed >= 5) {
+  if (printed >= 6) {
     return "reserveBoost";
   }
 
@@ -88,17 +88,17 @@ export function isReserveBoostTarget(card: Card): boolean {
 }
 
 const ABILITY_DESCRIPTIONS: Record<AbilityKind, (card?: Card) => string> = {
-  swapReserve: () => "Swap this card with one from your reserve.",
-  rerollReserve: () => "Discard a reserve card and draw a new one.",
+  swapReserve: () => "Swap this lane card with one from your reserve.",
+  rerollReserve: () => "Discard a reserve card, draw a new one, then recalc reserve (repeat once).",
   boostCard: (card) => {
     const value = Math.abs(getSkillCardValue(card ?? ({} as Card)));
-    return `Add ${value} to a card in play.`;
+    return `Add ${value} to a friendly card in play.`;
   },
   reserveBoost: (card) => {
     const value = getReserveBoostValue(card ?? ({} as Card));
     return value > 0
-      ? `Consume a reserve worth ${value} to boost this lane.`
-      : "Consume a positive reserve to boost this lane.";
+      ? `Exhaust a positive reserve worth ${value} to boost this lane.`
+      : "Exhaust a positive reserve to boost this lane.";
   },
 };
 

--- a/tests/skillAbilityClassification.test.ts
+++ b/tests/skillAbilityClassification.test.ts
@@ -39,7 +39,10 @@ const makeCard = (overrides: Partial<Record<keyof Card, unknown>>): Card => {
 {
   const card = makeCard({ baseNumber: "3" as unknown as number });
   assert.equal(determineSkillAbility(card), "boostCard");
-  assert.equal(describeSkillAbility("boostCard", card), "Add 3 to a card in play.");
+  assert.equal(
+    describeSkillAbility("boostCard", card),
+    "Add 3 to a friendly card in play.",
+  );
 }
 
 {


### PR DESCRIPTION
## Summary
- add new skill value thresholds and refreshed descriptions
- exhaust skill cards after use while applying swap, reroll, boost, and reserve boost effects
- rotate exhausted lane cards and update skill ability classification tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e55e0e0e1c8332bf5debb4605c5275