### PR TITLE
Fix CPU skill auto-chaining in singleplayer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -888,6 +888,12 @@ export default function ThreeWheel_WinsOnly({
     useSkillAbilityBase,
   ]);
 
+  const attemptCpuSkillRef = useRef(attemptCpuSkill);
+
+  useEffect(() => {
+    attemptCpuSkillRef.current = attemptCpuSkill;
+  }, [attemptCpuSkill]);
+
   useEffect(() => {
     if (cpuSpellResponseTick === 0) return;
     const timeout = window.setTimeout(() => {
@@ -901,12 +907,12 @@ export default function ThreeWheel_WinsOnly({
   useEffect(() => {
     if (cpuSkillResponseTick === 0) return;
     const timeout = window.setTimeout(() => {
-      void attemptCpuSkill();
+      void attemptCpuSkillRef.current();
     }, 1000);
     return () => {
       window.clearTimeout(timeout);
     };
-  }, [attemptCpuSkill, cpuSkillResponseTick]);
+  }, [cpuSkillResponseTick]);
 
   useEffect(() => {
     if (!isGrimoireMode) {


### PR DESCRIPTION
## Summary
- keep the CPU skill response callback in a ref so the scheduler only fires on new ticks
- prevent additional CPU skill activations after one resolves in singleplayer

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e67ecdf2a083328bb6a051ab4bae70