### PR TITLE
Ensure CPU reroll skills trigger banner overlays

### DIFF
--- a/src/features/threeWheel/components/HUDPanels.tsx
+++ b/src/features/threeWheel/components/HUDPanels.tsx
@@ -26,6 +26,7 @@ interface HUDPanelsProps {
   isGrimoireOpen?: boolean;
   playerManaButtonRef?: React.Ref<HTMLButtonElement>;
   reserveSpellHighlights: Record<LegacySide, boolean>;
+  skillReserveEmojis: Record<LegacySide, string | null>;
 }
 
 const HUDPanels: React.FC<HUDPanelsProps> = ({
@@ -43,6 +44,7 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
   isGrimoireOpen,
   playerManaButtonRef,
   reserveSpellHighlights,
+  skillReserveEmojis,
 }) => {
   const rsP = reserveSums ? reserveSums.player : null;
   const rsE = reserveSums ? reserveSums.enemy : null;
@@ -62,6 +64,7 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
         phase === "ended") &&
       rs !== null;
     const reserveHighlighted = Boolean(reserveSpellHighlights?.[side]);
+    const reserveSkillEmoji = skillReserveEmojis?.[side] ?? null;
 
     const manaCount = isPlayer ? manaPools.player : manaPools.enemy;
 
@@ -159,8 +162,7 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
             </div>
             {isReserveVisible && (
               <div
-
-                className="flex items-center gap-1 rounded-full border px-3 py-1 sm:px-2 sm:py-0.5 text-[11px] sm:max-w-[44vw] overflow-hidden text-ellipsis whitespace-nowrap flex-shrink-0"
+                className="relative flex items-center gap-1 rounded-full border px-3 py-1 sm:px-2 sm:py-0.5 text-[11px] sm:max-w-[44vw] overflow-hidden text-ellipsis whitespace-nowrap flex-shrink-0"
                 style={{
                   minWidth: "90px",
                   background: "#1b1209ee",
@@ -170,6 +172,7 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
                 }}
                 title={rs !== null ? `Reserve: ${rs}` : undefined}
                 data-spell-affected={reserveHighlighted ? "true" : undefined}
+                data-skill-affected={reserveSkillEmoji ? "true" : undefined}
               >
                 <span className="sm:hidden mr-1">Reserve:</span>
                 <span className="hidden sm:inline">Reserve: </span>
@@ -181,6 +184,15 @@ const HUDPanels: React.FC<HUDPanelsProps> = ({
                     style={{ textShadow: "0 1px 4px rgba(0,0,0,0.7)" }}
                   >
                     ✨
+                  </span>
+                ) : null}
+                {reserveSkillEmoji ? (
+                  <span
+                    aria-hidden
+                    className="skill-pop pointer-events-none absolute inset-0 flex items-center justify-center text-[20px]"
+                    style={{ textShadow: "0 2px 6px rgba(0,0,0,0.7)" }}
+                  >
+                    {reserveSkillEmoji}
                   </span>
                 ) : null}
               </div>

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -94,6 +94,7 @@ export interface WheelPanelProps {
   } | null;
   skillTargetableLaneIndexes?: Set<number> | null;
   numberColorMode?: "arcana" | "skill";
+  skillEffectEmojis?: Record<LegacySide, Map<number, string>>;
 }
 
 const slotWidthPx = 80;
@@ -155,6 +156,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
   skillTargeting,
   skillTargetableLaneIndexes,
   numberColorMode = "arcana",
+  skillEffectEmojis,
 }) => {
   const playerCard = assign.player[index];
   const enemyCard = assign.enemy[index];
@@ -197,6 +199,8 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
 
   const isLeftSelected = !!leftSlot.card && selectedCardId === leftSlot.card.id;
   const isRightSelected = !!rightSlot.card && selectedCardId === rightSlot.card.id;
+  const leftSkillEmoji = skillEffectEmojis?.player?.get(index) ?? null;
+  const rightSkillEmoji = skillEffectEmojis?.enemy?.get(index) ?? null;
 
   const leftSlotOwnership: SpellTargetOwnership | null = pendingSpell
     ? leftSlot.side === pendingSpell.side
@@ -539,7 +543,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
             setSelectedCardId(leftSlot.card.id);
           }
         }}
-        className="w-[80px] h-[92px] rounded-md border px-1 py-0 flex items-center justify-center flex-none"
+        className="relative w-[80px] h-[92px] rounded-md border px-1 py-0 flex items-center justify-center flex-none"
         style={{
           backgroundColor:
             dragOverWheel === index || isLeftSelected ? "rgba(182,138,78,.12)" : theme.slotBg,
@@ -562,6 +566,15 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
             {leftSlot.side === localLegacySide ? "Your card" : leftSlot.name}
           </div>
         )}
+        {leftSkillEmoji ? (
+          <span
+            aria-hidden
+            className="skill-pop pointer-events-none absolute inset-0 flex items-center justify-center text-[28px]"
+            style={{ textShadow: "0 2px 6px rgba(0,0,0,0.7)" }}
+          >
+            {leftSkillEmoji}
+          </span>
+        ) : null}
       </div>
 
       <div
@@ -602,7 +615,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
       </div>
 
       <div
-        className="w-[80px] h-[92px] rounded-md border px-1 py-0 flex items-center justify-center flex-none"
+        className="relative w-[80px] h-[92px] rounded-md border px-1 py-0 flex items-center justify-center flex-none"
         style={{
           backgroundColor:
             dragOverWheel === index || isRightSelected ? "rgba(182,138,78,.12)" : theme.slotBg,
@@ -658,6 +671,15 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
             {rightSlot.side === localLegacySide ? "Your card" : rightSlot.name}
           </div>
         )}
+        {rightSkillEmoji ? (
+          <span
+            aria-hidden
+            className="skill-pop pointer-events-none absolute inset-0 flex items-center justify-center text-[28px]"
+            style={{ textShadow: "0 2px 6px rgba(0,0,0,0.7)" }}
+          >
+            {rightSkillEmoji}
+          </span>
+        ) : null}
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -141,3 +141,26 @@ div.relative[aria-label^="Wheel"]:last-of-type {
   margin-bottom: 1rem;
 }
 
+@keyframes skill-pop {
+  0% {
+    transform: scale(0.6);
+    opacity: 0;
+  }
+  35% {
+    transform: scale(1.15);
+    opacity: 1;
+  }
+  70% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0.9);
+    opacity: 0;
+  }
+}
+
+.skill-pop {
+  animation: skill-pop 0.95s ease-out forwards;
+}
+


### PR DESCRIPTION
## Summary
- log CPU reroll skill usage as skill-type events to drive banners and emoji overlays
- preserve player messaging while ensuring reroll reserve instructions still appear

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e65a0b3f9883329d5ca3def875b922