### PR TITLE
Add CPU difficulty controls to mode select

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,10 @@ import {
 import { easeInOutCubic, inSection, createSeededRng } from "./game/math";
 import { VC_META, genWheelSections } from "./game/wheel";
 import { DEFAULT_GAME_MODE, normalizeGameMode } from "./gameModes";
+import {
+  DEFAULT_CPU_DIFFICULTY,
+  type CpuDifficulty,
+} from "./game/ai/cpuDifficulty";
 import type { ArchetypeId } from "./game/archetypes";
 import {
   makeFighter,
@@ -273,6 +277,7 @@ export default function ThreeWheel_WinsOnly({
   hostId,
   targetWins,
   easyMode = false,
+  cpuDifficulty = DEFAULT_CPU_DIFFICULTY,
   onExit,
 }: {
   localSide: TwoSide;
@@ -284,6 +289,7 @@ export default function ThreeWheel_WinsOnly({
   hostId?: string;
   targetWins?: number;
   easyMode?: boolean;
+  cpuDifficulty?: CpuDifficulty;
   onExit?: () => void;
 }) {
 
@@ -297,6 +303,7 @@ export default function ThreeWheel_WinsOnly({
     targetWins,
     gameMode,
     easyMode,
+    cpuDifficulty,
     onExit,
   });
   // --- from hook

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -7,6 +7,10 @@ import { TARGET_WINS, type Players, type Side } from "./game/types";
 import ProfilePage from "./ProfilePage";
 import ModeSelect from "./ModeSelect";
 import { DEFAULT_GAME_MODE, normalizeGameMode, type GameMode } from "./gameModes";
+import {
+  DEFAULT_CPU_DIFFICULTY,
+  type CpuDifficulty,
+} from "./game/ai/cpuDifficulty";
 
 type MPStartPayload = Parameters<
   NonNullable<React.ComponentProps<typeof MultiplayerRoute>["onStart"]>
@@ -27,6 +31,9 @@ export default function AppShell() {
   const [gameMode, setGameMode] = useState<GameMode>(() => [...DEFAULT_GAME_MODE]);
   const [soloTargetWins, setSoloTargetWins] = useState<number>(TARGET_WINS);
   const [easyMode, setEasyMode] = useState<boolean>(false);
+  const [cpuDifficulty, setCpuDifficulty] = useState<CpuDifficulty>(
+    DEFAULT_CPU_DIFFICULTY,
+  );
 
   if (view.key === "hub") {
     return (
@@ -74,6 +81,10 @@ export default function AppShell() {
     const initialTargetWins = view.next.mode === "mp"
       ? view.next.mpPayload?.targetWins ?? mpPayload?.targetWins ?? TARGET_WINS
       : soloTargetWins;
+    const initialCpuDifficulty =
+      view.next.mode === "mp"
+        ? DEFAULT_CPU_DIFFICULTY
+        : cpuDifficulty;
 
     return (
       <ModeSelect
@@ -84,16 +95,19 @@ export default function AppShell() {
             ? view.next.mpPayload?.easyMode ?? mpPayload?.easyMode ?? false
             : easyMode
         }
+        initialCpuDifficulty={initialCpuDifficulty}
         showTargetWinsInput={view.next.mode === "solo"}
+        showCpuDifficulty={view.next.mode === "solo"}
         backLabel={backLabel}
         confirmLabel={confirmLabel}
         onBack={() => {
           setView({ key: view.from });
           setMpPayload(null);
         }}
-        onConfirm={(mode, winsGoal, easy) => {
+        onConfirm={(mode, winsGoal, easy, cpuDiff) => {
           setGameMode(normalizeGameMode(mode));
           setEasyMode(easy);
+          setCpuDifficulty(cpuDiff);
 
           if (view.next.mode === "mp") {
             const payload = view.next.mpPayload ?? mpPayload;
@@ -130,6 +144,7 @@ export default function AppShell() {
     hostId?: string;
     targetWins?: number;
     easyMode?: boolean;
+    cpuDifficulty?: CpuDifficulty;
   } = {};
 
   if (view.mode === "mp" && (view.mpPayload ?? mpPayload)) {
@@ -152,7 +167,7 @@ export default function AppShell() {
     };
     localSide = "left";
     localPlayerId = "local";
-    extraProps = { targetWins: soloTargetWins, easyMode };
+    extraProps = { targetWins: soloTargetWins, easyMode, cpuDifficulty };
   }
 
   const exitToMenu = () => {

--- a/src/ModeSelect.tsx
+++ b/src/ModeSelect.tsx
@@ -2,6 +2,11 @@ import React, { useEffect, useMemo, useState } from "react";
 
 import { TARGET_WINS } from "./game/types";
 import {
+  CPU_DIFFICULTY_OPTIONS,
+  DEFAULT_CPU_DIFFICULTY,
+  type CpuDifficulty,
+} from "./game/ai/cpuDifficulty";
+import {
   DEFAULT_GAME_MODE,
   GAME_MODE_DETAILS,
   normalizeGameMode,
@@ -15,8 +20,15 @@ type ModeSelectProps = {
   initialMode?: GameMode;
   initialTargetWins?: number;
   initialEasyMode?: boolean;
+  initialCpuDifficulty?: CpuDifficulty;
   showTargetWinsInput?: boolean;
-  onConfirm: (mode: GameMode, targetWins: number, easyMode: boolean) => void;
+  showCpuDifficulty?: boolean;
+  onConfirm: (
+    mode: GameMode,
+    targetWins: number,
+    easyMode: boolean,
+    cpuDifficulty: CpuDifficulty,
+  ) => void;
   onBack: () => void;
   backLabel?: string;
   confirmLabel?: string;
@@ -26,7 +38,9 @@ export default function ModeSelect({
   initialMode = DEFAULT_GAME_MODE,
   initialTargetWins = TARGET_WINS,
   initialEasyMode = false,
+  initialCpuDifficulty = DEFAULT_CPU_DIFFICULTY,
   showTargetWinsInput = false,
+  showCpuDifficulty = false,
   onConfirm,
   onBack,
   backLabel = "← Back",
@@ -36,6 +50,7 @@ export default function ModeSelect({
   const [targetWins, setTargetWins] = useState<number>(() => clampTargetWins(initialTargetWins));
   const [targetWinsInput, setTargetWinsInput] = useState<string>(String(clampTargetWins(initialTargetWins)));
   const [easyMode, setEasyMode] = useState<boolean>(Boolean(initialEasyMode));
+  const [cpuDifficulty, setCpuDifficulty] = useState<CpuDifficulty>(initialCpuDifficulty);
 
   const detailEntries = useMemo(
     () =>
@@ -59,6 +74,10 @@ export default function ModeSelect({
   useEffect(() => {
     setEasyMode(Boolean(initialEasyMode));
   }, [initialEasyMode]);
+
+  useEffect(() => {
+    setCpuDifficulty(initialCpuDifficulty);
+  }, [initialCpuDifficulty]);
 
   const handleWinsChange = (value: string) => {
     if (!/^\d*$/.test(value)) return;
@@ -176,10 +195,35 @@ export default function ModeSelect({
           })}
         </div>
 
-        <div className="mt-8 flex flex-col items-stretch gap-3 sm:flex-row sm:justify-end">
+        <div
+          className="mt-8 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end"
+        >
+          {showCpuDifficulty && (
+            <label className="flex flex-col gap-1 text-sm sm:flex-row sm:items-center sm:gap-2">
+              <span className="font-semibold text-slate-300">CPU Difficulty</span>
+              <select
+                className="rounded-full border border-slate-700 bg-slate-900/60 px-3 py-1.5 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+                value={cpuDifficulty}
+                onChange={(event) => setCpuDifficulty(event.target.value as CpuDifficulty)}
+              >
+                {CPU_DIFFICULTY_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
           <button
             type="button"
-            onClick={() => onConfirm(normalizeGameMode(selectedModes), targetWins, easyMode)}
+            onClick={() =>
+              onConfirm(
+                normalizeGameMode(selectedModes),
+                targetWins,
+                easyMode,
+                cpuDifficulty,
+              )
+            }
             className="inline-flex items-center justify-center rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300"
           >
             {confirmLabel}

--- a/src/features/threeWheel/hooks/useThreeWheelGame.ts
+++ b/src/features/threeWheel/hooks/useThreeWheelGame.ts
@@ -65,6 +65,11 @@ import {
   type GameState as AIDecisionState,
   type AIMove,
 } from "../../../game/ai/DecisionEngine.js";
+import {
+  CPU_DIFFICULTY_TRIALS,
+  DEFAULT_CPU_DIFFICULTY,
+  type CpuDifficulty,
+} from "../../../game/ai/cpuDifficulty.js";
 
 export type { LegacySide, SpellEffectPayload } from "../../../game/spellEngine.js";
 export type { SkillAbilityTarget } from "../utils/skillAbilityExecution.js";
@@ -90,6 +95,7 @@ export type ThreeWheelGameProps = {
   targetWins?: number;
   gameMode?: GameMode;
   easyMode?: boolean;
+  cpuDifficulty?: CpuDifficulty;
   onExit?: () => void;
 };
 
@@ -304,6 +310,7 @@ export function useThreeWheelGame({
   targetWins,
   gameMode,
   easyMode,
+  cpuDifficulty = DEFAULT_CPU_DIFFICULTY,
   onExit,
 }: ThreeWheelGameProps): ThreeWheelGameReturn {
   const mountedRef = useRef(true);
@@ -338,6 +345,7 @@ export function useThreeWheelGame({
 
   const playerName = players.left.name || "Wanderer";
   const enemyName = players.right.name || "Shade Bandit";
+  const trialsPerDecision = CPU_DIFFICULTY_TRIALS[cpuDifficulty];
 
   const namesByLegacy: Record<LegacySide, string> = {
     player: playerName,
@@ -1198,7 +1206,11 @@ export function useThreeWheelGame({
     let stateForMove: AIDecisionState = aiState;
 
     while (availableWheels.length > 0) {
-      const move: AIMove | null = chooseBestMove(stateForMove, availableWheels);
+      const move: AIMove | null = chooseBestMove(
+        stateForMove,
+        availableWheels,
+        trialsPerDecision,
+      );
       if (!move) break;
 
       picks[move.wheelIndex] = move.card;

--- a/src/game/ai/cpuDifficulty.ts
+++ b/src/game/ai/cpuDifficulty.ts
@@ -1,0 +1,15 @@
+export type CpuDifficulty = "easy" | "medium" | "hard";
+
+export const DEFAULT_CPU_DIFFICULTY: CpuDifficulty = "medium";
+
+export const CPU_DIFFICULTY_TRIALS: Record<CpuDifficulty, number> = {
+  easy: 80,
+  medium: 200,
+  hard: 400,
+};
+
+export const CPU_DIFFICULTY_OPTIONS: { value: CpuDifficulty; label: string }[] = [
+  { value: "easy", label: "Easy" },
+  { value: "medium", label: "Medium" },
+  { value: "hard", label: "Hard" },
+];


### PR DESCRIPTION
## Summary
- add a CPU difficulty dropdown to Mode Select for solo runs and plumb the selection through AppShell
- provide shared CPU difficulty constants and pass the value into App and the three-wheel hook
- scale the Monte Carlo AI trials per difficulty so the dropdown meaningfully impacts CPU strength

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fd189fcd64833280df24d1a439b4f6