### PR TITLE
Further tighten Balanced Slices toggle footprint

### DIFF
--- a/src/ModeSelect.tsx
+++ b/src/ModeSelect.tsx
@@ -146,7 +146,7 @@ export default function ModeSelect({
               <EasyModeSwitch
                 checked={easyMode}
                 onToggle={setEasyMode}
-                className="shrink-0"
+                className="hidden shrink-0 sm:inline-flex"
               />
             </div>
           </div>
@@ -199,7 +199,7 @@ export default function ModeSelect({
           className="mt-8 flex flex-wrap items-center gap-3 sm:items-center sm:justify-end"
         >
           {showCpuDifficulty && (
-            <label className="flex flex-col gap-1 text-sm sm:flex-row sm:items-center sm:gap-2">
+            <label className="order-1 flex flex-col gap-1 text-sm sm:order-none sm:flex-row sm:items-center sm:gap-2">
               <span className="font-semibold text-slate-300">CPU Difficulty</span>
               <select
                 className="rounded-full border border-slate-700 bg-slate-900/60 px-3 py-1.5 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
@@ -214,6 +214,13 @@ export default function ModeSelect({
               </select>
             </label>
           )}
+          {showTargetWinsInput && (
+            <EasyModeSwitch
+              checked={easyMode}
+              onToggle={setEasyMode}
+              className="order-2 shrink-0 rounded-full border border-slate-700 bg-slate-900/60 sm:hidden"
+            />
+          )}
           <button
             type="button"
             onClick={() =>
@@ -224,7 +231,7 @@ export default function ModeSelect({
                 cpuDifficulty,
               )
             }
-            className="ml-auto inline-flex items-center justify-center rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300 sm:ml-0"
+            className="order-3 ml-auto inline-flex items-center justify-center rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300 sm:ml-0 sm:order-none"
           >
             {confirmLabel}
           </button>

--- a/src/components/EasyModeSwitch.tsx
+++ b/src/components/EasyModeSwitch.tsx
@@ -18,7 +18,7 @@ export default function EasyModeSwitch({
       type="button"
       role="switch"
       aria-checked={checked}
-      aria-label="Toggle easy mode"
+      aria-label="Toggle balanced slices mode"
       disabled={disabled}
       onClick={() => {
         if (!disabled) {
@@ -26,27 +26,27 @@ export default function EasyModeSwitch({
         }
       }}
       className={[
-        "group inline-flex items-center gap-3 rounded-full border border-transparent px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide transition",
+        "group inline-flex items-center gap-1.5 rounded-full border border-transparent px-2.5 py-1 text-[10px] font-semibold transition sm:gap-3 sm:px-4 sm:py-1.5 sm:text-[11px] sm:font-medium sm:uppercase sm:tracking-wide",
         disabled
           ? "cursor-not-allowed text-slate-500"
           : "text-slate-300 hover:border-emerald-400/60 hover:text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/40",
         className,
       ].join(" ")}
     >
-      <span className="select-none">Easy Mode</span>
+      <span className="select-none leading-none">Balanced Slices</span>
       <span
         className={[
-          "relative inline-flex h-6 w-12 items-center rounded-full border transition-colors",
+          "inline-flex h-4 w-[2.25rem] items-center rounded-full border px-0.5 transition-all sm:h-6 sm:w-12 sm:px-1",
           checked
-            ? "border-emerald-400 bg-emerald-400/20"
-            : "border-slate-600 bg-slate-800",
+            ? "justify-end border-emerald-400 bg-emerald-400/20"
+            : "justify-start border-slate-600 bg-slate-800",
           disabled ? "opacity-60" : "",
         ].join(" ")}
       >
         <span
           className={[
-            "absolute left-1 h-4 w-4 rounded-full transition-transform",
-            checked ? "translate-x-5 bg-emerald-300" : "translate-x-0 bg-slate-400",
+            "h-3.5 w-3.5 rounded-full transition-all sm:h-4 sm:w-4",
+            checked ? "bg-emerald-300" : "bg-slate-400",
           ].join(" ")}
         />
       </span>


### PR DESCRIPTION
## Summary
- compress the Balanced Slices switch spacing and typography on mobile to reduce its horizontal footprint
- update the toggle track layout so the knob flexes between ends instead of using large translations, keeping the control compact while retaining desktop styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fd241fe8108332b342f5fad26f2fef