### PR TITLE
Allow skill mode selection in multiplayer lobby

### DIFF
--- a/src/MultiplayerRoute.tsx
+++ b/src/MultiplayerRoute.tsx
@@ -38,7 +38,11 @@ type ConnectOptions = {
   requireExistingMembers?: boolean;
 };
 
-const LOBBY_MODE_OPTIONS: readonly GameModeOption[] = GAME_MODE_OPTIONS;
+// Surface the new Skill mode alongside the existing multiplayer toggles.
+const LOBBY_MODE_OPTIONS: readonly GameModeOption[] = [
+  "skill",
+  ...GAME_MODE_OPTIONS.filter((mode) => mode !== "skill"),
+];
 const MODE_LABELS: Record<GameModeOption, string> = GAME_MODE_LABELS;
 
 export default function MultiplayerRoute({


### PR DESCRIPTION
## Summary
- add the Skill mode option to the multiplayer lobby toggle list so it can be selected alongside other modifiers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e663521f50833299b71b7baab5342f