### PR TITLE
Add skill mode card number color scheme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1880,9 +1880,10 @@ export default function ThreeWheel_WinsOnly({
                 skillPhaseActive={skillPhaseActive}
                 skillLaneStates={localSkillLanes}
                 onSkillAbilityStart={beginSkillTargeting}
-                        onSkillTargetSelect={handleSkillLaneTarget}
+                onSkillTargetSelect={handleSkillLaneTarget}
                 skillTargeting={skillTargetingForChildren}
                 skillTargetableLaneIndexes={skillTargetableLaneIndexes}
+                numberColorMode={isSkillMode ? "skill" : "arcana"}
               />
             </div>
           ))}
@@ -1916,6 +1917,7 @@ export default function ThreeWheel_WinsOnly({
         skillTargeting={skillTargetingForChildren}
         skillTargetableReserveIds={skillTargetableReserveIds}
         onSkillTargetSelect={handleSkillReserveTarget}
+        numberColorMode={isSkillMode ? "skill" : "arcana"}
       />
 
       <FirstRunCoach

--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -61,6 +61,7 @@ interface HandDockProps {
   skillTargetableReserveIds?: Set<string> | null;
   onSkillTargetSelect?: (selection: { cardId: string }) => void;
   onSkillAbilityCancel?: () => void;
+  numberColorMode?: "arcana" | "skill";
 }
 
 const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
@@ -90,6 +91,7 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
     skillTargetableReserveIds,
     onSkillTargetSelect,
     onSkillAbilityCancel,
+    numberColorMode = "arcana",
   }, forwardedRef) => {
     const dockRef = useRef<HTMLDivElement | null>(null);
     const ghostRef = useRef<HTMLDivElement | null>(null);
@@ -253,7 +255,7 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
           aria-hidden
         >
           <div style={{ transform: "scale(0.9)", filter: "drop-shadow(0 6px 8px rgba(0,0,0,.35))" }}>
-            <StSCard card={ptrDragCard} />
+            <StSCard card={ptrDragCard} numberColorMode={numberColorMode} />
           </div>
         </div>
       ) : null;
@@ -301,6 +303,7 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
                       data-hand-card
                       className="pointer-events-auto"
                       card={card}
+                      numberColorMode={numberColorMode}
                       selected={isSelected}
                       disabled={cardDisabled}
                       spellTargetable={cardSelectable}

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -93,6 +93,7 @@ export interface WheelPanelProps {
     specKind: "reserve" | "friendlyLane";
   } | null;
   skillTargetableLaneIndexes?: Set<number> | null;
+  numberColorMode?: "arcana" | "skill";
 }
 
 const slotWidthPx = 80;
@@ -153,6 +154,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
   onSkillTargetSelect,
   skillTargeting,
   skillTargetableLaneIndexes,
+  numberColorMode = "arcana",
 }) => {
   const playerCard = assign.player[index];
   const enemyCard = assign.enemy[index];
@@ -382,6 +384,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
         <StSCard
           card={card}
           size="sm"
+          numberColorMode={numberColorMode}
           disabled={!cardInteractable}
           selected={isSlotSelected || isSkillAbilityLane}
           spellAffected={isSpellAffected}


### PR DESCRIPTION
## Summary
- add a skill-mode color mapping for card numbers in `StSCard`
- allow wheel and hand panels to forward the desired number color mode and default to skill colors when the game is in skill mode

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e64deb4c70833288e1f92d3096f660