### PR TITLE
Allow skill abilities to target source lane

### DIFF
--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -321,12 +321,12 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
         return;
       }
       if (skillTargeting) {
-        if (isSkillAbilityLane) {
-          onSkillAbilityCancel?.();
-          return;
-        }
         if (laneTargetableForSkill) {
           onSkillTargetSelect?.({ laneIndex: index, side: slot.side });
+          return;
+        }
+        if (isSkillAbilityLane) {
+          onSkillAbilityCancel?.();
           return;
         }
       }


### PR DESCRIPTION
## Summary
- allow skill ability targeting to select the source lane instead of cancelling immediately

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e64ab5feb08332b95a8fe11a09ac57