### PR TITLE
Refine mode select control alignment

### DIFF
--- a/src/ModeSelect.tsx
+++ b/src/ModeSelect.tsx
@@ -195,14 +195,12 @@ export default function ModeSelect({
           })}
         </div>
 
-        <div
-          className="mt-8 flex flex-wrap items-center gap-3 sm:items-center sm:justify-end"
-        >
+        <div className="mt-8 flex items-start gap-3 sm:justify-end">
           {showCpuDifficulty && (
-            <label className="order-1 flex flex-col gap-1 text-sm sm:order-none sm:flex-row sm:items-center sm:gap-2">
-              <span className="font-semibold text-slate-300">CPU Difficulty</span>
+            <label className="order-1 flex min-w-[7.5rem] flex-col text-xs font-semibold text-slate-300 sm:order-none sm:min-w-0 sm:text-sm">
+              <span>CPU Difficulty</span>
               <select
-                className="rounded-full border border-slate-700 bg-slate-900/60 px-3 py-1.5 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+                className="mt-1.5 rounded-full border border-slate-700 bg-slate-900/60 px-3 py-1.5 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
                 value={cpuDifficulty}
                 onChange={(event) => setCpuDifficulty(event.target.value as CpuDifficulty)}
               >
@@ -218,6 +216,7 @@ export default function ModeSelect({
             <EasyModeSwitch
               checked={easyMode}
               onToggle={setEasyMode}
+              stackedLabel
               className="order-2 shrink-0 rounded-full border border-slate-700 bg-slate-900/60 sm:hidden"
             />
           )}

--- a/src/components/EasyModeSwitch.tsx
+++ b/src/components/EasyModeSwitch.tsx
@@ -5,6 +5,8 @@ type EasyModeSwitchProps = {
   onToggle: (value: boolean) => void;
   disabled?: boolean;
   className?: string;
+  label?: string;
+  stackedLabel?: boolean;
 };
 
 export default function EasyModeSwitch({
@@ -12,6 +14,8 @@ export default function EasyModeSwitch({
   onToggle,
   disabled = false,
   className = "",
+  label = "Balanced Slices",
+  stackedLabel = false,
 }: EasyModeSwitchProps) {
   return (
     <button
@@ -26,17 +30,28 @@ export default function EasyModeSwitch({
         }
       }}
       className={[
-        "group inline-flex items-center gap-1.5 rounded-full border border-transparent px-2.5 py-1 text-[10px] font-semibold transition sm:gap-3 sm:px-4 sm:py-1.5 sm:text-[11px] sm:font-medium sm:uppercase sm:tracking-wide",
+        "group inline-flex rounded-full border border-transparent text-[10px] font-semibold transition sm:text-[11px] sm:font-medium sm:uppercase sm:tracking-wide",
+        stackedLabel
+          ? "flex-col items-start gap-1 px-3 py-2 text-left sm:gap-1.5 sm:px-4"
+          : "items-center gap-1.5 px-2.5 py-1 sm:gap-3 sm:px-4 sm:py-1.5",
         disabled
           ? "cursor-not-allowed text-slate-500"
           : "text-slate-300 hover:border-emerald-400/60 hover:text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/40",
         className,
       ].join(" ")}
     >
-      <span className="select-none leading-none">Balanced Slices</span>
+      <span
+        className={[
+          "select-none leading-none",
+          stackedLabel ? "text-left" : "",
+        ].join(" ")}
+      >
+        {label}
+      </span>
       <span
         className={[
           "inline-flex h-4 w-[2.25rem] items-center rounded-full border px-0.5 transition-all sm:h-6 sm:w-12 sm:px-1",
+          stackedLabel ? "mt-1.5" : "",
           checked
             ? "justify-end border-emerald-400 bg-emerald-400/20"
             : "justify-start border-slate-600 bg-slate-800",


### PR DESCRIPTION
## Summary
- keep the mode select action row controls aligned by top-aligning the CPU difficulty dropdown and balanced slices toggle when their labels are stacked
- add a stacked label option to the balanced slices switch so the label can sit above the control without affecting inline layouts elsewhere

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd299ec7cc833292a115c8f9fb32d7