### PR TITLE
Fix skill lane exhaustion display per side

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1298,7 +1298,6 @@ export default function ThreeWheel_WinsOnly({
       })()
     : "";
   const skillPhaseActive = isSkillMode && phaseForLogic === "skill" && !skill.completed;
-  const localSkillLanes = skill.lanes[localLegacySide] ?? [];
   const [skillTargeting, setSkillTargeting] = useState<SkillTargetingState | null>(null);
 
   useEffect(() => {
@@ -2131,7 +2130,7 @@ export default function ThreeWheel_WinsOnly({
                 variant="grouped"
                 spellHighlightedCardIds={spellHighlightedCardIds}
                 skillPhaseActive={skillPhaseActive}
-                skillLaneStates={localSkillLanes}
+                skillLaneStates={skill.lanes}
                 onSkillAbilityStart={beginSkillTargeting}
                 onSkillTargetSelect={handleSkillLaneTarget}
                 skillTargeting={skillTargetingForChildren}

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -82,7 +82,7 @@ export interface WheelPanelProps {
   isAwaitingSpellTarget: boolean;
   variant?: "standalone" | "grouped";
   skillPhaseActive?: boolean;
-  skillLaneStates?: Array<{ ability: AbilityKind | null; exhausted: boolean }>;
+  skillLaneStates?: SideState<Array<{ ability: AbilityKind | null; exhausted: boolean }>>;
   onSkillAbilityStart?: (laneIndex: number, ability: AbilityKind) => void;
   onSkillAbilityCancel?: () => void;
   onSkillTargetSelect?: (selection: { laneIndex: number; side: LegacySide }) => void;
@@ -295,7 +295,7 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
     const canInteractNormally =
       !awaitingSpellTarget && !skillTargeting && slot.side === localLegacySide && phase === "choose" && isWheelActive;
 
-    const skillState = skillLaneStates?.[index];
+    const skillState = skillLaneStates?.[slot.side]?.[index];
     const hasSkillAbility = Boolean(skillState?.ability && !skillState?.exhausted);
     const skillAbilityAvailable =
       skillPhaseActive &&


### PR DESCRIPTION
## Summary
- scope WheelPanel skill lane lookup to each slot's side so the opposing card doesn't inherit the local exhaustion state
- pass the full per-side skill lane record from App so WheelPanel can read the correct lane data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e676fd2e7c83328d33f00a0874afed