### PR TITLE
Stop host easy mode toggle from double-flipping

### DIFF
--- a/src/MultiplayerRoute.tsx
+++ b/src/MultiplayerRoute.tsx
@@ -124,9 +124,11 @@ export default function MultiplayerRoute({
     if (host) {
       const hostModes = host.gameMode ?? DEFAULT_GAME_MODE;
       setGameMode(normalizeGameMode(hostModes));
-      setEasyMode(Boolean(host.easyMode));
+      if (host.clientId !== clientId) {
+        setEasyMode(Boolean(host.easyMode));
+      }
     }
-  }, []);
+  }, [clientId]);
 
   const applySnapshot = useCallback(
   (list: PresenceMessage[] | undefined | null) => {


### PR DESCRIPTION
## Summary
- avoid overwriting the host's easy-mode selection with the mirrored presence state so clicks don't double-toggle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f81400447c83328527d2e528e0fe3a