### PR TITLE
Update wheel winner indicator text and spin button label

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1220,7 +1220,7 @@ export default function ThreeWheel_WinsOnly({
   const remoteResolveReady = resolveVotes[remoteLegacySide];
 
   const resolveButtonDisabled = !canReveal || (isMultiplayer && localResolveReady);
-  const resolveButtonLabel = isMultiplayer && localResolveReady ? "Ready" : "Resolve";
+  const resolveButtonLabel = isMultiplayer && localResolveReady ? "Ready" : "Spin!";
 
   const resolveStatusText =
     isMultiplayer && phase === "choose"

--- a/src/features/threeWheel/components/WheelPanel.tsx
+++ b/src/features/threeWheel/components/WheelPanel.tsx
@@ -479,31 +479,30 @@ const WheelPanel: React.FC<WheelPanelProps> = ({
 
   const panelStyle = variant === "standalone" ? standaloneStyle : groupedStyle;
 
+  const playerWon = wheelHudColor === hudColors.player;
+  const enemyWon = wheelHudColor === hudColors.enemy;
+
   const resultIndicators =
     (phase === "skill" || phase === "recalc" || phase === "roundEnd" || phase === "ended") && (
       <>
-        <span
-          aria-label={`Wheel ${index + 1} player result`}
-          className="absolute top-1 left-1 rounded-full border"
-          style={{
-            width: 10,
-            height: 10,
-            background: wheelHudColor === hudColors.player ? hudColors.player : "transparent",
-            borderColor: wheelHudColor === hudColors.player ? hudColors.player : theme.panelBorder,
-            boxShadow: "0 0 0 1px rgba(0,0,0,0.4)",
-          }}
-        />
-        <span
-          aria-label={`Wheel ${index + 1} enemy result`}
-          className="absolute top-1 right-1 rounded-full border"
-          style={{
-            width: 10,
-            height: 10,
-            background: wheelHudColor === hudColors.enemy ? hudColors.enemy : "transparent",
-            borderColor: wheelHudColor === hudColors.enemy ? hudColors.enemy : theme.panelBorder,
-            boxShadow: "0 0 0 1px rgba(0,0,0,0.4)",
-          }}
-        />
+        {playerWon && (
+          <span
+            aria-label={`Wheel ${index + 1} player result`}
+            className="absolute top-1 left-1 text-[10px] font-semibold uppercase tracking-wide"
+            style={{ color: hudColors.player }}
+          >
+            Winner
+          </span>
+        )}
+        {enemyWon && (
+          <span
+            aria-label={`Wheel ${index + 1} enemy result`}
+            className="absolute top-1 right-1 text-right text-[10px] font-semibold uppercase tracking-wide"
+            style={{ color: hudColors.enemy }}
+          >
+            Winner
+          </span>
+        )}
       </>
     );
 


### PR DESCRIPTION
## Summary
- rename the resolve button to display "Spin!" when available
- replace the wheel winner indicator dots with color-coded "Winner" text badges

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f7b4e39f508332bbce8b91ab1de97b