### PR TITLE
Add difficulty badges to mode select modes

### DIFF
--- a/src/ModeSelect.tsx
+++ b/src/ModeSelect.tsx
@@ -114,8 +114,18 @@ export default function ModeSelect({
                 aria-pressed={isSelected}
               >
                 <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <div className="text-lg font-semibold sm:text-xl">{info.title}</div>
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <div className="text-lg font-semibold sm:text-xl">{info.title}</div>
+                      <span
+                        className={[
+                          "rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide",
+                          info.difficulty.badgeClassName,
+                        ].join(" ")}
+                      >
+                        [{info.difficulty.label}]
+                      </span>
+                    </div>
                     <div className="text-sm text-slate-300 sm:text-base">{info.subtitle}</div>
                   </div>
                   {isSelected && (

--- a/src/ModeSelect.tsx
+++ b/src/ModeSelect.tsx
@@ -123,7 +123,7 @@ export default function ModeSelect({
                           info.difficulty.badgeClassName,
                         ].join(" ")}
                       >
-                        [{info.difficulty.label}]
+                        {info.difficulty.label}
                       </span>
                     </div>
                     <div className="text-sm text-slate-300 sm:text-base">{info.subtitle}</div>

--- a/src/gameModes.ts
+++ b/src/gameModes.ts
@@ -18,6 +18,10 @@ export const GAME_MODE_DETAILS: Record<
     title: string;
     subtitle: string;
     highlights: string[];
+    difficulty: {
+      label: string;
+      badgeClassName: string;
+    };
   }
 > = {
   skill: {
@@ -26,6 +30,10 @@ export const GAME_MODE_DETAILS: Record<
     highlights: [
       "Cards on board grant one-shot abilities like Swap, Reroll, and Boost.",
     ],
+    difficulty: {
+      label: "Intermediate",
+      badgeClassName: "border-amber-400/60 bg-amber-500/10 text-amber-300",
+    },
   },
   grimoire: {
     title: "Grimoire",
@@ -33,6 +41,10 @@ export const GAME_MODE_DETAILS: Record<
     highlights: [
       "Card totals in Reserve grant Mana, spend Mana to cast spells and use arcana symbols to boost them.",
     ],
+    difficulty: {
+      label: "Expert",
+      badgeClassName: "border-rose-400/60 bg-rose-500/10 text-rose-300",
+    },
   },
   ante: {
     title: "Ante",
@@ -40,6 +52,10 @@ export const GAME_MODE_DETAILS: Record<
     highlights: [
       "Win rounds to multiply your ante by dynamic odds",
     ],
+    difficulty: {
+      label: "Easy",
+      badgeClassName: "border-emerald-400/60 bg-emerald-500/10 text-emerald-300",
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- add difficulty metadata to each game mode definition
- render colored difficulty badges on the mode selection screen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e65ae96ba883329958ed4c6959101d