### PR TITLE
Allow reroll reserve ability to offer a second reroll

### DIFF
--- a/src/game/skills.ts
+++ b/src/game/skills.ts
@@ -89,7 +89,8 @@ export function isReserveBoostTarget(card: Card): boolean {
 
 const ABILITY_DESCRIPTIONS: Record<AbilityKind, (card?: Card) => string> = {
   swapReserve: () => "Swap this lane card with one from your reserve.",
-  rerollReserve: () => "Discard a reserve card, draw a new one, then recalc reserve (repeat once).",
+  rerollReserve: () =>
+    "Discard a reserve card, draw a new one, then recalc reserve. You may repeat once.",
   boostCard: (card) => {
     const value = Math.abs(getSkillCardValue(card ?? ({} as Card)));
     return `Add ${value} to a friendly card in play.`;


### PR DESCRIPTION
## Summary
- keep the reroll reserve target selection active after the first discard so players can choose a second card or cancel
- track remaining skill uses in the three wheel hook and add guidance logs for the optional reroll
- document the new flow and add coverage ensuring both reroll iterations refresh the reserve preview

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5754f50ac83329d888a05918e1c06