### PR TITLE
Adjust exhaust rotation translation

### DIFF
--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -371,7 +371,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
 
     const isExhausted = Boolean(skillState?.exhausted);
     const rotationClass = `inline-block transition-transform duration-200 ease-out ${
-      isExhausted ? "rotate-90" : ""
+      isExhausted ? "rotate-90 -translate-x-0.5" : ""
     }`;
 
     return (


### PR DESCRIPTION
## Summary
- shift exhausted cards 2px to the left when rotated so the visual exhaust state aligns as intended

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e57bdeeb2c833282c7b08d73276208