### PR TITLE
Prevent skill exhaustion from affecting the opposing card

### DIFF
--- a/src/features/threeWheel/hooks/skillState.ts
+++ b/src/features/threeWheel/hooks/skillState.ts
@@ -22,6 +22,9 @@ export type SkillState = {
   cardStatus: Record<string, SkillCardStatus>;
 };
 
+export const getSkillCardStatusKey = (side: LegacySide, cardId: string): string =>
+  `${side}:${cardId}`;
+
 export const createEmptySkillLane = (): SkillLane => ({
   ability: null,
   cardId: null,
@@ -110,8 +113,9 @@ export const reconcileSkillStateWithAssignments = (
 
     const ability: AbilityKind | null = determineSkillAbility(card);
     const cardId = card.id;
+    const statusKey = getSkillCardStatusKey(side, cardId);
 
-    let status = nextCardStatus[cardId];
+    let status = nextCardStatus[statusKey];
     if (!status || status.ability !== ability) {
       ensureCardStatusClone();
       status = {
@@ -119,7 +123,7 @@ export const reconcileSkillStateWithAssignments = (
         exhausted: ability ? false : true,
         usesRemaining: getInitialSkillUses(ability),
       };
-      nextCardStatus[cardId] = status;
+      nextCardStatus[statusKey] = status;
     }
 
     const desiredLane: SkillLane = {

--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -54,6 +54,7 @@ import {
 } from "../utils/skillAbilityExecution.js";
 import {
   createSkillState,
+  getSkillCardStatusKey,
   reconcileSkillStateWithAssignments,
   type SkillLane,
   type SkillState,
@@ -1995,7 +1996,8 @@ export function useThreeWheelGame({
         const cardId = lane.cardId;
         let nextCardStatus = prev.cardStatus;
         if (cardId) {
-          const existingStatus = prev.cardStatus[cardId];
+          const statusKey = getSkillCardStatusKey(side, cardId);
+          const existingStatus = prev.cardStatus[statusKey];
           if (
             !existingStatus ||
             existingStatus.ability !== ability ||
@@ -2004,7 +2006,7 @@ export function useThreeWheelGame({
           ) {
             nextCardStatus =
               nextCardStatus === prev.cardStatus ? { ...prev.cardStatus } : nextCardStatus;
-            nextCardStatus[cardId] = {
+            nextCardStatus[statusKey] = {
               ability,
               exhausted: willExhaust,
               usesRemaining: nextUsesRemaining,

--- a/tests/skillCardExhaustion.test.ts
+++ b/tests/skillCardExhaustion.test.ts
@@ -2,6 +2,7 @@ import assert from "assert";
 import type { Card } from "../src/game/types.js";
 import {
   createSkillState,
+  getSkillCardStatusKey,
   reconcileSkillStateWithAssignments,
 } from "../src/features/threeWheel/hooks/skillState.js";
 
@@ -44,9 +45,11 @@ const createSkillCard = (id: string, value: number): Card => ({
     usesRemaining: 0,
   };
 
+  const statusKey = getSkillCardStatusKey("player", skillCard.id);
+
   skillState = {
     ...skillState,
-    cardStatus: { ...skillState.cardStatus, [skillCard.id]: exhaustedCardStatus },
+    cardStatus: { ...skillState.cardStatus, [statusKey]: exhaustedCardStatus },
     lanes: {
       ...skillState.lanes,
       player: [exhaustedLane, ...skillState.lanes.player.slice(1)],


### PR DESCRIPTION
## Summary
- key skill exhaustion tracking by side and card id so mirrored lanes no longer share exhaustion state
- update skill state reconciliation and its regression test to use the side-aware exhaustion key

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e6709db2ac83329e6709aa563178ae