### PR TITLE
Adjust CPU difficulty selector layout on mobile

### DIFF
--- a/src/ModeSelect.tsx
+++ b/src/ModeSelect.tsx
@@ -196,7 +196,7 @@ export default function ModeSelect({
         </div>
 
         <div
-          className="mt-8 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end"
+          className="mt-8 flex flex-wrap items-center gap-3 sm:items-center sm:justify-end"
         >
           {showCpuDifficulty && (
             <label className="flex flex-col gap-1 text-sm sm:flex-row sm:items-center sm:gap-2">


### PR DESCRIPTION
## Summary
- update the mode selection footer layout so the CPU difficulty selector sits next to the start run button on mobile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd20e6f9708332bdc40cc1f259d345