### PR TITLE
Keep reserve boost cards exhausted in reserve

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -146,7 +146,7 @@ const SKILL_TARGET_SPECS: Record<AbilityKind, SkillTargetSpec> = {
   },
   reserveBoost: {
     kind: "reserveThenLane",
-    reservePrompt: "Select a positive reserve card to consume for a boost.",
+    reservePrompt: "Select a positive reserve card to exhaust for a boost.",
     lanePrompt: "Select a friendly lane to receive the reserve boost.",
     requirePositiveReserve: true,
   },

--- a/src/features/threeWheel/utils/skillAbilityExecution.ts
+++ b/src/features/threeWheel/utils/skillAbilityExecution.ts
@@ -195,15 +195,19 @@ export const applySkillAbilityEffect = (
         return { success: false, failureReason: "That reserve card is no longer available." };
       }
       const reserveCard = fighter.hand[reserveIndex];
+      if (reserveCard.reserveExhausted) {
+        return { success: false, failureReason: "That reserve card has already been exhausted." };
+      }
       const storedReserveValue = Math.max(0, getReserveBoostValue(reserveCard));
 
       updateFighter(side, (prev) => {
-        const nextHand = [...prev.hand];
-        const idx = nextHand.findIndex((card) => card.id === target.cardId);
+        const idx = prev.hand.findIndex((card) => card.id === target.cardId);
         if (idx === -1) return prev;
-        const [removed] = nextHand.splice(idx, 1);
-        const nextExhaust = removed ? [...prev.exhaust, removed] : [...prev.exhaust];
-        return { ...prev, hand: nextHand, exhaust: nextExhaust };
+        const existing = prev.hand[idx];
+        if (existing.reserveExhausted) return prev;
+        const nextHand = [...prev.hand];
+        nextHand[idx] = { ...existing, reserveExhausted: true };
+        return { ...prev, hand: nextHand };
       });
 
       updateReservePreview();

--- a/src/game/skills.ts
+++ b/src/game/skills.ts
@@ -64,6 +64,10 @@ export function getReserveBoostValue(card: Card): number {
     return 0;
   }
 
+  if (card.reserveExhausted) {
+    return 0;
+  }
+
   const base = sanitizeNumber(card.baseNumber);
   if (base !== undefined && base > 0) {
     return base;
@@ -79,6 +83,10 @@ export function getReserveBoostValue(card: Card): number {
 
 export function isReserveBoostTarget(card: Card): boolean {
   if (hasNegativeBase(card)) {
+    return false;
+  }
+
+  if (card.reserveExhausted) {
     return false;
   }
 
@@ -106,7 +114,7 @@ const ABILITY_DESCRIPTIONS: Record<AbilityKind, (card?: Card) => string> = {
   reserveBoost: (card) => {
     const value = getReserveBoostValue(card ?? ({} as Card));
     return value > 0
-      ? `Select a positive reserve card to boost a friendly lane by ${value}.`
+      ? `Select a positive reserve card to exhaust and boost a friendly lane by ${value}.`
       : "-";
   },
 };

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -41,6 +41,7 @@ export type Card = {
   rightValue?: number;  // when type === "split"
   tags: TagId[];
   arcana?: Arcana;
+  reserveExhausted?: boolean;
 };
 
 export type VC =

--- a/tests/skillAbilityClassification.test.ts
+++ b/tests/skillAbilityClassification.test.ts
@@ -73,13 +73,20 @@ const makeCard = (overrides: Partial<Record<keyof Card, unknown>>): Card => {
   const card = makeCard({ baseNumber: 5 });
   assert.equal(
     describeSkillAbility("reserveBoost", card),
-    "Select a positive reserve card to boost a friendly lane by 5.",
+    "Select a positive reserve card to exhaust and boost a friendly lane by 5.",
   );
 }
 
 {
   const card = makeCard({ number: 5, baseNumber: 5 });
   assert.equal(isReserveBoostTarget(card), true);
+}
+
+{
+  const card = makeCard({ number: 5, baseNumber: 5, reserveExhausted: true });
+  assert.equal(getReserveBoostValue(card), 0);
+  assert.equal(isReserveBoostTarget(card), false);
+  assert.equal(describeSkillAbility("reserveBoost", card), "-");
 }
 
 {

--- a/tests/skillAbilityExecution.test.ts
+++ b/tests/skillAbilityExecution.test.ts
@@ -251,16 +251,17 @@ const makeOptions = (
 
   const result = applySkillAbilityEffect(options);
   assert.equal(result.success, true);
-  assert.equal(fighterState.hand.length, 0, "reserve card should be removed from hand");
-  assert.deepEqual(fighterState.discard, [], "reserve card should not enter discard");
-  assert.deepEqual(
-    fighterState.exhaust.map((card) => card.id),
-    [reserveCard.id],
-    "reserve card should be exhausted",
+  assert.equal(fighterState.hand.length, 1, "reserve card should remain in hand");
+  assert.equal(
+    fighterState.hand[0]?.reserveExhausted,
+    true,
+    "reserve card should be marked exhausted",
   );
+  assert.deepEqual(fighterState.discard, [], "reserve card should not enter discard");
+  assert.deepEqual(fighterState.exhaust.map((card) => card.id), [], "reserve pile unchanged");
   const ensuredAssignments: AssignmentState<Card> = updatedAssignments!;
   const boostedLane = ensuredAssignments.player[0];
   assert.equal(boostedLane?.number, 8, "lane should gain the reserve card's value");
 
-  console.log("reserve boost exhausts reserve card test passed");
+  console.log("reserve boost exhausts reserve card in place test passed");
 }


### PR DESCRIPTION
## Summary
- leave reserve boost targets in the reserve by marking them exhausted instead of moving them to the exhaust pile
- gate boosting logic and UI copy on a reserveExhausted flag so spent cards cannot be reselected
- update unit tests to cover the new behaviour and messaging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e64b3bff308332a63a24730e1489ae