### PR TITLE
Add easy mode toggle for solo and multiplayer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -272,6 +272,7 @@ export default function ThreeWheel_WinsOnly({
   roomCode,
   hostId,
   targetWins,
+  easyMode = false,
   onExit,
 }: {
   localSide: TwoSide;
@@ -282,9 +283,10 @@ export default function ThreeWheel_WinsOnly({
   roomCode?: string;
   hostId?: string;
   targetWins?: number;
+  easyMode?: boolean;
   onExit?: () => void;
 }) {
-  
+
   const { state, derived, refs, actions } = useThreeWheelGame({
     localSide,
     localPlayerId,
@@ -294,6 +296,7 @@ export default function ThreeWheel_WinsOnly({
     hostId,
     targetWins,
     gameMode,
+    easyMode,
     onExit,
   });
   // --- from hook

--- a/src/ModeSelect.tsx
+++ b/src/ModeSelect.tsx
@@ -9,12 +9,14 @@ import {
   type GameMode,
   type GameModeOption,
 } from "./gameModes";
+import EasyModeSwitch from "./components/EasyModeSwitch";
 
 type ModeSelectProps = {
   initialMode?: GameMode;
   initialTargetWins?: number;
+  initialEasyMode?: boolean;
   showTargetWinsInput?: boolean;
-  onConfirm: (mode: GameMode, targetWins: number) => void;
+  onConfirm: (mode: GameMode, targetWins: number, easyMode: boolean) => void;
   onBack: () => void;
   backLabel?: string;
   confirmLabel?: string;
@@ -23,6 +25,7 @@ type ModeSelectProps = {
 export default function ModeSelect({
   initialMode = DEFAULT_GAME_MODE,
   initialTargetWins = TARGET_WINS,
+  initialEasyMode = false,
   showTargetWinsInput = false,
   onConfirm,
   onBack,
@@ -32,6 +35,7 @@ export default function ModeSelect({
   const [selectedModes, setSelectedModes] = useState<GameMode>(() => normalizeGameMode(initialMode));
   const [targetWins, setTargetWins] = useState<number>(() => clampTargetWins(initialTargetWins));
   const [targetWinsInput, setTargetWinsInput] = useState<string>(String(clampTargetWins(initialTargetWins)));
+  const [easyMode, setEasyMode] = useState<boolean>(Boolean(initialEasyMode));
 
   const detailEntries = useMemo(
     () =>
@@ -51,6 +55,10 @@ export default function ModeSelect({
   useEffect(() => {
     setSelectedModes(normalizeGameMode(initialMode));
   }, [initialMode]);
+
+  useEffect(() => {
+    setEasyMode(Boolean(initialEasyMode));
+  }, [initialEasyMode]);
 
   const handleWinsChange = (value: string) => {
     if (!/^\d*$/.test(value)) return;
@@ -144,9 +152,12 @@ export default function ModeSelect({
         <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           {showTargetWinsInput && (
             <div className="flex flex-col gap-1 text-left sm:flex-row sm:items-center sm:gap-3">
-              <label className="text-xs font-medium text-slate-300 sm:text-sm" htmlFor="target-wins-input">
-                Wins to take the match
-              </label>
+              <div className="flex items-center justify-between gap-3">
+                <label className="text-xs font-medium text-slate-300 sm:text-sm" htmlFor="target-wins-input">
+                  Wins to take the match
+                </label>
+                <EasyModeSwitch checked={easyMode} onToggle={setEasyMode} />
+              </div>
               <div className="flex items-center gap-2">
                 <input
                   id="target-wins-input"
@@ -165,7 +176,7 @@ export default function ModeSelect({
           )}
           <button
             type="button"
-            onClick={() => onConfirm(normalizeGameMode(selectedModes), targetWins)}
+            onClick={() => onConfirm(normalizeGameMode(selectedModes), targetWins, easyMode)}
             className="inline-flex items-center justify-center rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300"
           >
             {confirmLabel}

--- a/src/components/EasyModeSwitch.tsx
+++ b/src/components/EasyModeSwitch.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+
+type EasyModeSwitchProps = {
+  checked: boolean;
+  onToggle: (value: boolean) => void;
+  disabled?: boolean;
+  className?: string;
+};
+
+export default function EasyModeSwitch({
+  checked,
+  onToggle,
+  disabled = false,
+  className = "",
+}: EasyModeSwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label="Toggle easy mode"
+      disabled={disabled}
+      onClick={() => {
+        if (!disabled) {
+          onToggle(!checked);
+        }
+      }}
+      className={[
+        "group inline-flex items-center gap-2 text-[11px] font-medium uppercase tracking-wide transition",
+        disabled ? "cursor-not-allowed text-slate-500" : "text-slate-300 hover:text-slate-100",
+        className,
+      ].join(" ")}
+    >
+      <span>Easy Mode</span>
+      <span
+        className={[
+          "relative inline-flex h-5 w-10 items-center rounded-full border transition",
+          checked
+            ? "bg-emerald-400/20 border-emerald-400"
+            : "border-slate-600 bg-slate-800",
+          disabled ? "opacity-60" : "",
+        ].join(" ")}
+      >
+        <span
+          className={[
+            "absolute left-1 h-3.5 w-3.5 rounded-full transition-transform",
+            checked ? "translate-x-5 bg-emerald-300" : "translate-x-0 bg-slate-400",
+          ].join(" ")}
+        />
+      </span>
+    </button>
+  );
+}

--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -83,6 +83,7 @@ export type ThreeWheelGameProps = {
   hostId?: string;
   targetWins?: number;
   gameMode?: GameMode;
+  easyMode?: boolean;
   onExit?: () => void;
 };
 
@@ -296,6 +297,7 @@ export function useThreeWheelGame({
   hostId,
   targetWins,
   gameMode,
+  easyMode,
   onExit,
 }: ThreeWheelGameProps): ThreeWheelGameReturn {
   const mountedRef = useRef(true);
@@ -342,6 +344,7 @@ export function useThreeWheelGame({
       : TARGET_WINS;
 
   const currentGameMode = normalizeGameMode(gameMode ?? DEFAULT_GAME_MODE);
+  const easyModeEnabled = easyMode === true;
   const isAnteMode = currentGameMode.includes("ante");
   const isSkillMode = currentGameMode.includes("skill");
 
@@ -689,25 +692,29 @@ export function useThreeWheelGame({
     const seeded = createSeededRng(seed);
     wheelRngRef.current = seeded;
     return [
-      genWheelSections("bandit", seeded),
-      genWheelSections("sorcerer", seeded),
-      genWheelSections("beast", seeded),
+      genWheelSections("bandit", seeded, { easyMode: easyModeEnabled }),
+      genWheelSections("sorcerer", seeded, { easyMode: easyModeEnabled }),
+      genWheelSections("beast", seeded, { easyMode: easyModeEnabled }),
     ];
   });
 
   const generateWheelSet = useCallback((): Section[][] => {
     const rng = wheelRngRef.current ?? Math.random;
     return [
-      genWheelSections("bandit", rng),
-      genWheelSections("sorcerer", rng),
-      genWheelSections("beast", rng),
+      genWheelSections("bandit", rng, { easyMode: easyModeEnabled }),
+      genWheelSections("sorcerer", rng, { easyMode: easyModeEnabled }),
+      genWheelSections("beast", rng, { easyMode: easyModeEnabled }),
     ];
-  }, []);
+  }, [easyModeEnabled]);
 
   useEffect(() => {
     wheelRngRef.current = createSeededRng(seed);
     setWheelSections(generateWheelSet());
   }, [seed, generateWheelSet]);
+
+  useEffect(() => {
+    setWheelSections(generateWheelSet());
+  }, [easyModeEnabled, generateWheelSet]);
 
   const [tokens, setTokens] = useState<[number, number, number]>([0, 0, 0]);
   const tokensRef = useRef(tokens);

--- a/src/game/wheel.ts
+++ b/src/game/wheel.ts
@@ -16,13 +16,10 @@ import { shuffle } from "./math";
 
 export function genWheelSections(
   archetype: "bandit" | "sorcerer" | "beast" = "bandit",
-  rng: () => number = Math.random
+  rng: () => number = Math.random,
+  options: { easyMode?: boolean } = {}
 ): Section[] {
-  const lens = (() => {
-    if (archetype === "bandit") return shuffle([5, 4, 3, 2, 1], rng);
-    if (archetype === "sorcerer") return shuffle([5, 5, 2, 2, 1], rng);
-    return shuffle([6, 3, 3, 2, 1], rng);
-  })();
+  const easyMode = options.easyMode === true;
   const kinds: VC[] = shuffle([
     "Strongest",
     "Weakest",
@@ -30,11 +27,28 @@ export function genWheelSections(
     "ClosestToTarget",
     "Initiative",
   ], rng);
+
+  const lens = (() => {
+    if (easyMode) {
+      const total = SLICES - 1;
+      const candidate = [3, 2, 1].find((count) => count <= kinds.length && total % count === 0) ?? 1;
+      const count = Math.max(1, candidate);
+      const segmentLength = total / count;
+      return new Array(count).fill(segmentLength);
+    }
+
+    if (archetype === "bandit") return shuffle([5, 4, 3, 2, 1], rng);
+    if (archetype === "sorcerer") return shuffle([5, 5, 2, 2, 1], rng);
+    return shuffle([6, 3, 3, 2, 1], rng);
+  })();
+
   let start = 1;
   const sections: Section[] = [];
-  for (let i = 0; i < kinds.length; i++) {
+  const segmentCount = easyMode ? lens.length : kinds.length;
+  for (let i = 0; i < segmentCount; i++) {
     const id = kinds[i];
     const len = lens[i];
+    if (typeof id === "undefined" || typeof len !== "number") continue;
     const end = (start + len - 1) % SLICES;
     sections.push({
       id,


### PR DESCRIPTION
## Summary
- add an easy mode switch component and surface it on the solo mode select and multiplayer lobby screens
- propagate the easy mode setting through app shell, multiplayer payloads, and the three wheel game hook
- update wheel generation so easy mode limits wheels to three evenly sized win conditions

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f8077227948332b57332683bffece0