### PR TITLE
Align mobile start run button to the right

### DIFF
--- a/src/ModeSelect.tsx
+++ b/src/ModeSelect.tsx
@@ -224,7 +224,7 @@ export default function ModeSelect({
                 cpuDifficulty,
               )
             }
-            className="inline-flex items-center justify-center rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300"
+            className="ml-auto inline-flex items-center justify-center rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300 sm:ml-0"
           >
             {confirmLabel}
           </button>


### PR DESCRIPTION
## Summary
- push the mode select confirmation button to the right edge on small screens by adding auto margin

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd21d5c7f8833287711d2f304776be