### PR TITLE
Add skill mode guidance to help overlays

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1613,21 +1613,21 @@ export default function ThreeWheel_WinsOnly({
                         <span className="font-semibold">Skill Mode - Lane Abilities</span>
                       </div>
                       <div>
-                        After Resolve, any lane showing a skill icon enters a <span className="font-semibold">Skill phase</span>.
-                        Trigger the lane once per round to apply its effect immediately.
+                        After Resolve, players enter into a <span className="font-semibold">Skill phase</span>.
+                        Each card in play can be pressed to activate it's skill.
                       </div>
                       <div>
-                        Skill numbers glow by strength:
+                        Each skill is associated with a specific color depicted on a card's value:
                         <span className="ml-1 font-semibold text-amber-300">0</span>,
                         <span className="ml-1 font-semibold text-sky-300">1-2</span>,
                         <span className="ml-1 font-semibold text-rose-300">3-5</span>,
                         <span className="ml-1 font-semibold text-emerald-400">6+</span>.
                       </div>
                       <ul className="list-disc pl-5 space-y-1">
-                        <li><b>Swap Reserve:</b> Trade the lane’s card with one from your reserve.</li>
-                        <li><b>Reroll Reserve:</b> Discard a reserve card to draw a replacement.</li>
-                        <li><b>Boost Card:</b> Add that card’s value to a friendly lane for this round.</li>
-                        <li><b>Reserve Boost:</b> Exhaust a positive reserve card to grant its value to a lane.</li>
+                        <li><b>Swap Reserve:</b> Trade a card in play with one from your reserve.</li>
+                        <li><b>Reroll Reserve:</b> Discard up to 2 reserve cards and draw replacements.</li>
+                        <li><b>Boost Card:</b> Add activated card’s value to a card in play.</li>
+                        <li><b>Reserve Boost:</b> Exhaust a reserve card and grant its value to a card in play.</li>
                       </ul>
                     </div>
                   )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1607,6 +1607,30 @@ export default function ThreeWheel_WinsOnly({
                       </div>
                     </div>
                   )}
+                  {isSkillMode && (
+                    <div className="space-y-1">
+                      <div>
+                        <span className="font-semibold">Skill Mode - Lane Abilities</span>
+                      </div>
+                      <div>
+                        After Resolve, any lane showing a skill icon enters a <span className="font-semibold">Skill phase</span>.
+                        Trigger the lane once per round to apply its effect immediately.
+                      </div>
+                      <div>
+                        Skill numbers glow by strength:
+                        <span className="ml-1 font-semibold text-amber-300">0</span>,
+                        <span className="ml-1 font-semibold text-sky-300">1-2</span>,
+                        <span className="ml-1 font-semibold text-rose-300">3-5</span>,
+                        <span className="ml-1 font-semibold text-emerald-400">6+</span>.
+                      </div>
+                      <ul className="list-disc pl-5 space-y-1">
+                        <li><b>Swap Reserve:</b> Trade the lane’s card with one from your reserve.</li>
+                        <li><b>Reroll Reserve:</b> Discard a reserve card to draw a replacement.</li>
+                        <li><b>Boost Card:</b> Add that card’s value to a friendly lane for this round.</li>
+                        <li><b>Reserve Boost:</b> Exhaust a positive reserve card to grant its value to a lane.</li>
+                      </ul>
+                    </div>
+                  )}
                 </div>
               </div>
             )}

