### PR TITLE
Ensure skill hover descriptions appear on touch press

### DIFF
--- a/src/features/threeWheel/components/HandDock.tsx
+++ b/src/features/threeWheel/components/HandDock.tsx
@@ -207,8 +207,9 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
 
     useEffect(() => {
       if (!isPtrDragging) return;
+      if (ptrDragType === "touch") return;
       setHoveredSkillCardId(null);
-    }, [isPtrDragging]);
+    }, [isPtrDragging, ptrDragType]);
 
     const handleSkillHoverStart = useCallback(
       (cardId: string) => {
@@ -367,6 +368,9 @@ const HandDock = forwardRef<HTMLDivElement, HandDockProps>(
                     }}
                     onPointerUp={() => handleSkillHoverEnd(card.id)}
                     onPointerCancel={() => handleSkillHoverEnd(card.id)}
+                    onTouchStart={() => handleSkillHoverStart(card.id)}
+                    onTouchEnd={() => handleSkillHoverEnd(card.id)}
+                    onTouchCancel={() => handleSkillHoverEnd(card.id)}
                   >
                     <StSCard
                       data-hand-card


### PR DESCRIPTION
## Summary
- trigger skill hover panels on touch start so they appear when a card is pressed
- clear the hover panel on touch end and cancel to keep behaviour consistent with mouse interactions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e97d627f3c8332a83c2e14bcb01e57