### PR TITLE
Mirror right card slot frames to align with left slots

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -104,12 +104,34 @@ div.relative[data-drop="wheel"][aria-label^="Wheel"] {
 /* Player and enemy card slots */
 [aria-label$="player slot"],
 [aria-label$="enemy slot"] {
+  position: relative;
+  background-color: transparent;
+  border: none;
+}
+
+[aria-label$="player slot"]::before,
+[aria-label$="enemy slot"]::before {
+  content: "";
+  position: absolute;
+  inset: 0;
   background-image: url("/assets/card-frame.png");
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
-  background-color: transparent;
-  border: none;
+  border-radius: inherit;
+  pointer-events: none;
+  transform-origin: center;
+  z-index: 0;
+}
+
+[aria-label$="player slot"] > *,
+[aria-label$="enemy slot"] > * {
+  position: relative;
+  z-index: 1;
+}
+
+[aria-label$="right slot"]::before {
+  transform: scaleX(-1);
 }
 
 /*


### PR DESCRIPTION
## Summary
- mirror the background frame on right-side card slots so they sit parallel with their opposing left slots
- move the slot frame artwork into pseudo-elements to avoid flipping the card content while mirroring the frame

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68e6858c82b08332a37e5a999a80ecaa