--- a/ui/RogueWheelHub.tsx
+++ b/ui/RogueWheelHub.tsx
@@ -372,6 +372,45 @@ function HowToContent() {
           </div>
         </div>
       </div>
+
+      <div className="space-y-4">
+        <h2 className="text-xl font-bold border-b border-white/10 pb-2">Skill Mode</h2>
+        <p>
+          Each wheel lane gains a <b>Skill phase</b> after Resolve. If your card in that lane shows an ability, you may trigger it
+          once per round. Skill numbers glow by strength — <span className="text-amber-300 font-semibold">0</span>,
+          <span className="text-sky-300 font-semibold">1-2</span>, <span className="text-rose-300 font-semibold">3-5</span>,
+          <span className="text-emerald-400 font-semibold">6+</span> — so you can spot power cards at a glance.
+        </p>
+        <div className="grid gap-3 md:grid-cols-2">
+          <div className="rounded-xl bg-white/5 p-3 ring-1 ring-white/10">
+            <div className="font-semibold">Skill Abilities</div>
+            <ul className="mt-1 list-disc pl-5 space-y-1">
+              <li>
+                <b>Swap Reserve:</b> Trade the skill card with a reserve card and place it in the same lane.
+              </li>
+              <li>
+                <b>Reroll Reserve:</b> Discard a reserve card to draw a fresh replacement.
+              </li>
+              <li>
+                <b>Boost Card:</b> Add that card’s value to a friendly lane for the round.
+              </li>
+              <li>
+                <b>Reserve Boost:</b> Exhaust a positive reserve card to grant its value to a friendly lane.
+              </li>
+            </ul>
+          </div>
+          <div className="rounded-xl bg-white/5 p-3 ring-1 ring-white/10 space-y-1">
+            <div className="font-semibold">Timing &amp; Tips</div>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>Abilities unlock on the lane that played the card; each can fire only once per round.</li>
+              <li>
+                Boosts apply immediately — plan your Resolve placement so a later wheel can benefit from the buff.
+              </li>
+              <li>Reserve abilities respect exhaustion: once a reserve card is spent it can’t be boosted again.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
     </>
   );
 }

--- a/ui/RogueWheelHub.tsx
+++ b/ui/RogueWheelHub.tsx
@@ -376,37 +376,37 @@ function HowToContent() {
       <div className="space-y-4">
         <h2 className="text-xl font-bold border-b border-white/10 pb-2">Skill Mode</h2>
         <p>
-          Each wheel lane gains a <b>Skill phase</b> after Resolve. If your card in that lane shows an ability, you may trigger it
-          once per round. Skill numbers glow by strength — <span className="text-amber-300 font-semibold">0</span>,
+          Each card in play grants a <b>Skill</b> after Resolve. You may trigger a card's skill
+          once per round. Skills are associated with specific colors depicted by the card value — <span className="text-amber-300 font-semibold">0</span>,
           <span className="text-sky-300 font-semibold">1-2</span>, <span className="text-rose-300 font-semibold">3-5</span>,
-          <span className="text-emerald-400 font-semibold">6+</span> — so you can spot power cards at a glance.
+          <span className="text-emerald-400 font-semibold">6+</span> — so you can spot skills at a glance.
         </p>
         <div className="grid gap-3 md:grid-cols-2">
           <div className="rounded-xl bg-white/5 p-3 ring-1 ring-white/10">
             <div className="font-semibold">Skill Abilities</div>
             <ul className="mt-1 list-disc pl-5 space-y-1">
               <li>
-                <b>Swap Reserve:</b> Trade the skill card with a reserve card and place it in the same lane.
+                <b>Swap Reserve:</b> Trade the positions of the skill card with a reserve card.
               </li>
               <li>
-                <b>Reroll Reserve:</b> Discard a reserve card to draw a fresh replacement.
+                <b>Reroll Reserve:</b> Discard up to 2 reserve cards and draw fresh replacements.
               </li>
               <li>
-                <b>Boost Card:</b> Add that card’s value to a friendly lane for the round.
+                <b>Boost Card:</b> Add that card’s value to a card in play.
               </li>
               <li>
-                <b>Reserve Boost:</b> Exhaust a positive reserve card to grant its value to a friendly lane.
+                <b>Reserve Boost:</b> Exhaust a reserve card to grant its value to a card in play.
               </li>
             </ul>
           </div>
           <div className="rounded-xl bg-white/5 p-3 ring-1 ring-white/10 space-y-1">
             <div className="font-semibold">Timing &amp; Tips</div>
             <ul className="list-disc pl-5 space-y-1">
-              <li>Abilities unlock on the lane that played the card; each can fire only once per round.</li>
+              <li>Skills each can fire only once per round.</li>
               <li>
                 Boosts apply immediately — plan your Resolve placement so a later wheel can benefit from the buff.
               </li>
-              <li>Reserve abilities respect exhaustion: once a reserve card is spent it can’t be boosted again.</li>
+              <li>Reserve abilities respect exhaustion: once a reserve card is spent it can’t be used again in the round.</li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- expand the How to Play overlay with a dedicated Skill Mode section that explains ability types, timing, and color cues
- update the in-game reference popover to surface the same skill instructions only when the Skill mode is active

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e6514b0a848332bef76d6fc46d191d