### PR TITLE
Prevent overlapping skill activations in skill mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1209,6 +1209,13 @@ export default function ThreeWheel_WinsOnly({
   const beginSkillTargeting = useCallback(
     (laneIndex: number, ability: AbilityKind) => {
       if (!skillPhaseActive) return;
+      if (
+        skillTargeting &&
+        skillTargeting.side === localLegacySide &&
+        skillTargeting.laneIndex !== laneIndex
+      ) {
+        return;
+      }
       const spec = SKILL_TARGET_SPECS[ability];
       if (!spec) return;
       if (

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -292,7 +292,10 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
     const skillState = skillLaneStates?.[index];
     const hasSkillAbility = Boolean(skillState?.ability && !skillState?.exhausted);
     const skillAbilityAvailable =
-      skillPhaseActive && slot.side === localLegacySide && hasSkillAbility;
+      skillPhaseActive &&
+      slot.side === localLegacySide &&
+      hasSkillAbility &&
+      (!skillTargeting || targetedSkillLane);
     const skillTargetingFriendlyLane =
       skillTargeting &&
       skillTargeting.side === localLegacySide &&


### PR DESCRIPTION
## Summary
- prevent players from starting a new skill while another skill is being targeted
- ensure wheel UI disables additional skill activations until the current one is completed or cancelled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e64c072470833282ee9883cdf8f938